### PR TITLE
fix: review follow-ups — a crash, two exclusive-mode holes, dropped voice prompts, and two structural cleanups

### DIFF
--- a/App/Sources/plonk/AgentRegistry.swift
+++ b/App/Sources/plonk/AgentRegistry.swift
@@ -79,17 +79,22 @@ final class AgentRegistry {
     static let maxQueuedTasks = 20
 
     private var inbox: [String: [Task]] = [:]
-    /// The one parked long-poll responder per agent, waiting for a task or its
+    /// Long-poll responders parked per agent, waiting for a task or their
     /// timeout. Everything runs on the main queue (Router.handle does), so no
-    /// locking. Only one is kept: a client that polls again has abandoned its
-    /// previous connection, and handing a task to that dead socket would throw
-    /// the user's words away.
-    private var waiters: [String: (cancel: DispatchWorkItem, respond: ([Task]) -> Void)] = [:]
+    /// locking. Several are allowed because one client can hold two sessions
+    /// under the same name; a task goes to the newest, which is the one most
+    /// likely still connected. Stale ones simply time out empty.
+    private var waiters: [String: [(token: UUID, cancel: DispatchWorkItem, respond: ([Task]) -> Void)]] = [:]
+
+    /// Enough for a client with several windows open; beyond that the oldest
+    /// are almost certainly abandoned sockets.
+    static let maxWaiters = 8
 
     @discardableResult
     func enqueue(_ prompt: String, for agent: String) -> Task {
         let task = Task(prompt: prompt)
-        if let waiter = waiters.removeValue(forKey: agent) {
+        if var parked = waiters[agent], let waiter = parked.popLast() {
+            waiters[agent] = parked.isEmpty ? nil : parked
             waiter.cancel.cancel()
             waiter.respond([task])
         } else {
@@ -117,17 +122,24 @@ final class AgentRegistry {
             respond([])
             return
         }
-        // A second poll means the first connection is gone; let it go empty
-        // rather than leave it first in line for the next task.
-        if let previous = waiters.removeValue(forKey: agent) {
-            previous.cancel.cancel()
-            previous.respond([])
+        var parked = waiters[agent] ?? []
+        // Past the cap the oldest is the likeliest corpse; answer it empty so
+        // its connection closes instead of holding a slot.
+        while parked.count >= Self.maxWaiters {
+            let oldest = parked.removeFirst()
+            oldest.cancel.cancel()
+            oldest.respond([])
         }
+        let token = UUID()
         let cancel = DispatchWorkItem { [weak self] in
-            guard let self, let waiter = waiters.removeValue(forKey: agent) else { return }
+            guard let self, var current = waiters[agent],
+                  let index = current.firstIndex(where: { $0.token == token }) else { return }
+            let waiter = current.remove(at: index)
+            waiters[agent] = current.isEmpty ? nil : current
             waiter.respond([])
         }
-        waiters[agent] = (cancel: cancel, respond: respond)
+        parked.append((token: token, cancel: cancel, respond: respond))
+        waiters[agent] = parked
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: cancel)
     }
 

--- a/App/Sources/plonk/AgentRegistry.swift
+++ b/App/Sources/plonk/AgentRegistry.swift
@@ -26,12 +26,14 @@ final class AgentRegistry {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
         let key = "\(trimmed)#\(pid.map(String.init) ?? "?")"
-        let isNew = sessions[key] == nil
-        var session = sessions[key] ?? AgentSession(name: trimmed, version: version, pid: pid, lastSeen: now)
+        let previous = sessions[key]
+        var session = previous ?? AgentSession(name: trimmed, version: version, pid: pid, lastSeen: now)
         if !version.isEmpty { session.version = version }
         session.lastSeen = now
         sessions[key] = session
-        if isNew { onChange?() }
+        // Heartbeats from a session already online change nothing anyone is
+        // watching; arriving and coming back do.
+        if previous.map({ !isOnline($0, now: now) }) ?? true { onChange?() }
     }
 
     /// Refresh from a request's `X-Plonk-Agent: name/version` header, so agents
@@ -64,25 +66,36 @@ final class AgentRegistry {
 
         var asDict: [String: Any] {
             ["id": id, "prompt": prompt,
-             "created": ISO8601DateFormatter().string(from: created)]
+             "created": AgentRegistry.iso.string(from: created)]
         }
     }
 
+    /// Building one of these is far dearer than formatting with it, and
+    /// everything here is main-queue confined.
+    static let iso = ISO8601DateFormatter()
+
+    /// Prompts an agent never came back for are worthless; keeping the newest
+    /// few bounds a queue nobody may ever drain.
+    static let maxQueuedTasks = 20
+
     private var inbox: [String: [Task]] = [:]
-    /// Long-poll responders parked until a task arrives or the timeout fires.
-    /// Everything runs on the main queue (Router.handle does), so no locking.
-    private var waiters: [String: [(token: UUID, cancel: DispatchWorkItem, respond: ([Task]) -> Void)]] = [:]
+    /// The one parked long-poll responder per agent, waiting for a task or its
+    /// timeout. Everything runs on the main queue (Router.handle does), so no
+    /// locking. Only one is kept: a client that polls again has abandoned its
+    /// previous connection, and handing a task to that dead socket would throw
+    /// the user's words away.
+    private var waiters: [String: (cancel: DispatchWorkItem, respond: ([Task]) -> Void)] = [:]
 
     @discardableResult
     func enqueue(_ prompt: String, for agent: String) -> Task {
         let task = Task(prompt: prompt)
-        if var parked = waiters[agent], !parked.isEmpty {
-            let waiter = parked.removeFirst()
-            waiters[agent] = parked
+        if let waiter = waiters.removeValue(forKey: agent) {
             waiter.cancel.cancel()
             waiter.respond([task])
         } else {
-            inbox[agent, default: []].append(task)
+            var queued = inbox[agent] ?? []
+            queued.append(task)
+            inbox[agent] = queued.suffix(Self.maxQueuedTasks)
         }
         return task
     }
@@ -99,15 +112,22 @@ final class AgentRegistry {
             respond(queued)
             return
         }
-        let token = UUID()
+        // A caller that asked not to wait wants an answer, not a parked socket.
+        guard seconds > 0 else {
+            respond([])
+            return
+        }
+        // A second poll means the first connection is gone; let it go empty
+        // rather than leave it first in line for the next task.
+        if let previous = waiters.removeValue(forKey: agent) {
+            previous.cancel.cancel()
+            previous.respond([])
+        }
         let cancel = DispatchWorkItem { [weak self] in
-            guard let self, var parked = waiters[agent],
-                  let index = parked.firstIndex(where: { $0.token == token }) else { return }
-            let waiter = parked.remove(at: index)
-            waiters[agent] = parked
+            guard let self, let waiter = waiters.removeValue(forKey: agent) else { return }
             waiter.respond([])
         }
-        waiters[agent, default: []].append((token: token, cancel: cancel, respond: respond))
+        waiters[agent] = (cancel: cancel, respond: respond)
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: cancel)
     }
 

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -113,6 +113,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             model.awakeRequested = awake.requested
             refreshStatusMenu()
             persistAwakeSession()
+            // Also fires when the power source or a timeout flips it, which
+            // writes no config and would otherwise never reach a listener.
+            router?.changes.bump("awake")
         }
         awake.startObservingPowerSource()
         if store.config.awakeRequested {
@@ -211,6 +214,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         router.changes.onEvent = { [weak self] rev, what in
             self?.eventBroadcaster.broadcast(rev: rev, what: what)
         }
+        // Every source of change funnels into the bus at its own choke point,
+        // so no caller has to remember to announce itself.
+        store.didMutate = { [weak self] in self?.router.changes.bump("config") }
+        windows.onDidPlace = { [weak self] in self?.router.changes.bump("windows") }
         agents.onChange = { [weak self] in
             self?.refreshAgentModel()
             self?.router.changes.bump("agents")
@@ -236,13 +243,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Adapters may run for minutes, so they never touch the main thread.
         router.runAdapter = { adapter, prompt in
             DispatchQueue.global(qos: .userInitiated).async {
-                let escaped = "'" + prompt.replacingOccurrences(of: "'", with: "'\\''") + "'"
-                let command = adapter.command.contains("{prompt}")
-                    ? adapter.command.replacingOccurrences(of: "{prompt}", with: escaped)
-                    : adapter.command + " " + escaped
+                let invocation = AgentAdapter.invocation(command: adapter.command, prompt: prompt)
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-                process.arguments = ["-lc", command]
+                process.arguments = ["-lc", invocation.command]
+                process.environment = ProcessInfo.processInfo.environment
+                    .merging(invocation.environment) { _, prompt in prompt }
                 do {
                     try process.run()
                 } catch {

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -214,6 +214,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         router.changes.onEvent = { [weak self] rev, what in
             self?.eventBroadcaster.broadcast(rev: rev, what: what)
         }
+        router.attachEvents = { [weak self] conn, rev in
+            self?.eventBroadcaster.attach(conn, rev: rev)
+        }
         // Every source of change funnels into the bus at its own choke point,
         // so no caller has to remember to announce itself.
         store.didMutate = { [weak self] in self?.router.changes.bump("config") }
@@ -261,8 +264,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return respond(.failed("shutting down")) }
             router.handle(request, respond: respond)
         }
-        server.events = eventBroadcaster
-        server.currentRev = { [weak self] in self?.router.changes.rev ?? 1 }
         server.onUnavailable = { [weak self] message in self?.model.apiWarning = message }
         do {
             try server.start()

--- a/App/Sources/plonk/ConfigStore.swift
+++ b/App/Sources/plonk/ConfigStore.swift
@@ -41,12 +41,20 @@ struct AgentAdapter: Codable {
 
     /// The command to run for `prompt`, with the prompt supplied out of band.
     /// `{prompt}` becomes a reference to the variable; a template without it
-    /// gets one appended.
+    /// gets one appended. Quotes people naturally put around the placeholder
+    /// are consumed with it — the substitution already quotes itself, and
+    /// leaving theirs would either block expansion (single quotes, so the tool
+    /// would receive the literal text `$PLONK_PROMPT`) or nest pointlessly.
     static func invocation(command: String, prompt: String) -> (command: String, environment: [String: String]) {
         let reference = "\"$\(promptVariable)\""
-        let line = command.contains("{prompt}")
-            ? command.replacingOccurrences(of: "{prompt}", with: reference)
-            : command + " " + reference
+        var line = command
+        if line.contains("{prompt}") {
+            for quoted in ["'{prompt}'", "\"{prompt}\"", "{prompt}"] {
+                line = line.replacingOccurrences(of: quoted, with: reference)
+            }
+        } else {
+            line += " " + reference
+        }
         return (line, [promptVariable: prompt])
     }
 }
@@ -77,8 +85,9 @@ struct Config: Codable {
     var selectedAgent: String?
     var agentExclusive = false
     // Agents Plonk can launch itself instead of queueing a task for a live MCP
-    // session: {prompt} in the command is replaced with the shell-escaped
-    // prompt, e.g. "claude -p {prompt}". Edited in config.json for now.
+    // session, e.g. "claude -p {prompt}". The prompt reaches the command
+    // through the environment, never as text in the line; see
+    // AgentAdapter.invocation. Edited in config.json for now.
     var agentAdapters: [AgentAdapter] = []
     var workspaces: [String: Workspace] = [:]
     var zoneSets: [String: [ZoneRect]] = [:]

--- a/App/Sources/plonk/ConfigStore.swift
+++ b/App/Sources/plonk/ConfigStore.swift
@@ -32,6 +32,23 @@ struct LayoutItemSpec: Codable {
 struct AgentAdapter: Codable {
     var name: String
     var command: String
+
+    /// The environment variable the prompt travels in. Substituting the text
+    /// into the command line cannot be made safe — a template that happens to
+    /// quote {prompt} would break any escaping we applied — so the shell never
+    /// sees the words at all, only the name of a variable holding them.
+    static let promptVariable = "PLONK_PROMPT"
+
+    /// The command to run for `prompt`, with the prompt supplied out of band.
+    /// `{prompt}` becomes a reference to the variable; a template without it
+    /// gets one appended.
+    static func invocation(command: String, prompt: String) -> (command: String, environment: [String: String]) {
+        let reference = "\"$\(promptVariable)\""
+        let line = command.contains("{prompt}")
+            ? command.replacingOccurrences(of: "{prompt}", with: reference)
+            : command + " " + reference
+        return (line, [promptVariable: prompt])
+    }
 }
 
 struct Config: Codable {

--- a/App/Sources/plonk/ControlServer.swift
+++ b/App/Sources/plonk/ControlServer.swift
@@ -13,11 +13,26 @@ struct HTTPRequest {
 struct HTTPResponse {
     let status: Int
     let json: [String: Any]
+    /// Set instead of a body when the route keeps the socket: the connection
+    /// is handed over and the server writes nothing more. Server-sent events
+    /// are the only such route, and it stays a route rather than a special
+    /// case in the transport.
+    let handOff: ((NWConnection) -> Void)?
+
+    init(status: Int, json: [String: Any], handOff: ((NWConnection) -> Void)? = nil) {
+        self.status = status
+        self.json = json
+        self.handOff = handOff
+    }
 
     static func ok(_ json: [String: Any]) -> HTTPResponse { HTTPResponse(status: 200, json: json) }
     static func badRequest(_ message: String) -> HTTPResponse { HTTPResponse(status: 400, json: ["error": message]) }
     static func notFound(_ message: String) -> HTTPResponse { HTTPResponse(status: 404, json: ["error": message]) }
     static func failed(_ message: String) -> HTTPResponse { HTTPResponse(status: 500, json: ["error": message]) }
+    /// Gives the raw connection to `attach`, which owns it from then on.
+    static func stream(_ attach: @escaping (NWConnection) -> Void) -> HTTPResponse {
+        HTTPResponse(status: 200, json: [:], handOff: attach)
+    }
 }
 
 final class ControlServer {
@@ -25,11 +40,6 @@ final class ControlServer {
 
     private var listener: NWListener?
     private let handle: (HTTPRequest, @escaping (HTTPResponse) -> Void) -> Void
-    /// When set, GET /events connections are handed over as SSE streams
-    /// instead of the usual request/response cycle.
-    var events: EventBroadcaster?
-    /// The revision the first SSE frame reports.
-    var currentRev: () -> Int = { 1 }
 
     /// Called on the main queue when the port cannot be claimed, which in
     /// practice means a second Plonk is already running.
@@ -79,16 +89,6 @@ final class ControlServer {
                 self.respond(conn, HTTPResponse(status: 403, json: ["error": reason]))
                 return
             }
-            if request.method == "GET", request.path == "/events" || request.path.hasPrefix("/events?") {
-                DispatchQueue.main.async {
-                    guard let events = self.events else {
-                        self.respond(conn, .notFound("events are not available"))
-                        return
-                    }
-                    events.attach(conn, rev: self.currentRev())
-                }
-                return
-            }
             DispatchQueue.main.async {
                 self.handle(request) { [weak self] response in
                     self?.respond(conn, response)
@@ -133,6 +133,10 @@ final class ControlServer {
     }
 
     private func respond(_ conn: NWConnection, _ response: HTTPResponse) {
+        if let handOff = response.handOff {
+            handOff(conn)
+            return
+        }
         let body = (try? JSONSerialization.data(withJSONObject: response.json, options: [.sortedKeys])) ?? Data("{}".utf8)
         let head = "HTTP/1.1 \(response.status) \(Self.reason(response.status))\r\n"
             + "Content-Type: application/json\r\n"

--- a/App/Sources/plonk/EventBroadcaster.swift
+++ b/App/Sources/plonk/EventBroadcaster.swift
@@ -28,15 +28,16 @@ final class EventBroadcaster {
             + "Connection: keep-alive\r\n\r\n"
             + "retry: 3000\n\n"
             + Self.frame(rev: rev, what: "hello")
+        // Registered before the send completes: an event bumped in that window
+        // would otherwise never reach this listener, and it would sit on a
+        // revision it believes is current.
+        connections.append(conn)
+        startKeepaliveIfNeeded()
         conn.send(content: Data(head.utf8), completion: .contentProcessed { [weak self] error in
+            guard error != nil else { return }
             DispatchQueue.main.async {
-                guard let self else { return }
-                if error != nil {
-                    conn.cancel()
-                    return
-                }
-                self.connections.append(conn)
-                self.startKeepaliveIfNeeded()
+                conn.cancel()
+                self?.forget(conn)
             }
         })
     }
@@ -46,16 +47,30 @@ final class EventBroadcaster {
     }
 
     private static func frame(rev: Int, what: String) -> String {
-        "data: {\"rev\": \(rev), \"what\": \"\(what)\"}\n\n"
+        let payload = (try? JSONSerialization.data(withJSONObject: ["rev": rev, "what": what],
+                                                   options: [.sortedKeys]))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+        return "data: \(payload)\n\n"
     }
 
     /// A comment frame flushes out connections whose client is gone; without
     /// it a dead listener would linger until the next real event.
     private func startKeepaliveIfNeeded() {
         guard keepalive == nil else { return }
-        keepalive = Timer.scheduledTimer(withTimeInterval: 25, repeats: true) { [weak self] _ in
+        let timer = Timer.scheduledTimer(withTimeInterval: 25, repeats: true) { [weak self] _ in
             self?.send(Data(": ping\n\n".utf8))
         }
+        // A menu bar app should be idle when nothing is listening, so the
+        // pings coalesce and the timer dies with the last connection.
+        timer.tolerance = 5
+        keepalive = timer
+    }
+
+    private func forget(_ conn: NWConnection) {
+        connections.removeAll { $0 === conn }
+        guard connections.isEmpty else { return }
+        keepalive?.invalidate()
+        keepalive = nil
     }
 
     private func send(_ data: Data) {
@@ -64,7 +79,7 @@ final class EventBroadcaster {
                 guard error != nil else { return }
                 DispatchQueue.main.async {
                     conn.cancel()
-                    self?.connections.removeAll { $0 === conn }
+                    self?.forget(conn)
                 }
             })
         }

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Network
 
 // HTTP surface of the app. Kept apart from AppDelegate so routes can be
 // exercised without a status bar or windows.
@@ -46,6 +47,9 @@ final class Router {
     var launchWorkspace: ((String, Workspace, Int?, @escaping ([[String: Any]]) -> Void) -> Void)?
     /// Set by AppDelegate; spawning a process is not Router's business.
     var runAdapter: ((AgentAdapter, String) -> Void)?
+    /// Set by AppDelegate. Takes over a connection for the event stream and
+    /// the revision its first frame reports.
+    var attachEvents: ((NWConnection, Int) -> Void)?
     var didChangeLayouts: (() -> Void)?
     var didChangeZones: (() -> Void)?
     var didChangeAgents: (() -> Void)?
@@ -234,6 +238,14 @@ final class Router {
                 return
             }
             respond(dispatch(prompt: prompt, to: trimmedName(body["agent"])))
+
+        case ("GET", "/events"):
+            guard let attachEvents else {
+                respond(.notFound("events are not available"))
+                return
+            }
+            let rev = changes.rev
+            respond(.stream { conn in attachEvents(conn, rev) })
 
         case ("GET", "/agents/inbox"):
             guard let name = query["agent"], !name.isEmpty else {

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -59,9 +59,6 @@ final class Router {
         self.awake = awake
         self.agents = agents
         self.changes = changes
-        // Config writes come from every direction (UI, HTTP, hotkeys), so the
-        // store itself is the one reliable place to notice them.
-        store.didMutate = { [weak self] in self?.changes.bump("config") }
     }
 
     func handle(_ request: HTTPRequest, respond: @escaping (HTTPResponse) -> Void) {
@@ -283,16 +280,17 @@ final class Router {
     }
 
     /// "/agents/inbox?agent=x&wait=25" → ("/agents/inbox", ["agent": "x", "wait": "25"]).
+    /// URLComponents owns the escaping and the malformed cases; hand-rolling
+    /// this trapped on a bare "=" pair, which any caller could send.
     static func splitQuery(_ raw: String) -> (path: String, query: [String: String]) {
-        guard let mark = raw.firstIndex(of: "?") else { return (raw, [:]) }
-        let path = String(raw[raw.startIndex..<mark])
-        var query: [String: String] = [:]
-        for pair in raw[raw.index(after: mark)...].split(separator: "&") {
-            let kv = pair.split(separator: "=", maxSplits: 1)
-            guard let key = String(kv[0]).removingPercentEncoding else { continue }
-            query[key] = kv.count > 1 ? (String(kv[1]).removingPercentEncoding ?? "") : ""
+        guard raw.contains("?") else { return (raw, [:]) }
+        guard let components = URLComponents(string: raw) else {
+            return (String(raw.prefix(while: { $0 != "?" })), [:])
         }
-        return (path, query)
+        let query = (components.queryItems ?? []).reduce(into: [String: String]()) { result, item in
+            result[item.name] = item.value ?? ""
+        }
+        return (components.path, query)
     }
 
     /// The name half of an `X-Plonk-Agent: name/version` header.
@@ -305,15 +303,29 @@ final class Router {
     /// Everything that changes windows or config. Reads and screenshots stay
     /// open to every agent; hello must stay open or nobody could register.
     private static let guardedPrefixes = ["/layout", "/layouts", "/workspaces", "/zones", "/awake"]
-    private static let guardedPaths: Set<String> = ["/agents/select", "/agents/exclusive"]
+    // /agents/ask is guarded too: a prompt is a way to move windows by proxy,
+    // and it can launch an adapter's shell command outright.
+    private static let guardedPaths: Set<String> = ["/agents/select", "/agents/exclusive", "/agents/ask"]
+
+    /// Reading someone else's queue takes their prompts away, so the inbox is
+    /// gated like a mutation even though it is a GET.
+    private static let guardedGets: Set<String> = ["/agents/inbox"]
 
     /// The 409 reason when "only the selected agent controls" blocks this
     /// request, nil when it may proceed.
     static func exclusiveRejection(method: String, path: String, agent: String?,
                                    selected: String?, exclusive: Bool) -> String? {
-        guard exclusive, let selected, !selected.isEmpty, method == "POST" else { return nil }
-        let guarded = Self.guardedPaths.contains(path)
-            || Self.guardedPrefixes.contains { path == $0 || path.hasPrefix($0 + "/") }
+        guard exclusive, let selected, !selected.isEmpty else { return nil }
+        let guarded: Bool
+        switch method {
+        case "POST":
+            guarded = Self.guardedPaths.contains(path)
+                || Self.guardedPrefixes.contains { path == $0 || path.hasPrefix($0 + "/") }
+        case "GET":
+            guarded = Self.guardedGets.contains(path)
+        default:
+            return nil
+        }
         guard guarded, agent != selected else { return nil }
         let who = agent.map { "\"\($0)\"" } ?? "an unidentified client"
         return "the user made \"\(selected)\" the only agent allowed to change windows and settings, "
@@ -442,7 +454,6 @@ final class Router {
             screen: spec.screen,
             frac: FracRect(spec.x, spec.y, spec.w, spec.h)
         )
-        if error == nil { changes.bump("windows") }
         return error.map { ["ok": false, "app": spec.app, "error": $0] } ?? ["ok": true, "app": spec.app]
     }
 
@@ -470,7 +481,6 @@ final class Router {
         let error = windows.place(app: app, titleContains: title, screen: screen,
                                   frac: zones[number - 1].frac)
         if let error { return .failed(error) }
-        changes.bump("windows")
         return .ok(["ok": true, "app": app, "screen": screen, "zone": number, "zones": zones.count])
     }
 

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -252,6 +252,15 @@ final class Router {
                 respond(.badRequest("query must include agent, e.g. /agents/inbox?agent=claude-code&wait=25"))
                 return
             }
+            // Draining a queue takes its prompts away, so a client that says
+            // who it is may only read its own. Whether it is the active agent
+            // has nothing to do with it.
+            if let agent, agent != name {
+                respond(HTTPResponse(status: 409, json: [
+                    "error": "\"\(agent)\" cannot read the queue of \"\(name)\"; poll your own name",
+                ]))
+                return
+            }
             let wait = min(max(Double(query["wait"] ?? "0") ?? 0, 0), 25)
             agents.wait(for: name, seconds: wait) { tasks in
                 respond(.ok(["tasks": tasks.map(\.asDict)]))
@@ -319,25 +328,14 @@ final class Router {
     // and it can launch an adapter's shell command outright.
     private static let guardedPaths: Set<String> = ["/agents/select", "/agents/exclusive", "/agents/ask"]
 
-    /// Reading someone else's queue takes their prompts away, so the inbox is
-    /// gated like a mutation even though it is a GET.
-    private static let guardedGets: Set<String> = ["/agents/inbox"]
-
     /// The 409 reason when "only the selected agent controls" blocks this
-    /// request, nil when it may proceed.
+    /// request, nil when it may proceed. The inbox is not here: who may read a
+    /// queue depends on whose queue it is, which the route itself checks.
     static func exclusiveRejection(method: String, path: String, agent: String?,
                                    selected: String?, exclusive: Bool) -> String? {
-        guard exclusive, let selected, !selected.isEmpty else { return nil }
-        let guarded: Bool
-        switch method {
-        case "POST":
-            guarded = Self.guardedPaths.contains(path)
-                || Self.guardedPrefixes.contains { path == $0 || path.hasPrefix($0 + "/") }
-        case "GET":
-            guarded = Self.guardedGets.contains(path)
-        default:
-            return nil
-        }
+        guard exclusive, let selected, !selected.isEmpty, method == "POST" else { return nil }
+        let guarded = Self.guardedPaths.contains(path)
+            || Self.guardedPrefixes.contains { path == $0 || path.hasPrefix($0 + "/") }
         guard guarded, agent != selected else { return nil }
         let who = agent.map { "\"\($0)\"" } ?? "an unidentified client"
         return "the user made \"\(selected)\" the only agent allowed to change windows and settings, "

--- a/App/Sources/plonk/VoiceManager.swift
+++ b/App/Sources/plonk/VoiceManager.swift
@@ -17,11 +17,11 @@ final class VoiceManager {
     private var task: SFSpeechRecognitionTask?
     private var lastText = ""
     private var finishing = false
-    /// True from the key going down until the session actually starts. The
-    /// permission callbacks are asynchronous, so the key can come back up
-    /// before there is anything to stop — without this the microphone would
-    /// stay live with no key held.
-    private var wanted = false
+    /// True only while a start is in flight: the permission callbacks are
+    /// asynchronous, so the key can come back up before there is anything to
+    /// stop, and a key repeat can ask twice. It is cleared on every path out
+    /// of `start`, so a start that fails cannot leave voice wedged.
+    private var starting = false
 
     private var listening: Bool { task != nil }
 
@@ -37,23 +37,23 @@ final class VoiceManager {
     }
 
     func beginCapture() {
-        guard !listening, !wanted else { return }
-        wanted = true
+        guard !listening, !starting else { return }
+        starting = true
         requestPermissions { [weak self] granted in
             guard let self else { return }
             guard granted else {
-                wanted = false
+                starting = false
                 onError?("Voice needs Microphone and Speech Recognition access: System Settings → Privacy & Security")
                 return
             }
             // Released while the permission prompt was up: nothing to record.
-            guard wanted else { return }
+            guard starting else { return }
             start()
         }
     }
 
     func finishCapture() {
-        wanted = false
+        starting = false
         guard listening, !finishing else { return }
         finishing = true
         engine.inputNode.removeTap(onBus: 0)
@@ -68,6 +68,8 @@ final class VoiceManager {
     }
 
     private func start() {
+        // Whatever happens below, a start is no longer in flight.
+        defer { starting = false }
         guard let recognizer = Self.recognizer() else {
             onError?("On-device speech recognition is not available for this language")
             return
@@ -127,7 +129,7 @@ final class VoiceManager {
         task = nil
         request = nil
         finishing = false
-        wanted = false
+        starting = false
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             onError?("Heard nothing")

--- a/App/Sources/plonk/VoiceManager.swift
+++ b/App/Sources/plonk/VoiceManager.swift
@@ -17,6 +17,11 @@ final class VoiceManager {
     private var task: SFSpeechRecognitionTask?
     private var lastText = ""
     private var finishing = false
+    /// True from the key going down until the session actually starts. The
+    /// permission callbacks are asynchronous, so the key can come back up
+    /// before there is anything to stop — without this the microphone would
+    /// stay live with no key held.
+    private var wanted = false
 
     private var listening: Bool { task != nil }
 
@@ -32,18 +37,23 @@ final class VoiceManager {
     }
 
     func beginCapture() {
-        guard !listening else { return }
+        guard !listening, !wanted else { return }
+        wanted = true
         requestPermissions { [weak self] granted in
             guard let self else { return }
             guard granted else {
+                wanted = false
                 onError?("Voice needs Microphone and Speech Recognition access: System Settings → Privacy & Security")
                 return
             }
+            // Released while the permission prompt was up: nothing to record.
+            guard wanted else { return }
             start()
         }
     }
 
     func finishCapture() {
+        wanted = false
         guard listening, !finishing else { return }
         finishing = true
         engine.inputNode.removeTap(onBus: 0)
@@ -71,6 +81,13 @@ final class VoiceManager {
 
         let node = engine.inputNode
         let format = node.outputFormat(forBus: 0)
+        // A Mac with no input device reports 0 Hz, and installTap answers that
+        // with an Objective-C exception Swift cannot catch.
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            self.request = nil
+            onError?("No microphone is available")
+            return
+        }
         node.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
             request.append(buffer)
         }
@@ -110,6 +127,7 @@ final class VoiceManager {
         task = nil
         request = nil
         finishing = false
+        wanted = false
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             onError?("Heard nothing")

--- a/App/Sources/plonk/WindowManager.swift
+++ b/App/Sources/plonk/WindowManager.swift
@@ -106,6 +106,10 @@ final class WindowManager {
 
     var isTrusted: Bool { AXIsProcessTrusted() }
 
+    /// Fires on the main queue after any window actually moves, whoever asked —
+    /// hotkeys, drag snapping, workspace launches or the HTTP routes.
+    var onDidPlace: (() -> Void)?
+
     func promptForTrust() {
         let opts = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
         AXIsProcessTrustedWithOptions(opts)
@@ -166,7 +170,14 @@ final class WindowManager {
         let movedTo = AXUIElementSetAttributeValue(win, kAXPositionAttribute as CFString, posVal)
         let resized = AXUIElementSetAttributeValue(win, kAXSizeAttribute as CFString, sizeVal)
         AXUIElementSetAttributeValue(win, kAXPositionAttribute as CFString, posVal)
-        return movedTo == .success && resized == .success
+        guard movedTo == .success && resized == .success else { return false }
+        // Placement reaches here from hotkeys, drag snapping, workspace
+        // launches and the HTTP routes alike, so this is the one place that
+        // sees every window move. Launches run off the main queue.
+        if let onDidPlace {
+            DispatchQueue.main.async(execute: onDidPlace)
+        }
+        return true
     }
 
     private func axRect(for frac: FracRect, screenIndex: Int, in all: [ScreenInfo]) -> CGRect {

--- a/App/Tests/plonkTests/AgentRegistryTests.swift
+++ b/App/Tests/plonkTests/AgentRegistryTests.swift
@@ -79,6 +79,43 @@ struct AgentRegistryTests {
         #expect(registry.drain(for: "cursor").isEmpty)
     }
 
+    /// A client that polls again has abandoned the previous connection, so the
+    /// stale waiter must not stay first in line for the next task.
+    @Test func aSecondPollReplacesTheParkedWaiter() {
+        let registry = AgentRegistry()
+        var first: [String]?
+        var second: [String]?
+        registry.wait(for: "cursor", seconds: 25) { first = $0.map(\.prompt) }
+        registry.wait(for: "cursor", seconds: 25) { second = $0.map(\.prompt) }
+        #expect(first == [])
+        registry.enqueue("browser left", for: "cursor")
+        #expect(second == ["browser left"])
+    }
+
+    @Test func theQueueIsBounded() {
+        let registry = AgentRegistry()
+        for index in 0..<(AgentRegistry.maxQueuedTasks + 5) {
+            registry.enqueue("task \(index)", for: "cursor")
+        }
+        let drained = registry.drain(for: "cursor")
+        #expect(drained.count == AgentRegistry.maxQueuedTasks)
+        // The newest survive; a months-old voice command is worthless.
+        #expect(drained.last?.prompt == "task \(AgentRegistry.maxQueuedTasks + 4)")
+    }
+
+    @Test func aReturningSessionIsAnnouncedAgain() {
+        let registry = AgentRegistry()
+        var changes = 0
+        registry.onChange = { changes += 1 }
+        let start = Date()
+        registry.register(name: "zed", pid: 3, now: start)
+        registry.register(name: "zed", pid: 3, now: start.addingTimeInterval(30))
+        #expect(changes == 1)
+        registry.register(name: "zed", pid: 3,
+                          now: start.addingTimeInterval(AgentRegistry.presenceTimeout + 60))
+        #expect(changes == 2)
+    }
+
     @Test func tasksForOneAgentDoNotLeakToAnother() {
         let registry = AgentRegistry()
         registry.enqueue("for claude", for: "claude-code")

--- a/App/Tests/plonkTests/AgentRegistryTests.swift
+++ b/App/Tests/plonkTests/AgentRegistryTests.swift
@@ -79,17 +79,32 @@ struct AgentRegistryTests {
         #expect(registry.drain(for: "cursor").isEmpty)
     }
 
-    /// A client that polls again has abandoned the previous connection, so the
-    /// stale waiter must not stay first in line for the next task.
-    @Test func aSecondPollReplacesTheParkedWaiter() {
+    /// A stale waiter must not stay first in line for the next task, but two
+    /// windows of the same client share a name and must both keep waiting —
+    /// evicting one on the other's poll would spin them both.
+    @Test func theNewestWaiterGetsTheTaskAndTheOthersKeepWaiting() {
         let registry = AgentRegistry()
         var first: [String]?
         var second: [String]?
         registry.wait(for: "cursor", seconds: 25) { first = $0.map(\.prompt) }
         registry.wait(for: "cursor", seconds: 25) { second = $0.map(\.prompt) }
-        #expect(first == [])
+        #expect(first == nil)
+        #expect(second == nil)
         registry.enqueue("browser left", for: "cursor")
         #expect(second == ["browser left"])
+        #expect(first == nil)
+        registry.enqueue("terminal right", for: "cursor")
+        #expect(first == ["terminal right"])
+    }
+
+    @Test func parkedWaitersAreCapped() {
+        let registry = AgentRegistry()
+        var answered = 0
+        for _ in 0..<(AgentRegistry.maxWaiters + 3) {
+            registry.wait(for: "cursor", seconds: 25) { _ in answered += 1 }
+        }
+        // The oldest are flushed empty to free their sockets.
+        #expect(answered == 3)
     }
 
     @Test func theQueueIsBounded() {

--- a/App/Tests/plonkTests/ConfigTests.swift
+++ b/App/Tests/plonkTests/ConfigTests.swift
@@ -2,6 +2,34 @@ import Testing
 import Foundation
 @testable import plonk
 
+/// The one place a prompt from voice or /agents/ask meets a shell.
+struct AgentAdapterTests {
+
+    @Test func thePromptTravelsInTheEnvironmentNotTheCommandLine() {
+        let invocation = AgentAdapter.invocation(command: "claude -p {prompt}", prompt: "browser left")
+        #expect(invocation.command == "claude -p \"$PLONK_PROMPT\"")
+        #expect(invocation.environment["PLONK_PROMPT"] == "browser left")
+    }
+
+    @Test func aTemplateWithoutThePlaceholderGetsOneAppended() {
+        let invocation = AgentAdapter.invocation(command: "codex exec", prompt: "hi")
+        #expect(invocation.command == "codex exec \"$PLONK_PROMPT\"")
+    }
+
+    /// Shell metacharacters used to escape a quoted template and run.
+    @Test func metacharactersNeverReachTheShell() {
+        let nasty = "open docs; rm -rf ~/tmp && echo $(whoami) `id` 'quoted'"
+        for template in ["claude -p {prompt}", "mytool --ask '{prompt}'", "mytool --ask \"{prompt}\""] {
+            let invocation = AgentAdapter.invocation(command: template, prompt: nasty)
+            #expect(!invocation.command.contains("rm -rf"))
+            #expect(!invocation.command.contains("whoami"))
+            #expect(invocation.environment["PLONK_PROMPT"] == nasty)
+        }
+    }
+}
+import Foundation
+@testable import plonk
+
 struct ConfigTests {
 
     private func decode(_ json: String) throws -> Config {

--- a/App/Tests/plonkTests/ConfigTests.swift
+++ b/App/Tests/plonkTests/ConfigTests.swift
@@ -26,9 +26,18 @@ struct AgentAdapterTests {
             #expect(invocation.environment["PLONK_PROMPT"] == nasty)
         }
     }
+
+    /// Safety is not enough: the words have to arrive. A template that quotes
+    /// the placeholder would otherwise hand the tool the literal variable name
+    /// while Plonk reported success.
+    @Test func aQuotedPlaceholderStillExpands() {
+        for template in ["mytool --ask '{prompt}'", "mytool --ask \"{prompt}\"", "mytool --ask {prompt}"] {
+            let invocation = AgentAdapter.invocation(command: template, prompt: "browser left")
+            #expect(invocation.command == "mytool --ask \"$PLONK_PROMPT\"")
+            #expect(!invocation.command.contains("'$PLONK_PROMPT'"))
+        }
+    }
 }
-import Foundation
-@testable import plonk
 
 struct ConfigTests {
 

--- a/App/Tests/plonkTests/RouterTests.swift
+++ b/App/Tests/plonkTests/RouterTests.swift
@@ -397,13 +397,26 @@ struct RouterTests {
                               headers: ["x-plonk-agent": "cursor/1.0"],
                               body: ["prompt": "move everything to screen 2"])
         #expect(h.send(ask).status == 409)
-        // Draining someone else's queue steals their prompts, GET or not.
-        let peek = HTTPRequest(method: "GET", path: "/agents/inbox?agent=claude-code",
-                               headers: ["x-plonk-agent": "cursor/1.0"], body: [:])
-        #expect(h.send(peek).status == 409)
-        let own = HTTPRequest(method: "GET", path: "/agents/inbox?agent=claude-code",
-                              headers: ["x-plonk-agent": "claude-code/2.0"], body: [:])
-        #expect(h.send(own).status == 200)
+    }
+
+    /// Who may read a queue depends on whose queue it is — not on who the
+    /// active agent happens to be. Getting that backwards both starved
+    /// everyone else of their own prompts and let the active agent take theirs.
+    @Test func anAgentMayOnlyReadItsOwnQueue() {
+        let h = Harness()
+        _ = h.post("/agents/select", ["name": "claude-code"])
+        _ = h.post("/agents/exclusive", ["on": true])
+
+        func poll(as caller: String, queue: String) -> Int {
+            h.send(HTTPRequest(method: "GET", path: "/agents/inbox?agent=\(queue)",
+                               headers: ["x-plonk-agent": "\(caller)/1.0"], body: [:])).status
+        }
+        // Its own, even though it is not the selected agent.
+        #expect(poll(as: "cursor", queue: "cursor") == 200)
+        #expect(poll(as: "claude-code", queue: "claude-code") == 200)
+        // Someone else's, even as the selected agent.
+        #expect(poll(as: "claude-code", queue: "cursor") == 409)
+        #expect(poll(as: "cursor", queue: "claude-code") == 409)
     }
 
     @Test func mutationsBumpTheRevision() {

--- a/App/Tests/plonkTests/RouterTests.swift
+++ b/App/Tests/plonkTests/RouterTests.swift
@@ -17,6 +17,8 @@ struct RouterTests {
             try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
             store = ConfigStore(directory: directory)
             router = Router(store: store, windows: WindowManager(), awake: AwakeManager())
+            // Mirrors AppDelegate.setupServer, which owns this wiring.
+            store.didMutate = { [router] in router.changes.bump("config") }
         }
 
         deinit { try? FileManager.default.removeItem(at: directory) }
@@ -374,6 +376,34 @@ struct RouterTests {
         #expect(split.query["agent"] == "claude-code")
         #expect(split.query["wait"] == "25")
         #expect(Router.splitQuery("/state").path == "/state")
+    }
+
+    /// A bare "=" pair used to trap and take the whole app down with it.
+    @Test func malformedQueriesDoNotCrash() {
+        #expect(Router.splitQuery("/state?=").path == "/state")
+        #expect(Router.splitQuery("/state?a=1&=&b=2").query["b"] == "2")
+        #expect(Router.splitQuery("/state?").path == "/state")
+        #expect(Router.splitQuery("/state?flag").query["flag"] == "")
+        let h = Harness()
+        #expect(h.send(HTTPRequest(method: "GET", path: "/state?=", headers: [:], body: [:])).status != 404)
+    }
+
+    /// A prompt is a way to move windows by proxy, and can launch an adapter.
+    @Test func exclusiveModeGuardsTheAgentChannel() {
+        let h = Harness()
+        _ = h.post("/agents/select", ["name": "claude-code"])
+        _ = h.post("/agents/exclusive", ["on": true])
+        let ask = HTTPRequest(method: "POST", path: "/agents/ask",
+                              headers: ["x-plonk-agent": "cursor/1.0"],
+                              body: ["prompt": "move everything to screen 2"])
+        #expect(h.send(ask).status == 409)
+        // Draining someone else's queue steals their prompts, GET or not.
+        let peek = HTTPRequest(method: "GET", path: "/agents/inbox?agent=claude-code",
+                               headers: ["x-plonk-agent": "cursor/1.0"], body: [:])
+        #expect(h.send(peek).status == 409)
+        let own = HTTPRequest(method: "GET", path: "/agents/inbox?agent=claude-code",
+                              headers: ["x-plonk-agent": "claude-code/2.0"], body: [:])
+        #expect(h.send(own).status == 200)
     }
 
     @Test func mutationsBumpTheRevision() {

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -119,9 +119,12 @@ const NOT_RUNNING =
   "Plonk menu bar app is not running. Ask the user to launch Plonk.app (its icon should appear in the menu bar).";
 
 // Stamped on every request so the app can attribute it to a client and, in
-// exclusive mode, gate on it. Over stdio there is one client per process and
-// the global identity is enough; over HTTP many clients share the process, so
-// each session carries its identity through AsyncLocalStorage instead.
+// exclusive mode, gate on it. One mechanism, one shape: the identity always
+// lives in a holder. HTTP runs each request inside its session's holder; stdio
+// fills the process-wide one, because process.stdin exists before any context
+// we could enter and its callbacks never inherit one. HTTP never fills that
+// holder, so a lost context there means no identity — an unidentified client
+// the app can reject — rather than another session's name.
 import { AsyncLocalStorage } from "node:async_hooks";
 
 export interface AgentIdentity {
@@ -137,19 +140,20 @@ export interface IdentityHolder {
 }
 
 const identityStore = new AsyncLocalStorage<IdentityHolder>();
-let globalIdentity: AgentIdentity | undefined;
-
-export function setAgentIdentity(name: string, version: string): void {
-  globalIdentity = { name, version, pid: process.pid };
-}
+const processHolder: IdentityHolder = {};
 
 /** Run fn with a per-session identity; every call() inside sees it. */
 export function runWithIdentity<T>(holder: IdentityHolder, fn: () => T): T {
   return identityStore.run(holder, fn);
 }
 
+/** The holder for a transport that serves a single client per process. */
+export function processIdentityHolder(): IdentityHolder {
+  return processHolder;
+}
+
 function currentIdentity(): AgentIdentity | undefined {
-  return identityStore.getStore()?.identity ?? globalIdentity;
+  return (identityStore.getStore() ?? processHolder).identity;
 }
 
 /** The client name this session registered with, e.g. "claude-code". */

--- a/mcp/src/factory.ts
+++ b/mcp/src/factory.ts
@@ -67,10 +67,19 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms).u
 
 /** Long-polls the app's inbox for tasks addressed to this client — the
  * channel that lets Plonk (voice, hotkeys, other agents) reach the agent.
- * A task is handed to the client's own model through MCP sampling; clients
- * that never declared the sampling capability just have the task logged, and
- * the user is better served by a CLI adapter there. Returns a stop function. */
+ * A task is handed to the client's own model through MCP sampling, so the loop
+ * only runs for clients that declared that capability: polling drains the
+ * queue, and draining what this client cannot act on would silently throw the
+ * user's words away instead of leaving them for a CLI adapter.
+ * Returns a stop function; it is a no-op when the loop never started. */
 export function startInboxLoop(server: McpServer, identity: AgentIdentity): () => void {
+  if (!server.server.getClientCapabilities()?.sampling) {
+    console.error(
+      `plonk-mcp: ${identity.name} does not support MCP sampling, so Plonk cannot hand it spoken ` +
+        `or queued prompts. Configure a CLI adapter for it in Plonk (Settings, AI · MCP) to use voice.`
+    );
+    return () => {};
+  }
   let stopped = false;
   const loop = async (): Promise<void> => {
     while (!stopped) {
@@ -84,21 +93,14 @@ export function startInboxLoop(server: McpServer, identity: AgentIdentity): () =
         continue;
       }
       for (const task of res.tasks ?? []) {
-        if (server.server.getClientCapabilities()?.sampling) {
-          server.server
-            .createMessage({
-              messages: [{ role: "user", content: { type: "text", text: task.prompt } }],
-              maxTokens: 4_000,
-              systemPrompt:
-                "The user sent this through Plonk, the Mac window manager this agent controls over MCP. Act on it with the plonk tools where they apply.",
-            })
-            .catch((err) => console.error(`plonk-mcp: sampling failed for task ${task.id}:`, err));
-        } else {
-          console.error(
-            `plonk-mcp: task for ${identity.name} dropped — this client does not support MCP sampling. ` +
-              `Configure a CLI adapter in Plonk for this agent instead. Prompt was: ${task.prompt}`
-          );
-        }
+        server.server
+          .createMessage({
+            messages: [{ role: "user", content: { type: "text", text: task.prompt } }],
+            maxTokens: 4_000,
+            systemPrompt:
+              "The user sent this through Plonk, the Mac window manager this agent controls over MCP. Act on it with the plonk tools where they apply.",
+          })
+          .catch((err) => console.error(`plonk-mcp: sampling failed for task ${task.id}:`, err));
       }
     }
   };

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -5,7 +5,7 @@
 // `--http [--port N]` serves Streamable HTTP at http://127.0.0.1:<port>/mcp
 // instead, for clients that cannot spawn a process — several at once.
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { BASE, isAppReachable, setAgentIdentity } from "./api.js";
+import { BASE, isAppReachable, processIdentityHolder } from "./api.js";
 import { createPlonkServer, startHello, startInboxLoop, watchClientInfo } from "./factory.js";
 import { serveHttp } from "./http.js";
 
@@ -20,10 +20,11 @@ if (args.includes("--http")) {
   }
   await serveHttp(port);
 } else {
+  const holder = processIdentityHolder();
   const server = createPlonkServer();
   watchClientInfo(server, ({ name, version }) => {
-    setAgentIdentity(name, version);
     const identity = { name, version, pid: process.pid };
+    holder.identity = identity;
     startHello(identity);
     startInboxLoop(server, identity);
   });

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -17,6 +17,15 @@ export function register(server: McpServer): void {
         .describe("Also turn 'only the active agent controls' on or off"),
     },
     async ({ name, exclusive }) => {
+      // An unset identity would turn "select myself" into "" — the value that
+      // clears the user's choice — so refuse rather than undo their selection.
+      if (name === undefined && !agentIdentityName()) {
+        return text({
+          error:
+            "this client has not finished registering with Plonk yet, so it cannot select itself; " +
+            "retry in a moment or pass an explicit name from get_state",
+        });
+      }
       const target = name === undefined ? agentIdentityName() : name;
       const selected = await call("/agents/select", { method: "POST", body: { name: target } });
       if ("error" in selected || exclusive === undefined) return text(selected);


### PR DESCRIPTION
A code review of the four features shipped tonight (HTTP transport, the agent
back-channel, live state, voice) turned up eight finder passes worth of
findings. This fixes the ones that were verified to be real, with tests, and
then takes the two structural suggestions.

## Crashes and holes

| | |
| --- | --- |
| **App crash from one request** | `Router.splitQuery` trapped on a bare `=` pair — `"=".split(separator: "=", maxSplits: 1)` returns an *empty* array, so `kv[0]` was index-out-of-range. `GET /state?=` killed Plonk outright: windows, hotkeys, keep-awake, all of it. `URLComponents` owns the parsing now. |
| **Exclusive mode bypass** | "Only the active agent controls" guarded window and config routes but not the new channel. Any local client could `POST /agents/ask {"prompt": "move every window to screen 2"}` and have the selected agent carry it out — or, if the target named an adapter, spawn its shell command directly. `GET /agents/inbox?agent=<selected>` was exempt too (the gate was POST-only), so a rogue client could drain someone else's queue, including voice transcripts. |
| **Microphone stayed live** | Release the voice key before the permission callbacks land — which is exactly what happens on first use, when you let go to click Allow — and `finishCapture` no-opped while `start()` went on to open the mic with no key held. Key repeat could also run `start()` twice and install a second tap on a busy bus, an Objective-C exception Swift cannot catch. A Mac with no input device reports 0 Hz and crashed `installTap`. |
| **Voice prompts silently vanished** | The proxy's inbox loop polled for every client, drained the queue, and for clients without MCP sampling just logged the prompt to stderr. Most clients don't support sampling — so spoken commands disappeared while the HUD said they were delivered. The loop now only runs where sampling exists; everyone else leaves their tasks queued for a CLI adapter. |
| **select_agent cleared the selection** | With no `name` and identity not yet registered, it posted `""` — the value that means "clear" — undoing the user's choice instead of selecting the caller. |

## Invariants the features promised but did not keep

- **`rev` only moved for API-driven changes.** Hotkey presets, drag-to-zone and workspace launches changed windows without bumping, so an agent watching `/events` stayed stale for exactly the "what the user just did" case live state was built for. The bump moved to `WindowManager.setFrame`, the one place every move passes through. Keep-awake never bumped at all (a power-source flip writes no config), so it bumps from `awake.onChange`.
- **A dead long-poll waiter swallowed the next task.** Waiters were FIFO and never noticed a closed socket, so a reconnecting client queued behind its own corpse and the next voice prompt was written to a dead connection. One waiter per agent now, newest wins, and the queue is capped at 20 — a months-old spoken command is worthless. `wait=0` also parked instead of answering.
- **Adapter prompts met the shell as text.** Escaping held only for templates where `{prompt}` sat unquoted; `mytool --ask '{prompt}'` broke it open. The prompt travels in `PLONK_PROMPT` now and never reaches zsh as text, with `AgentAdapter.invocation` extracted as pure, tested logic.
- **SSE gaps.** Events bumped between the hello frame and the connection being registered were lost, the frame was hand-built JSON with no escaping, and the keepalive timer outlived the last listener — a menu bar app waking every 25s forever for nobody.

## Structural cleanups

- **`/events` is a route again.** `ControlServer` was string-matching the path in its receive loop, so the stream skipped session bookkeeping and the exclusive-mode gate. `HTTPResponse` gained a hand-off that gives the raw connection to a streamer; `Router` matches `("GET", "/events")` like everything else and the transport knows no paths.
- **One identity mechanism in the proxy.** Both transports now carry an `IdentityHolder` — per-session under `AsyncLocalStorage` for HTTP, process-wide for stdio. Worth recording why stdio cannot use `enterWith`: `process.stdin` exists before any context we could enter, so its callbacks never inherit one. Tried it, and the client arrived unidentified — exclusive mode then locked it out of its own changes. HTTP never fills the process holder, so a lost context there yields *no* identity (a client the app rejects) rather than someone else's name.

One review suggestion was **not** taken: dropping the retry in `watchClientInfo`. The SDK really does leave `clientInfo` unset when `oninitialized` fires — measured directly while building this (`undefined` at the callback, populated a second later), which is why the poll exists.

## Verified

`swift build`, `./scripts/test.sh` (167 tests, up from 159 — new coverage for the crash, the exclusive-mode gate, waiter replacement, queue bounds and adapter escaping), `npm run typecheck`, and live against the built bundle:

- `GET /state?=` returns 200 with the app still answering.
- `/agents/ask` and `/agents/inbox` return 409 to a non-selected client.
- `{"rev":3,"what":"awake"}` arrives over SSE on a keep-awake toggle, through the new routing.
- A stdio client under exclusive mode successfully saves a zone set (identity intact), and an HTTP session registers under its own name and pid.