### PR TITLE
Record the requirement codesign actually generates

### DIFF
--- a/scripts/release-requirement
+++ b/scripts/release-requirement
@@ -1,1 +1,1 @@
-identifier "dev.plonk.app" and certificate leaf = H"b8efe1c89e46815b26633abd275352e713ef8021"
+identifier "dev.plonk.app" and certificate root = H"b8efe1c89e46815b26633abd275352e713ef8021"


### PR DESCRIPTION
The release run got all the way through building and signing, then stopped on the check in `release.sh`:

```
  published: identifier "dev.plonk.app" and certificate leaf = H"b8efe1c8…"
  this one:  identifier "dev.plonk.app" and certificate root = H"b8efe1c8…"
```

Same certificate, same hash — but the new one is its own root (`CA:true`, since nothing else vouches for a self-signed identity), so codesign words the requirement as `certificate root` rather than `certificate leaf`. `scripts/release-requirement` was written from the certificate's fingerprint by hand rather than read back out of a real signature, and the guess was wrong.

Fixed to the string codesign emitted.

Worth noting what happened here: the check did its job. A requirement file that is merely a copy of the bundle's own signature would have compared a build against itself and passed, and the mistake would have shipped.

## After merging

```sh
git checkout main && git pull
git tag -f v0.0.5 && git push -f origin v0.0.5
```

The `mcp` job will still fail until `NPM_TOKEN` is a Classic **Automation** token — the current one is a Publish token and npm answers `EOTP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)