### PR TITLE
Sign with a key that can leave the machine it was made on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,15 @@ name: Release
 #
 # Secrets, set once under Settings > Secrets and variables > Actions:
 #
-#   PLONK_SIGN_CERT_P12       the "Plonk Dev" certificate and its key, base64
+#   PLONK_SIGN_CERT_P12       the "Plonk Signing" certificate and its key, base64
 #   PLONK_SIGN_CERT_PASSWORD  the password used when exporting it
 #   NPM_TOKEN                 an npm automation token that can publish plonk-mcp
 #
-# To produce the first two: Keychain Access > login > My Certificates, right
-# click "Plonk Dev" > Export, save a .p12 with a password, then
-#   base64 -i Plonk-Dev.p12 | pbcopy
+# The first two come from ./scripts/make-signing-cert.sh, which prints both.
+# The certificate is deliberately generated as a file rather than in the
+# keychain: macOS will not export a private key that was born there except
+# through the Keychain Access window, and a release pipeline cannot depend on
+# someone clicking through it.
 #
 # That key is worth guarding. It is not a Gatekeeper identity and proves
 # nothing to Apple, but every installed copy of Plonk will install an update
@@ -72,13 +74,13 @@ jobs:
           security import "$P12_FILE" -k "$KEYCHAIN" -P "$P12_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/security
 
-          # "Plonk Dev" is a self-signed root, so nothing on a fresh runner
+          # "Plonk Signing" is a self-signed root, so nothing on a fresh runner
           # vouches for it and `find-identity -v` — which build.sh checks —
           # leaves it out until the system keychain is told to trust it. The
           # certificate is read back out of the keychain rather than out of the
           # .p12, which would need an openssl new enough for -legacy and the
           # one on the runner is not it.
-          security find-certificate -c "Plonk Dev" -p "$KEYCHAIN" > "$CERT_FILE"
+          security find-certificate -c "Plonk Signing" -p "$KEYCHAIN" > "$CERT_FILE"
           sudo security add-trusted-cert -d -r trustRoot \
             -k /Library/Keychains/System.keychain "$CERT_FILE"
 
@@ -90,8 +92,8 @@ jobs:
             $(security list-keychains -d user | tr -d '"')
           rm -f "$P12_FILE" "$CERT_FILE"
 
-          if ! security find-identity -v -p codesigning | grep -q "Plonk Dev"; then
-            echo "::error::the imported certificate is not a valid codesigning identity named \"Plonk Dev\""
+          if ! security find-identity -v -p codesigning | grep -q "Plonk Signing"; then
+            echo "::error::the imported certificate is not a valid codesigning identity named \"Plonk Signing\""
             security find-identity -v -p codesigning
             exit 1
           fi
@@ -101,7 +103,7 @@ jobs:
 
       - name: Build, sign and package
         env:
-          PLONK_SIGN_IDENTITY: Plonk Dev
+          PLONK_SIGN_IDENTITY: Plonk Signing
         run: ./scripts/release.sh
 
       # What ties Plonk-<version>.zip to this repository, this commit and this

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Plonk.app/
 mcp/node_modules/
 mcp/dist/
 Plonk-*.zip
+*.p12

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Things that have already cost someone an hour.
 - **Permissions are pinned to the code signature, not to the app.** TCC stores
   the designated requirement, so any change to it drops Accessibility and
   Screen Recording at once. `scripts/build.sh` refuses to build without the
-  `Plonk Dev` identity for exactly this reason — never work around it by
+  `Plonk Signing` identity for exactly this reason — never work around it by
   ad-hoc signing. A grant that keeps vanishing across rebuilds is a stale entry
   from an older signature: `tccutil reset ScreenCapture dev.plonk.app`, then
   grant it once more.

--- a/README.md
+++ b/README.md
@@ -255,12 +255,19 @@ cd mcp && npm run build   # the MCP server
 `App/` is the Swift menu bar app, `mcp/` the TypeScript MCP server. Point an
 agent at [AGENTS.md](AGENTS.md) before it touches either.
 
-`build.sh` signs with a `Plonk Dev` keychain identity and stops if it is
-missing. macOS ties Accessibility and Screen Recording to the signature, and an
-ad-hoc one changes every build, so create that certificate once (Keychain
-Access → Certificate Assistant → Create a Certificate → type "Code Signing",
-name it `Plonk Dev`) and rebuilds stop resetting permissions. Set
-`PLONK_SIGN_IDENTITY` to sign with a different one.
+`build.sh` signs with a `Plonk Signing` identity and stops if it is missing.
+macOS ties Accessibility and Screen Recording to the signature, and an ad-hoc
+one changes every build, so a stable certificate is what stops rebuilds from
+resetting permissions. [scripts/make-signing-cert.sh](scripts/make-signing-cert.sh)
+creates one and prints how to import and trust it; set `PLONK_SIGN_IDENTITY` to
+sign with a different one.
+
+It writes a `.p12` rather than adding a certificate to the keychain directly,
+which looks like the long way round until you need the key somewhere else: a
+key created by Certificate Assistant cannot be exported except through the
+Keychain Access window, and the release workflow needs it as a file it can put
+in a secret. Keep that `.p12` somewhere safe. Every installed copy accepts an
+update only if it is signed with that key, and there is nobody to reissue it.
 
 If a permission was first granted while the app was ad-hoc signed, the old
 grant is pinned to a signature that no longer exists and every rebuild looks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,7 +85,7 @@ attestation of its own; verify the zip if you want the stronger statement.
 
 ## The signing certificate, and what it is not
 
-Plonk is signed with a self-signed certificate called `Plonk Dev`. It is **not**
+Plonk is signed with a self-signed certificate called `Plonk Signing`. It is **not**
 an Apple Developer ID and proves nothing about who wrote the app — Gatekeeper
 does not trust it, which is why first launch needs one trip through System
 Settings > Privacy & Security > **Open Anyway**.
@@ -99,6 +99,14 @@ requirement every release has to satisfy is committed to this repo, in
 [scripts/release-requirement](scripts/release-requirement), and
 [scripts/release.sh](scripts/release.sh) refuses to ship a build that does not
 match it.
+
+That requirement changed once, at 0.0.5. Releases up to 0.0.4 were signed with
+a key that lived only in one Mac's keychain and could not be got back out of
+it, which made building releases anywhere else impossible. Anyone who installed
+0.0.4 or earlier has to install 0.0.5 by hand and grant Accessibility and
+Screen Recording once more; updates carry across from there on. It is the kind
+of change that costs every user something, so it was made while there was
+almost nobody to charge.
 
 The private key lives in GitHub Actions secrets. Its worst case is worth stating
 plainly: someone holding that key could sign a build that installed copies of

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,14 +13,19 @@ cd "$(dirname "$0")/.."
 # time, which silently revokes both — refuse to produce a bundle like that
 # rather than let it look built and then fail at the first window move. Checked
 # before anything is written, so a missing identity leaves the working app alone.
-IDENTITY=${PLONK_SIGN_IDENTITY:-Plonk Dev}
+IDENTITY=${PLONK_SIGN_IDENTITY:-Plonk Signing}
 if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
 	cat >&2 <<MSG
 error: code-signing identity "$IDENTITY" is not in the keychain.
 
-Create it once, then re-run this script:
-  Keychain Access > Certificate Assistant > Create a Certificate...
-  Name: $IDENTITY   Identity Type: Self Signed Root   Type: Code Signing
+If you have the .p12, import it and trust it as a root — an untrusted one is
+not a *valid* identity and will not be found:
+  security import plonk-signing.p12 -k ~/Library/Keychains/login.keychain-db -T /usr/bin/codesign
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain cert.pem
+
+If no identity exists yet, ./scripts/make-signing-cert.sh creates one. Do not
+run it to work around this message: a different certificate is a different
+identity, and switching resets Accessibility and Screen Recording for everyone.
 
 Set PLONK_SIGN_IDENTITY to build with a different one.
 MSG

--- a/scripts/make-signing-cert.sh
+++ b/scripts/make-signing-cert.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Creates the self-signed code-signing identity Plonk is signed with, as a .p12
+# file.
+#
+# Certificate Assistant can make one too, but only into the login keychain, and
+# macOS will not let a key born there back out again: `security export` answers
+# "the contents of this item cannot be retrieved" and the only way past it is
+# the Keychain Access window. That is fine once and miserable forever — the
+# release workflow needs the key as a file it can put in a secret. So the key
+# is generated as a file first and imported afterwards, which is the same
+# certificate either way and one less thing that can only be done by hand.
+#
+# Run it once. Keep the .p12 somewhere safe: every installed copy of Plonk will
+# only accept an update signed with this key, and there is no way to reissue it.
+set -eu
+cd "$(dirname "$0")/.."
+
+NAME=${PLONK_SIGN_IDENTITY:-Plonk Signing}
+OUT=${1:-./plonk-signing.p12}
+OPENSSL=${OPENSSL:-/opt/homebrew/opt/openssl@3/bin/openssl}
+[ -x "$OPENSSL" ] || OPENSSL=openssl
+
+if [ -e "$OUT" ]; then
+	echo "error: $OUT already exists — refusing to overwrite an identity" >&2
+	exit 1
+fi
+
+D=$(mktemp -d)
+trap 'rm -rf "$D"' EXIT
+
+# codeSigning EKU is what makes macOS treat this as an identity it can sign
+# with; CA:true is what lets it be trusted as its own root, since nothing else
+# vouches for it. Ten years, because a signing identity that expires takes
+# every installed copy's ability to update with it.
+"$OPENSSL" req -x509 -newkey rsa:2048 -sha256 -days 3650 -nodes \
+	-keyout "$D/key.pem" -out "$D/cert.pem" \
+	-subj "/CN=$NAME/O=Plonk" \
+	-addext "basicConstraints=critical,CA:true" \
+	-addext "keyUsage=critical,digitalSignature,keyCertSign" \
+	-addext "extendedKeyUsage=critical,codeSigning" 2>/dev/null
+
+# -legacy, or OpenSSL 3 packs the archive with AES-256 and PBKDF2 and macOS
+# answers "MAC verification failed" no matter how right the password is.
+PASSWORD=$("$OPENSSL" rand -hex 24)
+"$OPENSSL" pkcs12 -export -legacy \
+	-inkey "$D/key.pem" -in "$D/cert.pem" -name "$NAME" \
+	-passout "pass:$PASSWORD" -out "$OUT"
+
+FINGERPRINT=$("$OPENSSL" x509 -in "$D/cert.pem" -noout -fingerprint -sha1 |
+	sed 's/.*=//; s/://g' | tr 'A-Z' 'a-z')
+
+cat <<MSG
+wrote $OUT
+
+  identity:    $NAME
+  sha1:        $FINGERPRINT
+  requirement: identifier "dev.plonk.app" and certificate leaf = H"$FINGERPRINT"
+
+password (needed to import it, and by PLONK_SIGN_CERT_PASSWORD):
+
+  $PASSWORD
+
+To sign locally, import it and tell macOS to trust it as a root — without the
+trust setting it is not a *valid* identity and scripts/build.sh will not see it:
+
+  security import "$OUT" -k ~/Library/Keychains/login.keychain-db -P '$PASSWORD' -T /usr/bin/codesign
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <(openssl pkcs12 -in "$OUT" -clcerts -nokeys -legacy -passin pass:'$PASSWORD')
+
+To let the release workflow sign with it:
+
+  base64 -i "$OUT" | gh secret set PLONK_SIGN_CERT_P12 --repo ostapondo/Plonk
+  gh secret set PLONK_SIGN_CERT_PASSWORD --repo ostapondo/Plonk
+MSG

--- a/scripts/release-requirement
+++ b/scripts/release-requirement
@@ -1,1 +1,1 @@
-identifier "dev.plonk.app" and certificate leaf = H"45e827d93af731b8daec6ca2c20e4bd630f18909"
+identifier "dev.plonk.app" and certificate leaf = H"b8efe1c89e46815b26633abd275352e713ef8021"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,7 @@ case "$IDENTITY" in
 "Developer ID Application:"*) ;;
 *)
 	NOTARIZE=no
-	IDENTITY=${PLONK_SIGN_IDENTITY:-Plonk Dev}
+	IDENTITY=${PLONK_SIGN_IDENTITY:-Plonk Signing}
 	cat >&2 <<MSG
 warning: no "Developer ID Application" certificate found, so this release will
 not be notarized and first launch will need System Settings > Open Anyway.


### PR DESCRIPTION
The release workflow could never have worked as written. It expects the signing key as a `.p12` in a secret, and the key it wanted was made by Certificate Assistant — which means it lives inside one login keychain and macOS will not let it out:

```
security export -k login.keychain-db -t identities -f pkcs12
security: SecKeychainItemExport: The contents of this item cannot be retrieved.
```

The only supported way past that is the Keychain Access window. On macOS 26 that app is no longer in Utilities, it is hidden in `/System/Library/CoreServices/Applications/`, and everything that looks like it should open it opens the Passwords app instead — which never shows certificates. So the first release run failed with an empty `PLONK_SIGN_CERT_P12`, and no amount of retrying was going to fix it.

## What changed

`scripts/make-signing-cert.sh` generates the identity with OpenSSL: key and certificate as files, then a `.p12`, then an import. Same self-signed code-signing certificate, except it exists as a file from the first second, so it can go in a secret, be backed up, or be used on another Mac. The old direction — create in the keychain, extract later — has no exit.

Details that matter: `codeSigning` EKU and `CA:true` (nothing else vouches for a self-signed root); `-legacy` on the pkcs12 export, or OpenSSL 3 writes AES-256/PBKDF2 and `security import` answers "MAC verification failed" no matter how right the password is; ten-year validity, because an expired signing identity takes every installed copy's ability to update with it.

The identity is renamed `Plonk Signing`, so it cannot be confused with the old `Plonk Dev` still sitting in the keychain, and `scripts/release-requirement` carries the new certificate's hash.

## The cost, stated plainly

This changes the designated requirement. Anyone running 0.0.4 or earlier must install 0.0.5 by hand and grant Accessibility and Screen Recording again — `UpdateManager` will refuse the update, which is exactly what it is for.

Total downloads across all four releases: **7**. That is the argument for doing it now rather than at any later point, and SECURITY.md says so in the same words rather than leaving users to discover it.

## Verified

- `scripts/make-signing-cert.sh` run for real; the `.p12` it produced imports on macOS (`1 identity imported`) and lists under the Code Signing policy
- the identity reports `CSSMERR_TP_NOT_TRUSTED` until a root trust setting is added, which is what the workflow's `add-trusted-cert` step does — worth knowing, because `security find-identity -v` hides untrusted identities and `build.sh` greps that list
- both secrets re-uploaded; `PLONK_SIGN_CERT_P12` is 3417 base64 bytes, not the empty value that failed the first run
- `sh -n` on all three scripts, workflow YAML parses, every `run` block passes `sh -n`
- no stale `Plonk Dev` left anywhere outside the SECURITY.md paragraph that explains the change

## After merging

`v0.0.5` currently points at a commit whose `scripts/release-requirement` still names the old certificate, so it has to move. Nothing consumed that tag — no release, no npm publish — so re-pointing it is clean:

```sh
git checkout main && git pull
git tag -f v0.0.5 && git push -f origin v0.0.5
```

`NPM_TOKEN` also still needs replacing with a Classic **Automation** token; the current one is a Publish token and fails with `EOTP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)