### PR TITLE
Make the build checkable, not just the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,199 @@
+name: Release
+
+# Cutting a release is `git tag v0.0.5 && git push --tags`. Everything after
+# that happens here rather than on a laptop, and that is the point: the zip and
+# the npm tarball each leave with a provenance attestation GitHub signs, so
+# anyone can tie the binary they downloaded back to the commit it was built
+# from. The commands to check both are in SECURITY.md.
+#
+# Secrets, set once under Settings > Secrets and variables > Actions:
+#
+#   PLONK_SIGN_CERT_P12       the "Plonk Dev" certificate and its key, base64
+#   PLONK_SIGN_CERT_PASSWORD  the password used when exporting it
+#   NPM_TOKEN                 an npm automation token that can publish plonk-mcp
+#
+# To produce the first two: Keychain Access > login > My Certificates, right
+# click "Plonk Dev" > Export, save a .p12 with a password, then
+#   base64 -i Plonk-Dev.p12 | pbcopy
+#
+# That key is worth guarding. It is not a Gatekeeper identity and proves
+# nothing to Apple, but every installed copy of Plonk will install an update
+# signed with it — and only one signed with it. Losing it means no user can
+# auto-update again; leaking it means someone else can offer them a build.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  app:
+    runs-on: macos-15
+    permissions:
+      contents: write # create the release, upload the zip
+      id-token: write # sign the attestation
+      attestations: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Read the version
+        id: version
+        run: |
+          set -eu
+          . ./version.env
+          echo "version=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
+          # version.env is the one source of truth for the release number, so a
+          # tag that disagrees with it is a mistake worth catching before a
+          # build goes out under the wrong name.
+          if [ "$GITHUB_REF_TYPE" = tag ] && [ "$GITHUB_REF_NAME" != "v$MARKETING_VERSION" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match MARKETING_VERSION=$MARKETING_VERSION in version.env"
+            exit 1
+          fi
+
+      - name: Import the signing certificate
+        env:
+          P12: ${{ secrets.PLONK_SIGN_CERT_P12 }}
+          P12_PASSWORD: ${{ secrets.PLONK_SIGN_CERT_PASSWORD }}
+        run: |
+          set -eu
+          if [ -z "${P12:-}" ]; then
+            echo "::error::PLONK_SIGN_CERT_P12 is not set — see the header of this workflow"
+            exit 1
+          fi
+          KEYCHAIN="$RUNNER_TEMP/plonk-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          P12_FILE="$RUNNER_TEMP/signing.p12"
+          CERT_FILE="$RUNNER_TEMP/signing.pem"
+
+          printf '%s' "$P12" | base64 --decode > "$P12_FILE"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 3600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12_FILE" -k "$KEYCHAIN" -P "$P12_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+
+          # "Plonk Dev" is a self-signed root, so nothing on a fresh runner
+          # vouches for it and `find-identity -v` — which build.sh checks —
+          # leaves it out until the system keychain is told to trust it. The
+          # certificate is read back out of the keychain rather than out of the
+          # .p12, which would need an openssl new enough for -legacy and the
+          # one on the runner is not it.
+          security find-certificate -c "Plonk Dev" -p "$KEYCHAIN" > "$CERT_FILE"
+          sudo security add-trusted-cert -d -r trustRoot \
+            -k /Library/Keychains/System.keychain "$CERT_FILE"
+
+          # codesign would otherwise stop to ask for the key, and there is
+          # nobody here to answer.
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | tr -d '"')
+          rm -f "$P12_FILE" "$CERT_FILE"
+
+          if ! security find-identity -v -p codesigning | grep -q "Plonk Dev"; then
+            echo "::error::the imported certificate is not a valid codesigning identity named \"Plonk Dev\""
+            security find-identity -v -p codesigning
+            exit 1
+          fi
+
+      - name: Test
+        run: ./scripts/test.sh
+
+      - name: Build, sign and package
+        env:
+          PLONK_SIGN_IDENTITY: Plonk Dev
+        run: ./scripts/release.sh
+
+      # What ties Plonk-<version>.zip to this repository, this commit and this
+      # workflow run. Without it the app's own promises are only checkable at
+      # runtime, on a binary nobody can trace back to the source.
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: Plonk-${{ steps.version.outputs.version }}.zip
+
+      - name: Publish the archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -eu
+          ZIP="Plonk-$VERSION.zip"
+          SHA=$(shasum -a 256 "$ZIP" | cut -d' ' -f1)
+
+          # A release with notes on it was written by hand and is left alone;
+          # anything else lands as a draft, so nothing reaches the updater
+          # before someone has said what changed.
+          if ! gh release view "v$VERSION" > /dev/null 2>&1; then
+            gh release create "v$VERSION" --draft --title "Plonk $VERSION" --notes "$(
+              printf '%s\n' \
+                "Drafted by CI. Replace this with the release notes before publishing." \
+                "" \
+                "Built from \`$GITHUB_SHA\` by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." \
+                "Verify it against that commit before installing:" \
+                "" \
+                '```sh' \
+                "gh attestation verify $ZIP -R $GITHUB_REPOSITORY" \
+                '```' \
+                "" \
+                "sha256: \`$SHA\`"
+            )"
+          fi
+          gh release upload "v$VERSION" "$ZIP" --clobber
+
+          {
+            echo "### Plonk $VERSION"
+            echo
+            echo "- sha256: \`$SHA\`"
+            echo "- update the cask in \`ostapondo/homebrew-plonk\` with that version and sha256"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mcp:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # what lets npm record where this tarball came from
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+
+      - run: npm ci
+        working-directory: mcp
+
+      - name: Check the version against version.env
+        id: version
+        run: |
+          set -eu
+          . ./version.env
+          PACKAGE=$(node -p "require('./mcp/package.json').version")
+          if [ "$PACKAGE" != "$MARKETING_VERSION" ]; then
+            echo "::error::mcp/package.json is $PACKAGE but version.env says $MARKETING_VERSION"
+            exit 1
+          fi
+          echo "version=$PACKAGE" >> "$GITHUB_OUTPUT"
+          # Re-running the workflow for a version already on npm is not a
+          # failure, it is a no-op — publishing again would be the failure.
+          if npm view "plonk-mcp@$PACKAGE" version > /dev/null 2>&1; then
+            echo "published=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=no" >> "$GITHUB_OUTPUT"
+          fi
+
+      # --provenance is the whole reason this is not an `npm publish` from a
+      # laptop: it puts a signed statement on the registry naming the commit
+      # and the workflow that produced the tarball, which is what `npx -y
+      # plonk-mcp` otherwise asks people to take on faith.
+      - name: Publish with provenance
+        if: steps.version.outputs.published == 'no'
+        working-directory: mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+      - name: Already published
+        if: steps.version.outputs.published == 'yes'
+        run: echo "plonk-mcp@${{ steps.version.outputs.version }} is already on npm; nothing to do."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,22 @@ jobs:
           ZIP="Plonk-$VERSION.zip"
           SHA=$(shasum -a 256 "$ZIP" | cut -d' ' -f1)
 
-          # A release with notes on it was written by hand and is left alone;
-          # anything else lands as a draft, so nothing reaches the updater
-          # before someone has said what changed.
-          if ! gh release view "v$VERSION" > /dev/null 2>&1; then
+          STATE=$(gh release view "v$VERSION" --json isDraft \
+            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo missing)
+
+          # A published release is already out in the world: its sha256 is what
+          # the Homebrew cask pins and what anyone who checked the download
+          # wrote down, and a rebuild is not byte-identical, so replacing the
+          # asset would break both. Re-running this workflow against one is a
+          # mistake, not a redeploy — bump version.env and tag again.
+          if [ "$STATE" = published ]; then
+            echo "::error::v$VERSION is already published; bump version.env and tag a new release instead"
+            exit 1
+          fi
+
+          # New releases land as drafts, so nothing reaches the updater before
+          # someone has said what changed.
+          if [ "$STATE" = missing ]; then
             gh release create "v$VERSION" --draft --title "Plonk $VERSION" --notes "$(
               printf '%s\n' \
                 "Drafted by CI. Replace this with the release notes before publishing." \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,10 @@ Put new logic there and cover it in `App/Tests/plonkTests/`.
   entirely when the user says so. Anything else that wants the network needs
   the README's privacy section rewritten first, which is the point of the rule.
 - Do not commit build artifacts (`.build/`, `Plonk.app`, `node_modules/`).
+- The claims in `README.md` and `SECURITY.md` are checkable, and have to stay
+  that way. Any change to the network, the permissions, the entitlements or the
+  update path makes one of them false — fix the document in the same commit,
+  and never widen a claim past what the code actually does.
 
 ## Agent notes
 
@@ -90,7 +94,15 @@ Things that have already cost someone an hour.
   ad-hoc signing. A grant that keeps vanishing across rebuilds is a stale entry
   from an older signature: `tccutil reset ScreenCapture dev.plonk.app`, then
   grant it once more.
-- **Releases go out through `scripts/release.sh`, never by hand.** v0.0.3 was
+- **Releases go out through the tag, never by hand.** Pushing `v<version>` runs
+  `.github/workflows/release.yml`, which builds, signs and attests on GitHub's
+  runners and publishes `plonk-mcp` with npm provenance. Building on a laptop
+  and uploading the zip breaks the one claim that ties a shipped binary to this
+  source, so `gh attestation verify` on it fails and the release is worse than
+  no release. `MARKETING_VERSION` in `version.env`, `version` in
+  `mcp/package.json` and the tag all have to agree; the workflow stops if they
+  do not.
+- **Releases are built by `scripts/release.sh`, never by hand.** v0.0.3 was
   zipped manually, went out ad-hoc signed, and reset the permissions of every
   user who installed it — and no copy can auto-update to or from it, because
   `UpdateManager` installs a build only when it satisfies the running copy's

--- a/App/Sources/plonk/Release.swift
+++ b/App/Sources/plonk/Release.swift
@@ -47,6 +47,26 @@ struct Release {
     let notes: String
     /// Asset size in bytes, for the progress bar. Zero when GitHub omits it.
     let size: Int64
+    /// The asset's SHA-256, hex, as GitHub records it — nil for releases made
+    /// before it started publishing one. It arrives in the same response as
+    /// the download URL, so it is no defence against a feed that lies: that is
+    /// what the signature check is for. What it catches is the download itself
+    /// going wrong — truncated, cached stale, swapped between the feed and the
+    /// disk — and it catches it before a byte is unpacked or run.
+    let digest: String?
+
+    /// GitHub writes the digest as "sha256:<hex>". Anything else — a missing
+    /// field, another algorithm, a malformed hash — reads as nil rather than
+    /// failing the update: a release that predates the field is still a
+    /// release, and the signature check has not moved.
+    static func hexSHA256(from raw: Any?) -> String? {
+        guard let text = raw as? String else { return nil }
+        let parts = text.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2, parts[0].lowercased() == "sha256" else { return nil }
+        let hex = parts[1].lowercased()
+        guard hex.count == 64, hex.allSatisfy(\.isHexDigit) else { return nil }
+        return hex
+    }
 
     /// Reads GitHub's `releases/latest` payload. Drafts and pre-releases are
     /// rejected rather than offered: they are published to be tried by hand.
@@ -87,7 +107,8 @@ struct Release {
             downloadURL: download,
             pageURL: page,
             notes: (root["body"] as? String) ?? "",
-            size: (asset["size"] as? NSNumber)?.int64Value ?? 0
+            size: (asset["size"] as? NSNumber)?.int64Value ?? 0,
+            digest: hexSHA256(from: asset["digest"])
         )
     }
 
@@ -138,6 +159,7 @@ enum UpdateError: LocalizedError {
     case network(String)
     case unpackFailed(String)
     case signatureRejected(String)
+    case digestMismatch
     case adHocCopy
     case notInstalled
     case notWritable(String)
@@ -153,6 +175,11 @@ enum UpdateError: LocalizedError {
             return "The download could not be unpacked: \(why)."
         case .signatureRejected(let why):
             return "The download was rejected: \(why). Nothing was installed."
+        case .digestMismatch:
+            return """
+            The download does not match the checksum published for it, so it is not the build \
+            that was offered. Nothing was installed.
+            """
         case .adHocCopy:
             return """
             This copy is ad-hoc signed, so a downloaded build cannot be checked against it. \

--- a/App/Sources/plonk/UpdateManager.swift
+++ b/App/Sources/plonk/UpdateManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CryptoKit
 import Security
 
 // Checks GitHub for a newer release and, when the user asks, installs it.
@@ -211,6 +212,7 @@ final class UpdateManager {
                 .appendingPathComponent("plonk-update-\(UUID().uuidString)", isDirectory: true)
             defer { try? FileManager.default.removeItem(at: archive) }
             do {
+                try checkDigest(of: archive, matches: release)
                 try unpack(archive, into: directory)
                 let staged = directory.appendingPathComponent(installed.lastPathComponent)
                 try checkPayload(at: staged, matches: release)
@@ -223,6 +225,30 @@ final class UpdateManager {
                 finish(error)
             }
         }
+    }
+
+    /// The cheapest check there is, and the first one: the bytes on disk have
+    /// to be the bytes the feed described. It runs before `ditto` is handed
+    /// the archive, so a download that went wrong on the way is never unpacked
+    /// at all. Releases cut before GitHub published a digest carry none, and
+    /// those fall through to the signature check exactly as they used to.
+    private func checkDigest(of archive: URL, matches release: Release) throws {
+        guard let expected = release.digest else { return }
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: archive)
+        } catch {
+            throw UpdateError.unpackFailed(error.localizedDescription)
+        }
+        defer { try? handle.close() }
+        // Hashed in chunks rather than read whole: the archive is the entire
+        // app, and this runs on a machine already busy launching one.
+        var hasher = SHA256()
+        while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        let actual = hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        guard actual == expected else { throw UpdateError.digestMismatch }
     }
 
     private func unpack(_ archive: URL, into directory: URL) throws {

--- a/App/Tests/plonkTests/ReleaseTests.swift
+++ b/App/Tests/plonkTests/ReleaseTests.swift
@@ -109,6 +109,44 @@ struct ReleaseParsingTests {
                        "browser_download_url": "https://example.invalid/Plonk-0.0.4.zip"]]
         #expect(try Release.parse(feed(assets: assets)).size == 0)
     }
+
+    @Test func theAssetDigestIsCarriedThrough() throws {
+        let hash = String(repeating: "ab", count: 32)
+        let assets = [["name": "Plonk-0.0.4.zip",
+                       "browser_download_url": "https://example.invalid/Plonk-0.0.4.zip",
+                       "digest": "sha256:\(hash.uppercased())"]]
+        #expect(try Release.parse(feed(assets: assets)).digest == hash)
+    }
+
+    /// Releases cut before GitHub published a digest still have to install,
+    /// and they are checked the way they always were.
+    @Test func aReleaseWithoutADigestStillParses() throws {
+        #expect(try Release.parse(feed()).digest == nil)
+    }
+}
+
+struct ReleaseDigestTests {
+
+    @Test func onlyASha256OfTheRightShapeIsAccepted() {
+        let hash = String(repeating: "0f", count: 32)
+        #expect(Release.hexSHA256(from: "sha256:\(hash)") == hash)
+        #expect(Release.hexSHA256(from: "SHA256:\(hash)") == hash)
+    }
+
+    /// A digest that cannot be read has to come back nil rather than an empty
+    /// or truncated string: the caller skips the check when there is none, so
+    /// anything short of a real hash must not present itself as one.
+    @Test func anythingElseIsNoDigestRatherThanABadOne() {
+        let hash = String(repeating: "0f", count: 32)
+        #expect(Release.hexSHA256(from: nil) == nil)
+        #expect(Release.hexSHA256(from: 42) == nil)
+        #expect(Release.hexSHA256(from: "") == nil)
+        #expect(Release.hexSHA256(from: hash) == nil, "no algorithm named")
+        #expect(Release.hexSHA256(from: "sha512:\(hash)") == nil)
+        #expect(Release.hexSHA256(from: "sha256:") == nil)
+        #expect(Release.hexSHA256(from: "sha256:\(hash.dropLast())") == nil, "too short")
+        #expect(Release.hexSHA256(from: "sha256:\(hash.dropLast())zz") == nil, "not hex")
+    }
 }
 
 struct InstallScriptTests {

--- a/README.md
+++ b/README.md
@@ -40,11 +40,17 @@ brew install --cask ostapondo/plonk/plonk
 Or download [the latest release](https://github.com/ostapondo/plonk/releases/latest),
 unzip, and drop Plonk.app into Applications.
 
-**First launch takes one extra click.** Plonk is code-signed, but not notarized
-by Apple, so macOS holds it the first time — whichever way you installed it.
-Open Plonk, dismiss the warning, then go to System Settings → Privacy &
-Security, scroll to Security, and click **Open Anyway**. That is once, for good.
-What it does with the access it asks for is [checkable](#check-it-yourself).
+**First launch takes one extra click.** Plonk is code-signed, but with a
+self-signed certificate rather than an Apple Developer ID, and Gatekeeper does
+not trust one of those — so macOS holds the app the first time, whichever way
+you installed it. Open Plonk, dismiss the warning, then go to System Settings →
+Privacy & Security, scroll to Security, and click **Open Anyway**. That is once,
+for good.
+
+What that warning means is that macOS cannot vouch for who built this. Fair. So
+rather than ask you to take it on trust, everything below is
+[checkable](#check-it-yourself) — starting with proving the file you just
+downloaded was built from the source in this repository.
 
 Grant Accessibility when asked, then relaunch. Screen Recording is asked for
 separately, the first time you capture. Nothing else — no Full Disk Access, no
@@ -81,6 +87,24 @@ Accessibility is the only way macOS lets one app move another's windows, and
 Screen Recording is what a screenshot costs. That is a lot to hand something you
 installed a minute ago, so none of this is a promise — it is all checkable.
 
+**The binary comes from the source.** Releases are built, signed and zipped by
+[a workflow](.github/workflows/release.yml) on GitHub's runners, never on a
+laptop, and ship with a provenance attestation GitHub signs:
+
+```sh
+gh attestation verify Plonk-<version>.zip -R ostapondo/plonk
+```
+
+That prints the commit and the workflow run the archive was built by. It is the
+step that makes reading the rest of this repo worth anything — without it, the
+code here and the app on your Mac are two separate claims. (Releases up to and
+including 0.0.4 were zipped by hand and carry no attestation, so the command
+fails on those. That is the whole reason it exists now.)
+
+The MCP server is published the same way, which matters more, because `npx -y
+plonk-mcp` fetches it every time: `npm view plonk-mcp dist.attestations`, or the
+Provenance panel on [its npm page](https://www.npmjs.com/package/plonk-mcp).
+
 **One thing dials out, and you can switch it off.** Every socket the app has
 open:
 
@@ -116,6 +140,11 @@ Screenshots go where you send them. There is no account to make.
 
 The MCP server is a separate npm package that depends only on the official MCP
 SDK and zod. It speaks to `127.0.0.1:43917` and nowhere else.
+
+[SECURITY.md](SECURITY.md) has the rest: the entitlements the bundle ships with
+(none), every step the updater takes before it replaces anything, what the
+signing certificate does and does not prove, and where each of these checks
+stops being one.
 
 ## Workspaces
 
@@ -176,7 +205,7 @@ it.
 | **Keep awake** | IOKit power assertions, not a jiggler. Display-on or system-only, pause on battery, auto while charging, timed sessions, and a menu bar icon that glows while it holds |
 | **Screenshots** | Region, window or screen through the native picker, then pen, arrow, rectangle, ellipse and highlighter. Saves at native resolution |
 | **Notices** | A panel in the top-right corner, not Notification Center: no permission to ask for, nothing left in your history, and it can show the screenshot instead of describing it |
-| **Updates** | One button on the Updates page. Plonk installs a build only if it is signed with the same certificate as the copy you are running — which is the same test macOS applies, so your Accessibility and Screen Recording grants carry over instead of being asked for again. Anything that fails the check is discarded and nothing is replaced. Switch the check off and the app never looks |
+| **Updates** | One button on the Updates page. The download is checked against the checksum GitHub published for it before it is unpacked, and Plonk installs a build only if it is signed with the same certificate as the copy you are running — the same test macOS applies, so your Accessibility and Screen Recording grants carry over instead of being asked for again. Anything that fails is discarded and nothing is replaced. Switch the check off and the app never looks |
 
 ## For agents
 
@@ -218,7 +247,7 @@ tell two sessions of the same client apart.
 
 ```sh
 cd App && swift build     # the app
-./scripts/test.sh         # 149 unit tests
+./scripts/test.sh         # 191 unit tests
 ./scripts/build.sh        # produces Plonk.app
 cd mcp && npm run build   # the MCP server
 ```
@@ -243,11 +272,19 @@ tccutil reset Accessibility dev.plonk.app
 ```
 
 Releases: bump `MARKETING_VERSION` and `BUILD_NUMBER` in
-[version.env](version.env). `scripts/build.sh` reads both into `Info.plist`.
-`scripts/release.sh` then builds with a Developer ID certificate, notarizes,
-staples the ticket into the bundle and writes `Plonk-<version>.zip` with the
-sha256 the cask needs. It needs a paid Apple account and stored `notarytool`
-credentials, and says how to get both if either is missing.
+[version.env](version.env) and `version` in `mcp/package.json`, then push a
+`v<version>` tag. [The release workflow](.github/workflows/release.yml) builds,
+signs and attests the app on GitHub's runners, uploads the zip to a draft
+release, and publishes the MCP server to npm with provenance. Nothing ships from
+a laptop, which is what makes `gh attestation verify` mean anything.
+
+`scripts/release.sh` is what that workflow runs, and it works locally too. It
+holds every build to the requirement in
+[scripts/release-requirement](scripts/release-requirement) — a release signed
+with anything else cannot be updated to and takes Accessibility and Screen
+Recording away from everyone who installs it by hand. It notarizes when a
+Developer ID certificate is in the keychain and says so when there is not;
+Plonk's releases are not notarized, which costs a paid Apple account.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,167 @@
+# Security
+
+Plonk asks for Accessibility and Screen Recording. Those are the two permissions
+that let one app read and move another's windows and see what is on your screen,
+and an agent on the other end of them can do both without you watching. That is
+a lot to hand a menu bar app you found on the internet.
+
+This page is what you can check instead of trusting it, what the checks actually
+prove, and where they stop.
+
+## What Plonk can do
+
+| | |
+| --- | --- |
+| **Accessibility** | Move and resize windows of other apps, and read their titles and frames. Granted by you, revocable in System Settings > Privacy & Security |
+| **Screen Recording** | Capture a region, a window or a screen, when a capture is asked for. macOS shows its own indicator every time |
+| **Microphone / Speech** | Only while a push-to-talk key is held. Transcription happens on this Mac |
+| **Disk** | One directory: `~/Library/Application Support/Plonk/`, plus wherever you save a screenshot, plus a temporary folder while an update is being unpacked |
+| **Login item** | Registered on first launch, through `SMAppService` — see below |
+| **Network** | One host — `api.github.com`, for the update check — and one loopback listener on `127.0.0.1:43917` |
+
+## What it cannot do
+
+The bundle ships with **no entitlements at all**, under the hardened runtime.
+Check the copy you have:
+
+```sh
+codesign -d --entitlements - --xml /Applications/Plonk.app   # empty
+codesign -dv --verbose=2 /Applications/Plonk.app 2>&1 | grep flags   # flags=0x10000(runtime)
+```
+
+There is no Full Disk Access, no Automation (it cannot script other apps), no
+Keychain access, no helper daemon, no privileged tool, no installer script. It
+is one binary in one bundle.
+
+**It does start at login, and it turns that on by itself.** A menu bar app that
+is not there after a reboot is not much of a menu bar app, so the first launch
+registers Plonk as a login item. It does that the supported way —
+`SMAppService.mainApp`, the API that puts a visible entry in System Settings >
+General > Login Items, which you can revoke there — and nothing outside the
+bundle is written to do it. The toggle is on Plonk's own Home page, and turning
+it off unregisters immediately. It is called out here because a login item you
+did not ask for is a fair thing to be annoyed about, not because it hides
+anywhere.
+
+Uninstalling is quitting Plonk, dragging it to the trash, and deleting
+`~/Library/Application Support/Plonk/`. Nothing survives that.
+
+## Where the build came from
+
+Releases are built, signed and packaged by
+[the release workflow](.github/workflows/release.yml) on GitHub's runners, never
+on a laptop, and leave with a provenance attestation GitHub signs. That is what
+connects the zip you downloaded to a commit you can read:
+
+```sh
+gh attestation verify Plonk-<version>.zip -R ostapondo/plonk
+```
+
+It prints the commit, the workflow file and the run that produced the archive. A
+build made by anyone else, or from a source tree that is not this repository,
+cannot produce that statement.
+
+Releases up to and including 0.0.4 predate this: they were built and zipped on a
+laptop and carry no attestation, so the command above fails on them. Nothing can
+be done about that retroactively — an attestation is a statement about a build
+that happened, and those builds happened somewhere nobody can check.
+
+The MCP server is published the same way, so `npx -y plonk-mcp` is checkable too:
+
+```sh
+npm view plonk-mcp dist.attestations
+```
+
+npmjs.com shows the same thing as a "Provenance" panel on the package page,
+naming the commit and the workflow run the tarball was built by.
+
+**What this does not cover.** Attestations say where a binary came from, not
+that its source is harmless — that part is still reading the code, and there is
+not much of it: ~7,600 lines of Swift and ~530 of TypeScript, with no
+third-party Swift dependencies at all
+([Package.swift](App/Package.swift)) and two on the npm side, the official MCP
+SDK and zod. A Homebrew install checks the cask's sha256 but carries no
+attestation of its own; verify the zip if you want the stronger statement.
+
+## The signing certificate, and what it is not
+
+Plonk is signed with a self-signed certificate called `Plonk Dev`. It is **not**
+an Apple Developer ID and proves nothing about who wrote the app — Gatekeeper
+does not trust it, which is why first launch needs one trip through System
+Settings > Privacy & Security > **Open Anyway**.
+
+What it does do is pin identity across versions. macOS ties your Accessibility
+and Screen Recording grants to the signature, and Plonk installs an update only
+when the new build satisfies the same designated requirement the running copy
+carries. So the certificate is what makes "the update is from the same author as
+the copy you already trusted" a checkable claim rather than a promise. The
+requirement every release has to satisfy is committed to this repo, in
+[scripts/release-requirement](scripts/release-requirement), and
+[scripts/release.sh](scripts/release.sh) refuses to ship a build that does not
+match it.
+
+The private key lives in GitHub Actions secrets. Its worst case is worth stating
+plainly: someone holding that key could sign a build that installed copies of
+Plonk would accept as an update. There is no revocation for a self-signed
+certificate. Attestations are the check that survives that — a build signed with
+the key but not produced by this repository's workflow will not verify.
+
+Notarization would remove the Gatekeeper warning and add Apple's own malware
+scan on top. It requires a paid Apple Developer account, and Plonk does not have
+one.
+
+## The update path
+
+This is the part of the app with the most reach, so here is every step it takes:
+
+1. On launch and once a day it asks `api.github.com` for the latest release, and
+   sends nothing but a `User-Agent` naming the app and its version. No
+   identifier, no account, no analytics. Turn the check off under Updates and
+   this stops happening, agents included — they get a 409 rather than a
+   connection opened on your behalf.
+2. Nothing downloads until you press Install.
+3. The archive's SHA-256 is checked against the digest GitHub published for that
+   asset, before it is unpacked. This catches a download that arrived damaged or
+   stale; it is not a defence against the feed itself lying, because both
+   travel in the same response.
+4. The unpacked bundle has to be Plonk, at the version that was offered.
+5. It has to satisfy the running copy's designated requirement — the step above
+   that matters, and the same test macOS applies to your permissions.
+6. Only then is the bundle swapped, by a script that puts the old copy back if
+   the swap fails.
+
+Anything that fails a step is discarded and nothing is replaced.
+
+## The local API
+
+The HTTP API on `127.0.0.1:43917` is unauthenticated, because it is how an agent
+on your own machine drives the app. Two things keep that from being a hole:
+
+- It binds to loopback. Nothing off the machine can reach it.
+- It refuses any request carrying headers a browser cannot suppress, so an open
+  web page cannot drive your desktop:
+
+```sh
+curl -so /dev/null -w '%{http_code}\n' -H 'Origin: https://example.com' \
+  http://127.0.0.1:43917/state
+403
+```
+
+What this does **not** protect against: any other program already running as
+your user can talk to that port. If something hostile is running locally with
+your privileges, Plonk is not the weakest thing it has access to — but it is
+fair to know the API is there.
+
+Optional strict mode narrows it further: only the agent you have made active can
+change anything, and everyone else gets a 409 on any call that moves a window or
+edits config.
+
+## Reporting a problem
+
+Open an issue at https://github.com/ostapondo/plonk/issues. For anything you
+would rather not post publicly, mark the issue with what you have found and ask
+for a private channel before writing details, or email the address on
+[ostapondo](https://github.com/ostapondo)'s GitHub profile.
+
+Plonk is one person's project with no paid support and no bounty. What you will
+get is an honest answer about whether it is real and when it is fixed.


### PR DESCRIPTION
The README already argued well for what Plonk does at runtime — one loopback listener, one outbound host, no dependencies — and every one of those claims is checkable against a *running process*. Nothing connected the zip on the releases page to the source in this repo. It was built and zipped on a laptop.

That is the gap this closes, and it closes it without an Apple Developer account.

## What changed

**Releases are built on GitHub's runners.** `.github/workflows/release.yml` fires on a `v<version>` tag: it imports the signing certificate, runs the tests, runs the existing `scripts/release.sh`, and attaches a provenance attestation. Anyone can then run

```sh
gh attestation verify Plonk-<version>.zip -R ostapondo/plonk
```

and get back the commit and workflow run the archive came from. A build made anywhere else cannot produce that statement — including one made with the signing key, which is the check that survives the key leaking.

**`plonk-mcp` publishes with npm provenance.** This matters more than the app: `npx -y plonk-mcp` refetches it on every agent run, and until now the published `dist/` had no link to `src/`.

**The updater checks the release checksum** against the digest GitHub publishes, before `ditto` touches the archive. Stated in the code and the docs as what it is — a check on the download, not a second signature, since the digest arrives in the same response as the URL.

**SECURITY.md**, and a README section that leads with the verify command.

## Two things now said out loud

- Plonk registers itself as a login item on first launch. It uses `SMAppService`, it shows up in System Settings, and the toggle is on the Home page — but it was not documented, and a reader auditing the app would have found it themselves. Worse than saying it.
- Releases up to 0.0.4 carry no attestation and never can. Written down rather than glossed.

The README also described releases as notarized in the Build section and un-notarized in Install. Fixed; they are not notarized, and that costs a paid Apple account.

## Before this can ship

Three secrets under Settings > Secrets and variables > Actions — `PLONK_SIGN_CERT_P12`, `PLONK_SIGN_CERT_PASSWORD`, `NPM_TOKEN`. The workflow header says how to export the first two.

## Verified

- `cd App && swift build`
- `./scripts/test.sh` — 191 tests pass (4 new, covering digest parsing)
- `cd mcp && npm run typecheck`
- workflow YAML parses; every `run` block passes `sh -n`
- entitlements and signing claims in SECURITY.md checked against `codesign -d` on the built bundle; the login-item and on-device-speech claims checked against `AppDelegate.swift` and `VoiceManager.swift`

The workflow itself cannot be exercised until the secrets exist and a tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)