### PR TITLE
Stop setup-node handing npm a placeholder credential

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,10 +175,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # Node 24 for npm 11, which is the first that can publish over OIDC.
+      #
+      # No registry-url on purpose. Given one, setup-node writes an .npmrc with
+      # an auth line and fills it with a placeholder when no token is passed —
+      # npm then authenticates with "XXXXX-XXXXX-XXXXX-XXXXX", gets a 404, and
+      # never tries OIDC at all, because OIDC is what it falls back to only
+      # when nothing else claims to be a credential. The default registry is
+      # registry.npmjs.org anyway.
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: mcp/package-lock.json
 


### PR DESCRIPTION
Trusted publishing was configured and the error changed, which is progress — `EOTP` became:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/plonk-mcp
npm error 404  The requested resource 'plonk-mcp@0.0.5' could not be found or you do not have permission to access it.
```

The cause is visible in the step's own environment block:

```
NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
```

Given `registry-url`, `actions/setup-node` writes an `.npmrc` with an auth line and fills it with that literal placeholder when no token is passed. npm authenticated with it, npmjs answered 404, and OIDC was never attempted — npm reaches for OIDC only when nothing else claims to be a credential, and a placeholder claims to be one.

Dropping `registry-url` leaves no auth line at all. The default registry is `registry.npmjs.org` regardless, and `cache: npm` does not depend on it.

## After merging

```sh
git checkout main && git pull
git tag -f v0.0.5 && git push -f origin v0.0.5
```

The `app` job has succeeded on the last three runs; only `mcp` is being iterated on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)