### PR TITLE
Publish plonk-mcp over OIDC instead of a token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,11 @@ name: Release
 #
 #   PLONK_SIGN_CERT_P12       the "Plonk Signing" certificate and its key, base64
 #   PLONK_SIGN_CERT_PASSWORD  the password used when exporting it
-#   NPM_TOKEN                 an npm automation token that can publish plonk-mcp
+#
+# npm needs no secret at all: plonk-mcp names this repository and this workflow
+# file as a trusted publisher (npmjs.com > the package > Settings > Trusted
+# publisher), and npm takes GitHub's OIDC token as proof. Nothing to rotate,
+# nothing to leak.
 #
 # The first two come from ./scripts/make-signing-cert.sh, which prints both.
 # The certificate is deliberately generated as a file rather than in the
@@ -165,12 +169,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # what lets npm record where this tarball came from
+      # Both halves of trusted publishing: it is what npm authenticates this
+      # workflow by, and what it records the tarball's origin from.
+      id-token: write
     steps:
       - uses: actions/checkout@v5
+      # Node 24 for npm 11, which is the first that can publish over OIDC.
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: mcp/package-lock.json
@@ -197,15 +204,18 @@ jobs:
             echo "published=no" >> "$GITHUB_OUTPUT"
           fi
 
-      # --provenance is the whole reason this is not an `npm publish` from a
-      # laptop: it puts a signed statement on the registry naming the commit
-      # and the workflow that produced the tarball, which is what `npx -y
-      # plonk-mcp` otherwise asks people to take on faith.
+      # No token. npm authenticates this workflow by the OIDC identity GitHub
+      # mints for it, against a trusted publisher configured on the package:
+      # this repository, this workflow file, nothing else. A token that can
+      # publish plonk-mcp therefore does not exist to be leaked, and npm is
+      # restricting the 2FA-bypassing tokens this used to need anyway.
+      #
+      # Provenance comes with it — a signed statement on the registry naming
+      # the commit and the run that produced the tarball, which is what
+      # `npx -y plonk-mcp` otherwise asks people to take on faith.
       - name: Publish with provenance
         if: steps.version.outputs.published == 'no'
         working-directory: mcp
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
       - name: Already published

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,6 +75,11 @@ npm view plonk-mcp dist.attestations
 npmjs.com shows the same thing as a "Provenance" panel on the package page,
 naming the commit and the workflow run the tarball was built by.
 
+There is no publish token for `plonk-mcp` anywhere — not in a secret, not on a
+laptop. npm is told to trust this repository's release workflow directly and
+authenticates it by the identity GitHub mints for each run, so the credential
+that would let someone else publish under that name does not exist.
+
 **What this does not cover.** Attestations say where a binary came from, not
 that its source is harmless — that part is still reading the code, and there is
 not much of it: ~7,600 lines of Swift and ~530 of TypeScript, with no


### PR DESCRIPTION
Three attempts at an npm token all ended the same way:

```
npm error code EOTP
This operation requires a one-time password from your authenticator.
```

The account is set to `two-factor auth: auth-and-writes`, so publishing needs either an interactive code or a token allowed to bypass 2FA. Classic automation tokens are gone from npm's UI entirely, and the granular replacement carries this notice:

> npm tokens that bypass 2FA are being restricted for account changes and direct publishing

So this was never a checkbox we kept missing. It is a path npm is closing.

## What replaces it

Trusted publishing. npm is told to trust this repository and this workflow file, and authenticates each run by the OIDC identity GitHub already mints for it — the same `id-token: write` permission provenance needed. Node 24, because npm 11 is the first that can do it.

`NPM_TOKEN` is gone from the workflow. That is the part worth keeping: there is now no credential anywhere that can publish `plonk-mcp` — not in a repo secret, not on a laptop, not in a shell history. Nothing to rotate and nothing to leak. SECURITY.md says so, since it is a stronger claim than the one it replaces.

## Before this can run

One form on npmjs.com, once — https://www.npmjs.com/package/plonk-mcp/access, section **Trusted publisher**:

| | |
| --- | --- |
| Publisher | GitHub Actions |
| Organization or user | `ostapondo` |
| Repository | `Plonk` |
| Workflow filename | `release.yml` |
| Environment | leave empty |

Then delete the `NPM_TOKEN` secret — it is unused after this, and the last one was pasted into a chat window.

## Verified

- workflow YAML parses; every `run` block passes `sh -n`
- the `app` job of the previous run already succeeded end to end: signed, attested, uploaded. `gh attestation verify` on the published `Plonk-0.0.5.zip` returns the commit `6806dd4`, ref `refs/tags/v0.0.5`, workflow `release.yml`, runner `github-hosted`
- the shipped bundle satisfies `scripts/release-requirement`, so updates from 0.0.5 onward will install

Only the `mcp` half was ever failing, and only on authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)