### PR TITLE
Refuse a second app instance, and add a liveness route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ cd App && swift build          # must pass before any commit
 ./scripts/test.sh              # unit tests — must pass
 cd mcp && npm run typecheck    # must pass when mcp/ changed
 ./scripts/build.sh             # produces Plonk.app
-curl -s 127.0.0.1:43917/state  # smoke test while the app is running
+curl -s 127.0.0.1:43917/ping   # smoke test while the app is running
 ```
 
 The release number lives in `version.env`, and only there. `scripts/build.sh`

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -20,6 +20,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var previewToken = 0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Before anything is on screen: a second copy would add its own menu bar
+        // icon and hotkeys, and lose the race for the control server's port.
+        if let existing = Self.otherRunningInstance() {
+            existing.activate()
+            NSApp.terminate(nil)
+            return
+        }
         store.load()
         windows.promptForTrust()
 
@@ -40,6 +47,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self, selector: #selector(screensChanged),
             name: NSApplication.didChangeScreenParametersNotification, object: nil
         )
+    }
+
+    /// Another copy of this bundle, if one is already up. Nil when running
+    /// unbundled through `swift run`, where there is no identifier to match on;
+    /// the control server's port check is the backstop there.
+    static func otherRunningInstance() -> NSRunningApplication? {
+        guard let id = Bundle.main.bundleIdentifier else { return nil }
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        return NSRunningApplication.runningApplications(withBundleIdentifier: id)
+            .first { $0.processIdentifier != ownPID && !$0.isTerminated }
     }
 
     // MARK: - Wiring

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -3,6 +3,7 @@ import AppKit
 // HTTP surface of the app. Kept apart from AppDelegate so routes can be
 // exercised without a status bar or windows.
 //
+//   GET  /ping              liveness, cheap: touches neither AX nor the screen
 //   GET  /state
 //   POST /awake             { on?, minutes? }
 //   POST /layout            { items: [{ app, title?, screen?, frame: {x,y,w,h} }] }
@@ -45,6 +46,9 @@ final class Router {
     func handle(_ request: HTTPRequest, respond: @escaping (HTTPResponse) -> Void) {
         let body = request.body
         switch (request.method, request.path) {
+        case ("GET", "/ping"):
+            respond(.ok(["ok": true, "app": "Plonk"]))
+
         case ("GET", "/state"):
             respond(.ok(state()))
 

--- a/App/Tests/plonkTests/RouterTests.swift
+++ b/App/Tests/plonkTests/RouterTests.swift
@@ -37,6 +37,14 @@ struct RouterTests {
         "frame": ["x": 0, "y": 0, "w": 0.5, "h": 1],
     ]
 
+    /// The MCP server's liveness check, so it must not depend on Accessibility.
+    @Test func pingAnswersWithoutPermissions() {
+        let h = Harness()
+        let response = h.send(HTTPRequest(method: "GET", path: "/ping", headers: [:], body: [:]))
+        #expect(response.status == 200)
+        #expect(response.json["ok"] as? Bool == true)
+    }
+
     @Test func unknownRouteIsNotFound() {
         let h = Harness()
         #expect(h.send(HTTPRequest(method: "GET", path: "/nope", headers: [:], body: [:])).status == 404)

--- a/App/Tests/plonkTests/WorkspaceLauncherTests.swift
+++ b/App/Tests/plonkTests/WorkspaceLauncherTests.swift
@@ -6,20 +6,27 @@ import AppKit
 // around it — the lock, and which screen an item goes back to.
 struct WorkspaceLauncherTests {
 
-    /// `cancel` used to read `isRunning`, taking the non-recursive lock twice on
-    /// the caller's thread and hanging the main queue behind the Cancel button.
-    @Test(.timeLimit(.minutes(1)))
-    func cancelReturnsWhenNothingIsLaunching() {
+    /// Off the test's own thread: `cancel` used to take the non-recursive lock
+    /// twice and block forever, which as an inline call hangs the run instead of
+    /// failing it.
+    private func expectReturns(_ body: @escaping () -> Void, _ what: Comment) {
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            body()
+            done.signal()
+        }
+        #expect(done.wait(timeout: .now() + 5) == .success, what)
+    }
+
+    @Test func cancelReturnsWhenNothingIsLaunching() {
         let launcher = WorkspaceLauncher(windows: WindowManager())
-        launcher.cancel()
+        expectReturns({ launcher.cancel() }, "cancel deadlocked")
         #expect(launcher.isRunning == false)
     }
 
-    @Test(.timeLimit(.minutes(1)))
-    func cancelIsRepeatable() {
+    @Test func cancelIsRepeatable() {
         let launcher = WorkspaceLauncher(windows: WindowManager())
-        launcher.cancel()
-        launcher.cancel()
+        expectReturns({ launcher.cancel(); launcher.cancel() }, "cancel deadlocked on the second call")
         #expect(launcher.isRunning == false)
     }
 

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -1,7 +1,7 @@
 // Typed HTTP client for the Plonk app's localhost API.
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-const BASE = "http://127.0.0.1:43917";
+export const BASE = "http://127.0.0.1:43917";
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 export interface Frame {
@@ -141,6 +141,14 @@ export async function call<T extends object = ApiResponse>(
   } catch {
     return { error: `Plonk returned ${res.status} with an unexpected body: ${text.slice(0, 200)}` };
   }
+}
+
+/**
+ * Whether the app is answering. Several servers may run at once — one per MCP
+ * client — but all of them are useless without the app behind the port.
+ */
+export async function isAppReachable(timeoutMs = 2_000): Promise<boolean> {
+  return !("error" in (await call("/ping", { timeoutMs })));
 }
 
 // An `error` key means the app refused or was unreachable; flagging it stops

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -2,6 +2,7 @@
 // Plonk MCP server — bridges AI agents to the Plonk menu bar app (localhost HTTP).
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { BASE, isAppReachable } from "./api.js";
 import { register as registerState } from "./tools/state.js";
 import { register as registerLayouts } from "./tools/layouts.js";
 import { register as registerWorkspaces } from "./tools/workspaces.js";
@@ -22,3 +23,9 @@ registerAnnotate(server);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);
+
+// stdout carries the protocol, so this goes to stderr. Not fatal: the app may
+// still be starting, and every tool reports the same thing on its own.
+if (!(await isAppReachable())) {
+  console.error(`plonk-mcp: nothing is answering on ${BASE} — launch Plonk.app or its tools will fail.`);
+}


### PR DESCRIPTION
A second copy of the app registers its own hotkeys and menu bar icon, then loses the race for the control server's port. It now hands over to the copy that is already running and quits before anything reaches the screen.

Several MCP servers are normal — the stdio transport gives each client its own process — so that side only warns, on stderr, when nothing is answering on the port. The check uses a new GET /ping, which unlike /state touches neither Accessibility nor the screen.

Also makes the WorkspaceLauncher cancel test fail instead of hang: it runs cancel() off the test's thread and waits, so a reintroduced deadlock is a 5s failure rather than a stuck run.