### PR TITLE
Publish to the MCP Registry from the release, not from memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,16 @@ jobs:
             echo "::error::mcp/package.json is $PACKAGE but version.env says $MARKETING_VERSION"
             exit 1
           fi
+          # server.json carries the version twice — the server's own, and the
+          # npm package it points at — and the registry believes both. Left
+          # behind, it advertises an older release than this run is shipping,
+          # which is exactly how the listing ended up four versions stale.
+          SERVER=$(node -p "require('./mcp/server.json').version")
+          SERVER_PACKAGE=$(node -p "require('./mcp/server.json').packages[0].version")
+          if [ "$SERVER" != "$MARKETING_VERSION" ] || [ "$SERVER_PACKAGE" != "$MARKETING_VERSION" ]; then
+            echo "::error::mcp/server.json says $SERVER / $SERVER_PACKAGE but version.env says $MARKETING_VERSION"
+            exit 1
+          fi
           echo "version=$PACKAGE" >> "$GITHUB_OUTPUT"
           # Re-running the workflow for a version already on npm is not a
           # failure, it is a no-op — publishing again would be the failure.
@@ -227,3 +237,32 @@ jobs:
       - name: Already published
         if: steps.version.outputs.published == 'yes'
         run: echo "plonk-mcp@${{ steps.version.outputs.version }} is already on npm; nothing to do."
+
+      # Being on npm is not the same as being findable. The registry at
+      # registry.modelcontextprotocol.io is what MCP clients and directories
+      # read to know this server exists, and publishing to it used to be a
+      # command someone had to remember — so nobody did, and the listing sat
+      # four releases behind the code while advertising half the tools.
+      #
+      # Same trust model as the npm publish above: no secret. The registry
+      # takes GitHub's OIDC token as proof that this workflow, in this
+      # repository, owns the io.github.ostapondo namespace. Ownership of the
+      # npm package is proved separately, by the mcpName field in
+      # package.json naming the same server.
+      - name: Publish to the MCP Registry
+        run: |
+          set -eu
+          VERSION="${{ steps.version.outputs.version }}"
+          if curl -sf "https://registry.modelcontextprotocol.io/v0/servers?search=plonk" \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
+                const found=JSON.parse(d).servers.some(e =>
+                  e.server.name==='io.github.ostapondo/plonk' && e.server.version===process.argv[1]);
+                process.exit(found?0:1)})" "$VERSION"
+          then
+            echo "$VERSION is already in the registry; nothing to do."
+            exit 0
+          fi
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
+            | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          cd mcp && ../mcp-publisher publish

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "subfolder": "mcp"
   },
   "websiteUrl": "https://github.com/ostapondo/plonk",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "plonk-mcp",
-      "version": "0.0.4",
+      "version": "0.1.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
The registry listing sat at 0.0.4 while npm was at 0.1.0. Publishing to it was a manual command, so it rotted — and `mcp/server.json` in the repo said 0.0.4 too, meaning that publish never happened at all.

That is worth more than it sounds. The official registry is what MCP clients and every downstream directory read to know this server exists. For four releases it advertised a version with roughly half the tools.

**The release publishes now.** No secret: the registry takes GitHub's OIDC token as proof that this workflow, in this repo, owns the `io.github.ostapondo` namespace — the same shape as the npm trusted-publisher setup right above it. Ownership of the npm package is proved separately by `mcpName` in package.json.

Re-running a release stays a no-op rather than a failure: the step asks the registry whether that version is already there first, mirroring what the npm step does.

**The version guard now covers `server.json`**, both places it names a version. Missing that is what let the file drift.

0.1.0 itself is already in the registry and marked latest — published by hand while writing this, so the fix and the backfill are separate things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)