### PR TITLE
A token on the local API, and somewhere to start for anyone who is not me

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,37 @@
+# The filename has to match the category slug. Rename the category and this
+# file stops being used until it is renamed to match.
+labels: ["idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Half-formed is fine here. This is the place for something you are not
+        sure is a good idea yet; ideas that hold up become issues. ROADMAP.md
+        has what is already planned and what was deliberately left out.
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: The idea
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: What happens at your desk today without it
+      description: >
+        The concrete version. A window manager accumulates features that sound
+        reasonable and nobody uses, and this is the question that separates them.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where it would live
+      options:
+        - The app
+        - An MCP tool, so an agent can drive it
+        - The plonk CLI
+        - Not sure

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,32 @@
+# The filename has to match the category slug. Rename the category and this
+# file stops being used until it is renamed to match.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For how to set something up, or whether Plonk can do a thing at all.
+        If it is something Plonk does wrong, an issue is the better place.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do
+      description: >
+        The result you want, not only the setting you were looking for. Half the
+        answers here turn out to be a different feature than the one asked about.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you have tried
+      description: Optional, but it saves a round trip.
+
+  - type: input
+    id: setup
+    attributes:
+      label: Plonk and macOS versions
+      description: >
+        Add the MCP client too if the question involves an agent.
+      placeholder: "Plonk 0.1.0, macOS 15.5, Claude Code"

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,49 @@
+# The filename has to match the category slug. Rename the category and this
+# file stops being used until it is renamed to match.
+title: "[Zone set] "
+labels: ["zone-set"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Layouts are the one thing nobody can design for someone else's desk. Post
+        one you keep going back to. Sets that hold up for more than one person
+        are how the built-ins get chosen.
+
+  - type: textarea
+    id: shape
+    attributes:
+      label: What the layout is for
+      description: >
+        The work it suits, and why the shape is what it is. A narrow rail for
+        chat next to a wide split is a different answer from three equal columns,
+        and the reason is the useful part.
+    validations:
+      required: true
+
+  - type: textarea
+    id: zones
+    attributes:
+      label: The set itself
+      description: >
+        The entry for it under `zoneSets` in
+        `~/Library/Application Support/Plonk/config.json`. Each zone is x, y, w
+        and h as fractions of the screen, origin top left.
+      render: json
+    validations:
+      required: true
+
+  - type: input
+    id: monitor
+    attributes:
+      label: The monitor you drew it on
+      description: Size and aspect ratio. A set drawn for 32:9 rarely survives 16:10.
+      placeholder: "34 inch ultrawide, 3440x1440"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: A screenshot
+      description: Optional, and the thing most people will actually look at.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something Plonk does that it should not, or does not do that it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Window bugs depend on hardware nobody else has, so the questions below
+        are the ones that decide whether this can be reproduced at all.
+
+        If what you have found is exploitable, close this and read SECURITY.md
+        instead.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what happened instead.
+      placeholder: |
+        Dragged a Safari window into zone 2 on the right-hand monitor.
+        Expected it to fill the zone. It landed a few points short at the top
+        and kept the gap on the left.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: From a freshly launched Plonk, if you can get there.
+      placeholder: |
+        1. Assign the three-column set to the second monitor
+        2. Drag any window into the middle column
+        3. Look at the top edge
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Plonk version
+      description: The Updates page shows it.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: "15.5, Apple silicon"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How it was installed
+      options:
+        - Homebrew cask
+        - Downloaded release zip
+        - Built from source
+    validations:
+      required: true
+
+  - type: textarea
+    id: displays
+    attributes:
+      label: Monitors
+      description: >
+        How many, their arrangement, and their scale factors if you know them.
+        A mixed-scale setup or a display to the left of the primary one is the
+        cause of a surprising share of placement bugs.
+      placeholder: |
+        Built-in 14" at 2x, plus a 27" 4K at 1x positioned above and to the left.
+    validations:
+      required: true
+
+  - type: input
+    id: app
+    attributes:
+      label: Which app owned the window
+      description: >
+        Leave blank if it happens with every app. Some apps refuse to be resized
+        or manage their own geometry, which is what the excluded-apps list is for.
+      placeholder: "Safari"
+
+  - type: textarea
+    id: state
+    attributes:
+      label: Output of the state route
+      description: >
+        Optional, and often the fastest way to show what the desk looked like -
+        run `curl -s 127.0.0.1:43917/state` while Plonk is running. It lists the
+        title of every open window, so read it before pasting it.
+      render: json
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I am on the latest release, or I have said above why I am not
+          required: true
+        - label: It still happens after quitting and relaunching Plonk
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -91,8 +91,10 @@ body:
       label: Output of the state route
       description: >
         Optional, and often the fastest way to show what the desk looked like -
-        run `curl -s 127.0.0.1:43917/state` while Plonk is running. It lists the
-        title of every open window, so read it before pasting it.
+        run this while Plonk is running. It lists the title of every open
+        window, so read it before pasting it.
+
+        curl -s -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" 127.0.0.1:43917/state
       render: json
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question about using Plonk
+    url: https://github.com/ostapondo/plonk/discussions/categories/q-a
+    about: How to set something up, or whether Plonk can do a thing at all.
+  - name: An idea, before it is a request
+    url: https://github.com/ostapondo/plonk/discussions/categories/ideas
+    about: Half-formed is fine. Ideas that hold up become issues.
+  - name: Show a zone set or a workspace
+    url: https://github.com/ostapondo/plonk/discussions/categories/show-and-tell
+    about: Post a layout you keep going back to. Good ones ship as built-ins.
+  - name: A security problem
+    url: https://github.com/ostapondo/plonk/blob/main/SECURITY.md
+    about: Do not open a public issue first. SECURITY.md has the route.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Something Plonk should be able to do
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ROADMAP.md is worth a look first. It has what is being built now, and a
+        "Not planned" section explaining what was considered and left out, which
+        may already answer this.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do
+      description: >
+        The situation at your desk, not the feature. What the layout looks like,
+        what you end up doing by hand, how often.
+      placeholder: |
+        Every morning I open the same four apps and drag them into the same
+        places across two monitors, because one of them opens on the wrong
+        screen and takes the others with it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: What you do about it today
+      description: >
+        Including anything in Plonk you tried that nearly worked. A feature that
+        already exists under a different name is the most common outcome here.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where it belongs
+      description: Best guess is fine.
+      options:
+        - The app - a setting, a hotkey, a page
+        - An MCP tool, so an agent can drive it
+        - The plonk CLI
+        - A mix, or not sure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: constraints
+    attributes:
+      label: Does it need anything Plonk currently avoids
+      description: >
+        None of these is a refusal by itself, but each one is a promise the
+        README makes that would have to be rewritten, so it is better said now
+        than found later.
+      options:
+        - label: A network connection
+        - label: A macOS permission beyond Accessibility and Screen Recording
+        - label: A third-party dependency
+        - label: None of these, as far as I can tell
+
+  - type: checkboxes
+    id: offer
+    attributes:
+      label: Optional
+      options:
+        - label: I would be up for building this if the approach is agreed first

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,12 @@ Put new logic there and cover it in `App/Tests/plonkTests/`.
 ## Boundaries
 
 - The HTTP API binds to loopback only. Never expose it on other interfaces.
-- It has no authentication, so it must keep rejecting browser-originated
-  requests (`ControlServer.browserRejection`). Do not add CORS headers.
+- It must keep rejecting browser-originated requests
+  (`ControlServer.browserRejection`). Do not add CORS headers.
+- Every route but `/ping` is gated on the token in `APIToken`, and the check
+  lives in the transport so a new route is covered without doing anything.
+  Do not add exemptions. `/ping` is the only one, so a client can tell a closed
+  app from a stale token, and it has to stay free of anything worth reading.
 - Nothing on the main thread may wait on another process or on the user.
   `screencapture` runs asynchronously for exactly this reason.
 - No telemetry, no analytics, no crash reporting, and no third-party Swift

--- a/App/Sources/plonk/APIToken.swift
+++ b/App/Sources/plonk/APIToken.swift
@@ -38,6 +38,9 @@ enum APIToken {
     /// Nil when there is no file this user can both read and keep to
     /// themselves. That is not a token, so the API refuses to answer rather
     /// than answering to anyone — see `rejection`.
+    ///
+    /// A file that arrives readable by others is replaced, not repaired: its
+    /// contents have already been exposed for however long it sat there.
     static func loadOrCreate(in directory: URL? = nil) -> String? {
         let url = Self.url(in: directory)
         try? FileManager.default.createDirectory(
@@ -45,9 +48,9 @@ enum APIToken {
 
         if let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) {
             // Somebody else's file — one `sudo` launch leaves a root-owned one
-            // behind — cannot be tightened by this user and must not be
-            // trusted: its contents are a secret they do not control. Same for
-            // anything that is not a plain file.
+            // behind — is neither replaceable by this user nor trustworthy:
+            // its contents are a secret they do not control. Same for anything
+            // that is not a plain file.
             let owner = (attributes[.ownerAccountID] as? NSNumber)?.uint32Value
             guard owner == getuid() else {
                 NSLog("Plonk: the API token at \(url.path) belongs to another user (uid \(owner.map(String.init) ?? "unknown"))")
@@ -59,23 +62,22 @@ enum APIToken {
             }
         }
 
-        if let existing = try? String(contentsOf: url, encoding: .utf8) {
-            let token = existing.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !token.isEmpty {
-                // An earlier copy, a restored backup or a hand-edited file can
-                // be world-readable. Tighten it rather than trust it — and if
-                // it will not tighten, it is a secret the rest of the machine
-                // has already read, so it is no longer one.
-                try? FileManager.default.setAttributes(
-                    [.posixPermissions: NSNumber(value: 0o600)], ofItemAtPath: url.path)
-                let mode = (try? FileManager.default.attributesOfItem(atPath: url.path))
-                    .flatMap { ($0[.posixPermissions] as? NSNumber)?.int16Value } ?? 0
-                guard mode & 0o077 == 0 else {
-                    NSLog("Plonk: the API token at \(url.path) stayed readable by other users")
-                    return nil
-                }
-                return token
+        if let existing = try? String(contentsOf: url, encoding: .utf8),
+           !existing.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            // Unknown counts as loose: a mode this cannot read is a mode this
+            // cannot vouch for, and the safe reading of "I do not know who can
+            // read this secret" is "everyone".
+            let mode = (try? FileManager.default.attributesOfItem(atPath: url.path))
+                .flatMap { ($0[.posixPermissions] as? NSNumber)?.int16Value } ?? 0o777
+            if mode & 0o077 == 0 {
+                return existing.trimmingCharacters(in: .whitespacesAndNewlines)
             }
+            // A restored backup or a copied Application Support folder arrives
+            // world-readable, and by then anything on the machine may have
+            // read it. Tightening such a file makes the permissions right and
+            // the secret no better, so it is replaced rather than kept: the
+            // clients that held the old one re-read the file on the first 401.
+            NSLog("Plonk: the API token at \(url.path) was readable by other users; replacing it")
         }
 
         // Created by open(2) rather than FileManager, which writes the file

--- a/App/Sources/plonk/APIToken.swift
+++ b/App/Sources/plonk/APIToken.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// The shared secret the loopback API is gated on.
+///
+/// Binding to loopback keeps the machine's network out. It does nothing about
+/// the machine itself: every process running as this user can reach the port,
+/// and Plonk holds Screen Recording, so an unauthenticated `/shot/capture`
+/// hands a caller that has no such grant of its own a picture of the screen.
+/// That is the permission being lent out, not just the window layout.
+///
+/// So a client has to present a token it could only have got by reading a file
+/// in this user's home directory. Anything already able to read that file could
+/// read the screen by asking macOS directly, which is where this stops being
+/// worth more: the point is that reaching the port is no longer enough.
+///
+/// It lives in its own file rather than in `config.json`, because config is
+/// documented as plain JSON people open, edit and paste into bug reports, and a
+/// secret in it would leave with the first pasted zone set.
+enum APIToken {
+
+    /// Lowercased, because `HTTPRequest.headers` is.
+    static let headerName = "x-plonk-token"
+
+    /// Reaching the port must stay enough to answer "is the app running", so
+    /// the MCP server and the CLI can tell a closed app from a stale token
+    /// without holding either. It reveals nothing else.
+    static let openPaths: Set<String> = ["/ping"]
+
+    static func url(in directory: URL? = nil) -> URL {
+        let dir = directory ?? FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Plonk", isDirectory: true)
+        return dir.appendingPathComponent("token")
+    }
+
+    /// The token for this install, generated on first launch.
+    ///
+    /// A file that cannot be read or written leaves the app without one, and
+    /// the caller decides what that means — refusing every request would lock
+    /// the user out of their own agent over a permissions problem on a file
+    /// they never made.
+    static func loadOrCreate(in directory: URL? = nil) -> String? {
+        let url = Self.url(in: directory)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        if let existing = try? String(contentsOf: url, encoding: .utf8) {
+            let token = existing.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !token.isEmpty {
+                // An earlier copy, a restored backup or a hand-edited file can
+                // be world-readable. Tighten it rather than trust it.
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: NSNumber(value: 0o600)], ofItemAtPath: url.path)
+                return token
+            }
+        }
+
+        let token = generate()
+        let created = FileManager.default.createFile(
+            atPath: url.path,
+            contents: Data(token.utf8),
+            attributes: [.posixPermissions: NSNumber(value: 0o600)])
+        guard created else {
+            NSLog("Plonk: could not write the API token to \(url.path)")
+            return nil
+        }
+        return token
+    }
+
+    /// 32 bytes, hex. `random(in:)` draws from `SystemRandomNumberGenerator`,
+    /// which is the platform's cryptographic source.
+    static func generate() -> String {
+        (0..<32)
+            .map { _ in String(format: "%02x", Int(UInt8.random(in: 0...255))) }
+            .joined()
+    }
+
+    /// Equal-length comparison that does not stop at the first difference. The
+    /// length itself is not secret; which byte failed would be.
+    static func matches(_ presented: String, _ token: String) -> Bool {
+        let a = Array(presented.utf8), b = Array(token.utf8)
+        guard a.count == b.count, !a.isEmpty else { return false }
+        var difference: UInt8 = 0
+        for i in a.indices { difference |= a[i] ^ b[i] }
+        return difference == 0
+    }
+
+    /// The 401 reason, or nil when the request may proceed.
+    ///
+    /// `token` is nil when the app could not read or write the token file. The
+    /// API stays open in that case: the alternative is an app that silently
+    /// stops answering its own MCP server, which reads as a bug in everything
+    /// except the one place the problem is.
+    static func rejection(for request: HTTPRequest, token: String?) -> String? {
+        guard let token else { return nil }
+        if Self.openPaths.contains(request.path) { return nil }
+        guard let presented = request.headers[Self.headerName], matches(presented, token) else {
+            return "this request carried no valid token. Plonk's API is gated on the token in "
+                + "~/Library/Application Support/Plonk/token, which the MCP server and the plonk "
+                + "command read for themselves. A client that was started before the token changed "
+                + "has to be restarted."
+        }
+        return nil
+    }
+}

--- a/App/Sources/plonk/APIToken.swift
+++ b/App/Sources/plonk/APIToken.swift
@@ -35,22 +35,45 @@ enum APIToken {
 
     /// The token for this install, generated on first launch.
     ///
-    /// A file that cannot be read or written leaves the app without one, and
-    /// the caller decides what that means — refusing every request would lock
-    /// the user out of their own agent over a permissions problem on a file
-    /// they never made.
+    /// Nil when there is no file this user can both read and keep to
+    /// themselves. That is not a token, so the API refuses to answer rather
+    /// than answering to anyone — see `rejection`.
     static func loadOrCreate(in directory: URL? = nil) -> String? {
         let url = Self.url(in: directory)
         try? FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
 
+        if let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) {
+            // Somebody else's file — one `sudo` launch leaves a root-owned one
+            // behind — cannot be tightened by this user and must not be
+            // trusted: its contents are a secret they do not control. Same for
+            // anything that is not a plain file.
+            let owner = (attributes[.ownerAccountID] as? NSNumber)?.uint32Value
+            guard owner == getuid() else {
+                NSLog("Plonk: the API token at \(url.path) belongs to another user (uid \(owner.map(String.init) ?? "unknown"))")
+                return nil
+            }
+            guard attributes[.type] as? FileAttributeType == .typeRegular else {
+                NSLog("Plonk: the API token path \(url.path) is not a regular file")
+                return nil
+            }
+        }
+
         if let existing = try? String(contentsOf: url, encoding: .utf8) {
             let token = existing.trimmingCharacters(in: .whitespacesAndNewlines)
             if !token.isEmpty {
                 // An earlier copy, a restored backup or a hand-edited file can
-                // be world-readable. Tighten it rather than trust it.
+                // be world-readable. Tighten it rather than trust it — and if
+                // it will not tighten, it is a secret the rest of the machine
+                // has already read, so it is no longer one.
                 try? FileManager.default.setAttributes(
                     [.posixPermissions: NSNumber(value: 0o600)], ofItemAtPath: url.path)
+                let mode = (try? FileManager.default.attributesOfItem(atPath: url.path))
+                    .flatMap { ($0[.posixPermissions] as? NSNumber)?.int16Value } ?? 0
+                guard mode & 0o077 == 0 else {
+                    NSLog("Plonk: the API token at \(url.path) stayed readable by other users")
+                    return nil
+                }
                 return token
             }
         }
@@ -85,20 +108,41 @@ enum APIToken {
         return difference == 0
     }
 
-    /// The 401 reason, or nil when the request may proceed.
+    /// Why a request is not being answered: the caller's problem, or the app's.
+    /// They are different failures and a client can only act on the difference.
+    struct Rejection: Equatable {
+        var status: Int
+        var message: String
+    }
+
+    /// The rejection, or nil when the request may proceed.
     ///
-    /// `token` is nil when the app could not read or write the token file. The
-    /// API stays open in that case: the alternative is an app that silently
-    /// stops answering its own MCP server, which reads as a bug in everything
-    /// except the one place the problem is.
-    static func rejection(for request: HTTPRequest, token: String?) -> String? {
-        guard let token else { return nil }
-        if Self.openPaths.contains(request.path) { return nil }
+    /// A missing token fails closed. The gate exists because reaching the port
+    /// must not be enough to borrow Screen Recording, and an app that cannot
+    /// hold a secret has not stopped holding that grant — so it stops
+    /// answering instead, loudly, in a way that says which file to look at.
+    /// The cost is an agent that goes quiet until a permissions problem is
+    /// fixed; the alternative is a screenshot for anything on the machine that
+    /// opens a socket.
+    static func rejection(for request: HTTPRequest, token: String?) -> Rejection? {
+        // The router strips the query before matching a path, so this must
+        // too — otherwise "/ping?t=1" misses the one rule written to let it
+        // through, and the two disagree about what a path is.
+        let path = Router.splitQuery(request.path).path
+        if Self.openPaths.contains(path) { return nil }
+        guard let token else {
+            return Rejection(status: 503, message:
+                "Plonk has no usable API token, so it is answering nothing but /ping. The token "
+                + "lives at ~/Library/Application Support/Plonk/token and has to be a plain file "
+                + "owned by you and readable by you alone. Delete it and relaunch Plonk to have a "
+                + "new one written.")
+        }
         guard let presented = request.headers[Self.headerName], matches(presented, token) else {
-            return "this request carried no valid token. Plonk's API is gated on the token in "
+            return Rejection(status: 401, message:
+                "this request carried no valid token. Plonk's API is gated on the token in "
                 + "~/Library/Application Support/Plonk/token, which the MCP server and the plonk "
                 + "command read for themselves. A client that was started before the token changed "
-                + "has to be restarted."
+                + "has to be restarted.")
         }
         return nil
     }

--- a/App/Sources/plonk/APIToken.swift
+++ b/App/Sources/plonk/APIToken.swift
@@ -78,13 +78,28 @@ enum APIToken {
             }
         }
 
+        // Created by open(2) rather than FileManager, which writes the file
+        // first and applies `.posixPermissions` after: on this machine a stat
+        // loop caught the new token at mode 0644, secret already inside, three
+        // times in four thousand samples. That window belongs to exactly the
+        // process this file exists to keep out. O_EXCL means we never write
+        // into something already there, and O_NOFOLLOW means never through a
+        // symlink someone planted.
         let token = generate()
-        let created = FileManager.default.createFile(
-            atPath: url.path,
-            contents: Data(token.utf8),
-            attributes: [.posixPermissions: NSNumber(value: 0o600)])
-        guard created else {
-            NSLog("Plonk: could not write the API token to \(url.path)")
+        // Only a blank or unreadable file reaches here; a usable one returned
+        // above, and one that is not ours was refused.
+        try? FileManager.default.removeItem(at: url)
+        let descriptor = open(url.path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else {
+            NSLog("Plonk: could not create the API token at \(url.path) (errno \(errno))")
+            return nil
+        }
+        defer { close(descriptor) }
+        let bytes = Array(token.utf8)
+        let written = bytes.withUnsafeBufferPointer { write(descriptor, $0.baseAddress, $0.count) }
+        guard written == bytes.count else {
+            NSLog("Plonk: could not write the API token to \(url.path) (errno \(errno))")
+            try? FileManager.default.removeItem(at: url)
             return nil
         }
         return token

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -593,8 +593,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let token = APIToken.loadOrCreate()
         if token == nil {
-            model.apiWarning = "The token at \(APIToken.url().path) could not be read or written, so the "
-                + "local API is answering without one. Check that file's permissions and relaunch Plonk."
+            model.apiWarning = "No usable token at \(APIToken.url().path), so the local API is "
+                + "refusing everything but /ping — agents and the plonk command will not work. It "
+                + "has to be a plain file owned by you and readable by you alone; delete it and "
+                + "relaunch Plonk to have a new one written."
         }
         let server = ControlServer(token: token) { [weak self] request, respond in
             guard let self else { return respond(.failed("shutting down")) }

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -591,7 +591,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        let server = ControlServer { [weak self] request, respond in
+        let token = APIToken.loadOrCreate()
+        if token == nil {
+            model.apiWarning = "The token at \(APIToken.url().path) could not be read or written, so the "
+                + "local API is answering without one. Check that file's permissions and relaunch Plonk."
+        }
+        let server = ControlServer(token: token) { [weak self] request, respond in
             guard let self else { return respond(.failed("shutting down")) }
             router.handle(request, respond: respond)
         }

--- a/App/Sources/plonk/ControlServer.swift
+++ b/App/Sources/plonk/ControlServer.swift
@@ -96,8 +96,9 @@ final class ControlServer {
                 self.respond(conn, HTTPResponse(status: 403, json: ["error": reason]))
                 return
             }
-            if let reason = APIToken.rejection(for: request, token: self.token) {
-                self.respond(conn, HTTPResponse(status: 401, json: ["error": reason]))
+            if let rejection = APIToken.rejection(for: request, token: self.token) {
+                self.respond(conn, HTTPResponse(status: rejection.status,
+                                                json: ["error": rejection.message]))
                 return
             }
             DispatchQueue.main.async {

--- a/App/Sources/plonk/ControlServer.swift
+++ b/App/Sources/plonk/ControlServer.swift
@@ -41,11 +41,16 @@ final class ControlServer {
     private var listener: NWListener?
     private let handle: (HTTPRequest, @escaping (HTTPResponse) -> Void) -> Void
 
+    /// The secret every request but `/ping` has to carry. Nil only when the
+    /// token file could not be read or written; see `APIToken.rejection`.
+    private let token: String?
+
     /// Called on the main queue when the port cannot be claimed, which in
     /// practice means a second Plonk is already running.
     var onUnavailable: ((String) -> Void)?
 
-    init(handle: @escaping (HTTPRequest, @escaping (HTTPResponse) -> Void) -> Void) {
+    init(token: String?, handle: @escaping (HTTPRequest, @escaping (HTTPResponse) -> Void) -> Void) {
+        self.token = token
         self.handle = handle
     }
 
@@ -85,8 +90,14 @@ final class ControlServer {
                 if isComplete { conn.cancel() } else { self.receive(on: conn, buffer: buf) }
                 return
             }
+            // Browser first, so a page that reaches the port is told it is a
+            // page rather than told to go and read a file it cannot read.
             if let reason = Self.browserRejection(for: request) {
                 self.respond(conn, HTTPResponse(status: 403, json: ["error": reason]))
+                return
+            }
+            if let reason = APIToken.rejection(for: request, token: self.token) {
+                self.respond(conn, HTTPResponse(status: 401, json: ["error": reason]))
                 return
             }
             DispatchQueue.main.async {
@@ -97,10 +108,12 @@ final class ControlServer {
         }
     }
 
-    /// The API has no authentication beyond being loopback-only, so a web page
-    /// the user happens to have open must not be able to drive it. Browsers
-    /// always attach Origin to cross-site POSTs and Sec-Fetch-Site to every
-    /// request, and neither header can be suppressed from page script.
+    /// A web page the user happens to have open must not be able to drive the
+    /// API. Browsers always attach Origin to cross-site POSTs and
+    /// Sec-Fetch-Site to every request, and neither header can be suppressed
+    /// from page script. This is kept alongside the token rather than replaced
+    /// by it: a page cannot read the token file either, but this refuses the
+    /// page for what it is, and does so before anything else is considered.
     static func browserRejection(for request: HTTPRequest) -> String? {
         guard request.headers["origin"] != nil || request.headers["sec-fetch-site"] != nil else { return nil }
         return "requests from web pages are not accepted"
@@ -151,6 +164,7 @@ final class ControlServer {
         switch status {
         case 200: return "OK"
         case 400: return "Bad Request"
+        case 401: return "Unauthorized"
         case 403: return "Forbidden"
         case 404: return "Not Found"
         case 409: return "Conflict"

--- a/App/Sources/plonk/ControlServer.swift
+++ b/App/Sources/plonk/ControlServer.swift
@@ -169,6 +169,7 @@ final class ControlServer {
         case 403: return "Forbidden"
         case 404: return "Not Found"
         case 409: return "Conflict"
+        case 503: return "Service Unavailable"
         default: return "Internal Server Error"
         }
     }

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -306,10 +306,10 @@ final class Router {
                 return
             }
             // Turning the check off has to mean nothing dials out, including
-            // on an agent's behalf. The API has no authentication, so anything
-            // running as the user could otherwise undo the setting silently —
-            // and the app promises a process that only listens. The button in
-            // Plonk still works: that one is the user asking.
+            // on an agent's behalf. Any client holding the token could
+            // otherwise undo the setting silently — and the app promises a
+            // process that only listens. The button in Plonk still works: that
+            // one is the user asking.
             guard store.config.updateCheckAutomatically else {
                 respond(HTTPResponse(status: 409, json: [
                     "error": "the user turned update checks off, so Plonk makes no outbound "

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -77,8 +77,14 @@ final class Router {
     func handle(_ request: HTTPRequest, respond: @escaping (HTTPResponse) -> Void) {
         let (path, query) = Self.splitQuery(request.path)
         let agent = Self.agentName(fromHeader: request.headers["x-plonk-agent"])
-        agents.touch(header: request.headers["x-plonk-agent"],
-                     pid: request.headers["x-plonk-agent-pid"].flatMap(Int.init))
+        // Not from a route that answers without a token: /ping is open so a
+        // client can tell a closed app from a stale token, and that is all it
+        // is for. Registering from it would let anything on the machine invent
+        // agents that appear in the menu bar and in /state.
+        if !APIToken.openPaths.contains(path) {
+            agents.touch(header: request.headers["x-plonk-agent"],
+                         pid: request.headers["x-plonk-agent-pid"].flatMap(Int.init))
+        }
         if let reason = Self.exclusiveRejection(
             method: request.method, path: path, agent: agent,
             selected: store.config.selectedAgent, exclusive: store.config.agentExclusive

--- a/App/Tests/plonkTests/APITokenTests.swift
+++ b/App/Tests/plonkTests/APITokenTests.swift
@@ -83,6 +83,20 @@ struct APITokenFileTests {
         #expect(APIToken.loadOrCreate(in: dir) == nil)
     }
 
+    /// A symlink at that path would have the token written wherever it points,
+    /// with this user's hand on the pen. Refused twice over: the attributes of
+    /// a link are the link's, and the create is O_NOFOLLOW.
+    @Test func aSymlinkAtTheTokenPathIsRefused() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let target = dir.appendingPathComponent("elsewhere")
+        FileManager.default.createFile(atPath: target.path, contents: Data())
+        try FileManager.default.createSymbolicLink(at: APIToken.url(in: dir), withDestinationURL: target)
+
+        #expect(APIToken.loadOrCreate(in: dir) == nil)
+        #expect(try String(contentsOf: target, encoding: .utf8).isEmpty)
+    }
+
     /// Anything that is not a plain file — a directory planted at that path
     /// before first launch — is refused rather than worked around.
     @Test func aDirectoryAtTheTokenPathIsRefused() throws {

--- a/App/Tests/plonkTests/APITokenTests.swift
+++ b/App/Tests/plonkTests/APITokenTests.swift
@@ -33,8 +33,10 @@ struct APITokenFileTests {
     }
 
     /// A file restored from a backup, or copied by hand, can arrive readable by
-    /// everyone. Reading it is also the moment to fix it.
-    @Test func aLooseFileIsTightenedRatherThanTrusted() throws {
+    /// everyone — and by the time Plonk sees it, anything on the machine may
+    /// already have read it. Fixing the mode does not unread it, so the secret
+    /// itself is replaced.
+    @Test func aLooseFileIsReplacedRatherThanTightened() throws {
         let dir = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let url = APIToken.url(in: dir)
@@ -43,10 +45,14 @@ struct APITokenFileTests {
             contents: Data("borrowed\n".utf8),
             attributes: [.posixPermissions: NSNumber(value: 0o644)])
 
-        #expect(APIToken.loadOrCreate(in: dir) == "borrowed")
+        let token = try #require(APIToken.loadOrCreate(in: dir))
+        #expect(token != "borrowed")
+        #expect(token.count == 64)
         let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
         let mode = try #require(attributes[.posixPermissions] as? NSNumber)
         #expect(mode.int16Value == 0o600)
+        // And it stays put from then on, rather than rotating every launch.
+        #expect(APIToken.loadOrCreate(in: dir) == token)
     }
 
     @Test func anEmptyFileIsReplacedRatherThanUsed() throws {

--- a/App/Tests/plonkTests/APITokenTests.swift
+++ b/App/Tests/plonkTests/APITokenTests.swift
@@ -66,6 +66,32 @@ struct APITokenFileTests {
         }
         #expect(APIToken.loadOrCreate(in: a) != APIToken.loadOrCreate(in: b))
     }
+
+    /// A file this user cannot tighten is one the rest of the machine has
+    /// already read. It is not a secret any more, so it is not a token.
+    @Test func aFileThatWillNotTightenIsRefused() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = APIToken.url(in: dir)
+        FileManager.default.createFile(atPath: url.path, contents: Data("loose\n".utf8),
+                                       attributes: [.posixPermissions: NSNumber(value: 0o644)])
+        // Make the directory read-only so the mode cannot be changed, the way
+        // a root-owned file behaves for a normal user.
+        try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: url.path)
+        defer { try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: url.path) }
+
+        #expect(APIToken.loadOrCreate(in: dir) == nil)
+    }
+
+    /// Anything that is not a plain file — a directory planted at that path
+    /// before first launch — is refused rather than worked around.
+    @Test func aDirectoryAtTheTokenPathIsRefused() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.createDirectory(at: APIToken.url(in: dir), withIntermediateDirectories: true)
+
+        #expect(APIToken.loadOrCreate(in: dir) == nil)
+    }
 }
 
 struct APITokenComparisonTests {
@@ -130,10 +156,28 @@ struct APITokenRejectionTests {
         #expect(APIToken.rejection(for: request("/ping"), token: token) == nil)
     }
 
-    /// Without a token the app says so in its own window rather than refusing
-    /// every request, which would look like a broken MCP server.
-    @Test func anAppWithoutATokenGatesNothing() {
-        #expect(APIToken.rejection(for: request("/shot/capture"), token: nil) == nil)
+    /// Fail closed. An app that cannot hold a secret still holds Screen
+    /// Recording, so it stops answering rather than answering to anyone.
+    @Test func anAppWithoutATokenRefusesEverythingButPing() {
+        let refused = APIToken.rejection(for: request("/shot/capture"), token: nil)
+        #expect(refused?.status == 503)
+        // Still tellable from a closed app, which is all /ping is for.
+        #expect(APIToken.rejection(for: request("/ping"), token: nil) == nil)
+    }
+
+    /// A bad token is the caller's problem and a missing one is the app's, and
+    /// a client can only tell them apart by the status.
+    @Test func theTwoFailuresAreDifferentStatuses() {
+        #expect(APIToken.rejection(for: request("/state"), token: token)?.status == 401)
+        #expect(APIToken.rejection(for: request("/state"), token: nil)?.status == 503)
+    }
+
+    /// The router matches paths with the query stripped. So must the gate, or
+    /// the only always-open route stops being open the moment anything adds a
+    /// parameter to it.
+    @Test func theQueryDoesNotHideAnOpenPath() {
+        #expect(APIToken.rejection(for: request("/ping?t=1"), token: token) == nil)
+        #expect(APIToken.rejection(for: request("/state?screen=0"), token: token)?.status == 401)
     }
 
     @Test func theHeaderSurvivesRequestParsing() throws {

--- a/App/Tests/plonkTests/APITokenTests.swift
+++ b/App/Tests/plonkTests/APITokenTests.swift
@@ -1,0 +1,144 @@
+import Testing
+import Foundation
+@testable import plonk
+
+struct APITokenFileTests {
+
+    /// A directory of its own per test, so nothing here can touch the token the
+    /// developer's own copy of Plonk is running with.
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plonk-token-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func firstLaunchWritesATokenAndKeepsIt() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let first = try #require(APIToken.loadOrCreate(in: dir))
+        #expect(!first.isEmpty)
+        #expect(APIToken.loadOrCreate(in: dir) == first)
+    }
+
+    @Test func theFileIsReadableOnlyByItsOwner() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        _ = APIToken.loadOrCreate(in: dir)
+        let attributes = try FileManager.default.attributesOfItem(atPath: APIToken.url(in: dir).path)
+        let mode = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(mode.int16Value == 0o600)
+    }
+
+    /// A file restored from a backup, or copied by hand, can arrive readable by
+    /// everyone. Reading it is also the moment to fix it.
+    @Test func aLooseFileIsTightenedRatherThanTrusted() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = APIToken.url(in: dir)
+        FileManager.default.createFile(
+            atPath: url.path,
+            contents: Data("borrowed\n".utf8),
+            attributes: [.posixPermissions: NSNumber(value: 0o644)])
+
+        #expect(APIToken.loadOrCreate(in: dir) == "borrowed")
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let mode = try #require(attributes[.posixPermissions] as? NSNumber)
+        #expect(mode.int16Value == 0o600)
+    }
+
+    @Test func anEmptyFileIsReplacedRatherThanUsed() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data("   \n".utf8).write(to: APIToken.url(in: dir))
+
+        let token = try #require(APIToken.loadOrCreate(in: dir))
+        #expect(!token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test func twoInstallsDoNotShareAToken() {
+        let a = temporaryDirectory(), b = temporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: a)
+            try? FileManager.default.removeItem(at: b)
+        }
+        #expect(APIToken.loadOrCreate(in: a) != APIToken.loadOrCreate(in: b))
+    }
+}
+
+struct APITokenComparisonTests {
+
+    @Test func aTokenMatchesItself() {
+        let token = APIToken.generate()
+        #expect(APIToken.matches(token, token))
+    }
+
+    @Test func aDifferentTokenOfTheSameLengthDoesNot() {
+        #expect(!APIToken.matches(String(repeating: "a", count: 64), String(repeating: "b", count: 64)))
+    }
+
+    @Test func aPrefixIsNotEnough() {
+        let token = APIToken.generate()
+        #expect(!APIToken.matches(String(token.dropLast()), token))
+    }
+
+    @Test func emptyMatchesNothingIncludingItself() {
+        #expect(!APIToken.matches("", ""))
+    }
+
+    @Test func generatedTokensAreLongAndDistinct() {
+        let tokens = Set((0..<32).map { _ in APIToken.generate() })
+        #expect(tokens.count == 32)
+        #expect(tokens.allSatisfy { $0.count == 64 })
+    }
+}
+
+struct APITokenRejectionTests {
+
+    private let token = "5f1e" + String(repeating: "0", count: 60)
+
+    private func request(_ path: String, headers: [String: String] = [:]) -> HTTPRequest {
+        HTTPRequest(method: "POST", path: path, headers: headers, body: [:])
+    }
+
+    @Test func theRightTokenIsLetThrough() {
+        let r = request("/shot/capture", headers: [APIToken.headerName: token])
+        #expect(APIToken.rejection(for: r, token: token) == nil)
+    }
+
+    @Test func aRequestWithoutOneIsRefused() {
+        #expect(APIToken.rejection(for: request("/shot/capture"), token: token) != nil)
+    }
+
+    @Test func aWrongTokenIsRefused() {
+        let r = request("/shot/capture", headers: [APIToken.headerName: String(repeating: "0", count: 64)])
+        #expect(APIToken.rejection(for: r, token: token) != nil)
+    }
+
+    /// The screenshot routes are the reason the gate exists: they lend out
+    /// Screen Recording, which the caller may well not hold itself.
+    @Test func capturingAndReadingTheScreenAreBothGated() {
+        for path in ["/shot/capture", "/shot/text", "/state"] {
+            #expect(APIToken.rejection(for: request(path), token: token) != nil,
+                    Comment(rawValue: path))
+        }
+    }
+
+    @Test func pingStaysOpenSoAClosedAppIsTellableFromAStaleToken() {
+        #expect(APIToken.rejection(for: request("/ping"), token: token) == nil)
+    }
+
+    /// Without a token the app says so in its own window rather than refusing
+    /// every request, which would look like a broken MCP server.
+    @Test func anAppWithoutATokenGatesNothing() {
+        #expect(APIToken.rejection(for: request("/shot/capture"), token: nil) == nil)
+    }
+
+    @Test func theHeaderSurvivesRequestParsing() throws {
+        let raw = "POST /state HTTP/1.1\r\nX-Plonk-Token: \(token)\r\n\r\n"
+        let parsed = try #require(ControlServer.parseIfComplete(Data(raw.utf8)))
+        #expect(APIToken.rejection(for: parsed, token: token) == nil)
+    }
+}

--- a/App/Tests/plonkTests/RouterTests.swift
+++ b/App/Tests/plonkTests/RouterTests.swift
@@ -265,11 +265,21 @@ struct RouterTests {
         #expect(h.post("/agents/hello", [:]).status == 400)
     }
 
-    @Test func anyRequestWithTheAgentHeaderRegistersIt() {
+    @Test func anyTokenedRequestWithTheAgentHeaderRegistersIt() {
         let h = Harness()
-        _ = h.send(HTTPRequest(method: "GET", path: "/ping",
+        _ = h.send(HTTPRequest(method: "GET", path: "/state",
                                headers: ["x-plonk-agent": "openai-test-agent/0.1"], body: [:]))
         #expect(h.router.agents.onlineNames() == ["openai-test-agent"])
+    }
+
+    /// `/ping` answers without a token, so it must not be able to write to the
+    /// registry: otherwise anything on the machine can invent agents that show
+    /// up in the menu bar selector and in `/state`, and the list only grows.
+    @Test func pingCannotInventAnAgent() {
+        let h = Harness()
+        _ = h.send(HTTPRequest(method: "GET", path: "/ping",
+                               headers: ["x-plonk-agent": "not-an-agent/0.1"], body: [:]))
+        #expect(h.router.agents.onlineNames().isEmpty)
     }
 
     @Test func selectStoresAndClearsTheChoice() {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,16 @@ Use the bug template. The three things that decide whether a window bug is
 reproducible are the macOS version, the monitor arrangement, and which app owned
 the window, so the template asks for all three.
 
-`curl -s 127.0.0.1:43917/state` is often the fastest way to show what your desk
-looked like. It lists the title of every open window, so read it before you paste
-it.
+The fastest way to show what your desk looked like is the state route. It is
+gated on the API token like everything else, so pass it:
+
+```sh
+curl -s -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
+  127.0.0.1:43917/state
+```
+
+It lists the title of every open window, so read it before you paste it. `plonk
+state` prints the same thing and finds the token for you.
 
 ## Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,13 @@ on first clone. It is not: the certificate is needed only to produce and launch
 are exactly what CI runs:
 
 ```sh
-cd App && swift build                        # the app compiles
+(cd App && swift build)                      # the app compiles
 ./scripts/test.sh                            # the unit suite
-cd mcp && npm ci && npm run typecheck        # the MCP server
+(cd mcp && npm ci && npm run typecheck)      # the MCP server
 ```
+
+Each line is a subshell, so all three run from the repository root as written —
+paste the block and it works.
 
 Zone geometry, config decoding, HTTP routing, MCP tools, voice command parsing,
 the CLI and every document in the repo are all reachable from that loop, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing
+
+Bug reports, zone sets, client one-pagers and code are all welcome. This page is
+the short version; [AGENTS.md](AGENTS.md) is the long one and is worth reading
+before you write anything, even though it is addressed to agents. It has the
+repo layout, the five places a new module touches, which coordinate space each
+number is in, and the mistakes that have already cost someone an hour.
+
+## You do not need a signing certificate
+
+`scripts/build.sh` refuses to run without one, which makes the repo look closed
+on first clone. It is not: the certificate is needed only to produce and launch
+`Plonk.app`. Everything else works on a plain checkout, and these three commands
+are exactly what CI runs:
+
+```sh
+cd App && swift build                        # the app compiles
+./scripts/test.sh                            # the unit suite
+cd mcp && npm ci && npm run typecheck        # the MCP server
+```
+
+Zone geometry, config decoding, HTTP routing, MCP tools, voice command parsing,
+the CLI and every document in the repo are all reachable from that loop, and
+most changes never need more.
+
+To actually run the app, make your own certificate once:
+
+```sh
+./scripts/make-signing-cert.sh   # creates one and prints how to trust it
+./scripts/build.sh               # produces Plonk.app
+open Plonk.app
+```
+
+That certificate is yours, not the one releases are signed with, so a local
+build will not auto-update and macOS asks for Accessibility and Screen Recording
+again the first time it runs. Both are expected. Do not work around `build.sh`
+by ad-hoc signing: macOS pins those two permissions to the code signature, an
+ad-hoc signature is a different one every build, and the result is a bundle that
+looks built and then silently cannot move a window.
+
+## Places to start
+
+- **A one-pager for an MCP client.** `docs/clients/` has Cursor, Zed and Cline.
+  Any client that can run a stdio server works; the page is the missing part.
+- **A zone set.** If you have drawn a layout you keep going back to, post it
+  under Show and tell. Good ones end up shipping as built-ins.
+- **A voice command.** `VoiceCommands.swift` maps spoken phrases to actions
+  that run in the app, with no agent and no network. Adding a phrase is a small
+  change with a unit test next to it in `VoiceCommandTests.swift`.
+- **A bug with a reproduction.** Window managers break on hardware nobody else
+  has: unusual monitor arrangements, mixed scale factors, apps that fight back.
+  A report that says which is often worth more than a patch.
+- **A new module.** The seam is described under "Adding a module" in AGENTS.md.
+  Open an issue first so two people do not build the same thing.
+
+## Sending a change
+
+- Branch off `main`. Nothing is pushed to `main` directly, including by the
+  maintainer.
+- Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`.
+  Imperative subject under 72 characters, body only when the why is not obvious.
+- One logical change per commit, and `swift build` passes on every one of them.
+- Put new logic somewhere testable. `ZoneGeometry`, `Config`, `ImageFit`,
+  `Router` and `ControlServer.parseIfComplete` exist to be reachable without a
+  desktop session; cover what you add in `App/Tests/plonkTests/`.
+- A pull request says what changed, why, and which commands you ran.
+  Screenshots for anything visual.
+- Match the surrounding code. Swift API design guidelines, comments only for
+  constraints that are not obvious from the code, no emoji anywhere including
+  user-facing strings, and user-facing text in English.
+
+If a change touches the network, the permissions, the entitlements or the update
+path, it makes a claim in `README.md` or `SECURITY.md` false. Fix the document
+in the same commit. Those claims are meant to be checkable from a terminal, and
+that is the only reason they are worth anything.
+
+## Reporting a bug
+
+Use the bug template. The three things that decide whether a window bug is
+reproducible are the macOS version, the monitor arrangement, and which app owned
+the window, so the template asks for all three.
+
+`curl -s 127.0.0.1:43917/state` is often the fastest way to show what your desk
+looked like. It lists the title of every open window, so read it before you paste
+it.
+
+## Security
+
+Do not open a normal issue for something exploitable. `SECURITY.md` has the
+reporting route, and the same page describes the boundaries the app is supposed
+to hold, which is the useful thing to check a finding against.
+
+## What this project will not take
+
+Some directions are settled, and a pull request in them will be declined however
+good it is:
+
+- Accounts, cloud sync, telemetry, analytics or crash reporting.
+- Third-party Swift dependencies in `App/`.
+- Any outbound connection other than the existing update check.
+- CORS headers on the local API, or binding it to anything but loopback.
+
+`ROADMAP.md` has the rest, including the features that were considered and
+deliberately left out.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ Several clients at once is fine; see [Agents](#for-agents) below.
 A client that cannot spawn a process connects over HTTP instead:
 `npx -y plonk-mcp --http` serves Streamable HTTP at
 `http://127.0.0.1:43918/mcp` (loopback only, many clients per process,
-`--port` to change).
+`--port` to change). That port asks for the same token the app does, so give
+the client an `X-Plonk-Token` header holding the contents of
+`~/Library/Application Support/Plonk/token` — otherwise the transport would be
+a way around the gate rather than through it.
 
 Or build everything from source: clone the repo, run `./scripts/build.sh`, and
 point `claude mcp add plonk -- node …/mcp/dist/server.js` at a locally built

--- a/README.md
+++ b/README.md
@@ -304,14 +304,35 @@ that only ever listens. The URLs compiled into the app are that endpoint, the
 releases page, and the issue tracker that opens when you click Report a bug —
 [Release.swift](App/Sources/plonk/Release.swift) has all three.
 
-**A web page cannot drive it.** The API is loopback-only and unauthenticated, so
-it refuses anything carrying headers a browser cannot suppress:
+**A web page cannot drive it.** The API is loopback-only, so it refuses anything
+carrying headers a browser cannot suppress:
 
 ```sh
 curl -so /dev/null -w '%{http_code}\n' -H 'Origin: https://example.com' \
   http://127.0.0.1:43917/state
 403
 ```
+
+**Neither can another program on your Mac.** Loopback keeps the network out and
+does nothing about the machine, so the API is gated on a token Plonk writes to
+`~/Library/Application Support/Plonk/token`, readable by you and nobody else.
+The MCP server and the `plonk` command read it for themselves; you never handle
+it. Without it, a request gets a 401:
+
+```sh
+curl -so /dev/null -w '%{http_code}\n' http://127.0.0.1:43917/state
+401
+curl -so /dev/null -w '%{http_code}\n' \
+  -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
+  http://127.0.0.1:43917/state
+200
+```
+
+This matters most for the screenshot routes. Plonk holds Screen Recording; a
+script running as you may well not, and before the token it could borrow
+Plonk's by asking the port. Where it stops: anything that can read that file
+can read your screen by asking macOS itself, so this is a fence around the
+port, not around your account.
 
 **There is not much else to hide.** [Package.swift](App/Package.swift) declares
 no third-party dependencies, so a build from source is this repo and nothing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -190,13 +190,15 @@ token. It answers whether Plonk is running and nothing else.
 **Where this stops.** Anything that can read the token file is already running
 as you, and could ask macOS for the screen directly instead of going through
 Plonk. The token means reaching the port is no longer enough; it is not a
-boundary against code that is already you. Two limits worth naming:
+boundary against code that is already you. One limit worth naming:
 
-- `plonk-mcp --http` holds the token and serves MCP on `127.0.0.1:43918`
-  without one of its own, so while you run that transport a local process can
-  drive Plonk through it. The stdio transport the install instructions set up
-  opens no such port.
 - The token is a file, not a keychain item. Anything running as you reads it.
+
+`plonk-mcp --http` holds that token, so it asks its own callers for it too:
+`127.0.0.1:43918` refuses anything without the same `X-Plonk-Token` header, and
+answers nothing at all when the file cannot be read. Otherwise running that
+transport would have handed every local process the gate it had just been
+given. The stdio transport the install instructions set up opens no port.
 
 If something hostile is already running locally with your privileges, Plonk is
 not the weakest thing it has access to. The token is there so it is not the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -164,6 +164,13 @@ curl -so /dev/null -w '%{http_code}\n' -H 'Origin: https://example.com' \
   `~/Library/Application Support/Plonk/token` with mode `600`. The MCP server
   and the `plonk` command read it themselves; you never handle it.
 
+- If that file is not usable as a secret — owned by another user, not a plain
+  file, or it will not stay readable by you alone — Plonk writes no token and
+  answers nothing but `/ping`, with a `503` saying which file to look at. It
+  fails closed on purpose: an app that cannot hold a secret is still holding
+  Screen Recording, so the alternative would be handing that grant to anything
+  on the machine that can open a socket. The Home page says so too.
+
 ```sh
 curl -so /dev/null -w '%{http_code}\n' http://127.0.0.1:43917/state
 401

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -147,8 +147,8 @@ Anything that fails a step is discarded and nothing is replaced.
 
 ## The local API
 
-The HTTP API on `127.0.0.1:43917` is unauthenticated, because it is how an agent
-on your own machine drives the app. Two things keep that from being a hole:
+The HTTP API on `127.0.0.1:43917` is how an agent on your own machine drives the
+app. Three things stand in front of it:
 
 - It binds to loopback. Nothing off the machine can reach it.
 - It refuses any request carrying headers a browser cannot suppress, so an open
@@ -160,10 +160,40 @@ curl -so /dev/null -w '%{http_code}\n' -H 'Origin: https://example.com' \
 403
 ```
 
-What this does **not** protect against: any other program already running as
-your user can talk to that port. If something hostile is running locally with
-your privileges, Plonk is not the weakest thing it has access to — but it is
-fair to know the API is there.
+- Everything except `/ping` needs a token, written on first launch to
+  `~/Library/Application Support/Plonk/token` with mode `600`. The MCP server
+  and the `plonk` command read it themselves; you never handle it.
+
+```sh
+curl -so /dev/null -w '%{http_code}\n' http://127.0.0.1:43917/state
+401
+```
+
+Why a token, when the port was already unreachable from outside: Plonk holds
+Screen Recording, and `/shot/capture` and `/shot/text` turn that grant into a
+service. A local script with no Screen Recording of its own could take a
+silent, full-screen capture, or read the words off your screen, by asking the
+port. macOS hands that permission out one app at a time, and an open port
+handed Plonk's to anything running as you. `/state` was the same shape more
+quietly: it lists the title of every open window.
+
+`/ping` stays open on purpose, so a client can tell a closed app from a stale
+token. It answers whether Plonk is running and nothing else.
+
+**Where this stops.** Anything that can read the token file is already running
+as you, and could ask macOS for the screen directly instead of going through
+Plonk. The token means reaching the port is no longer enough; it is not a
+boundary against code that is already you. Two limits worth naming:
+
+- `plonk-mcp --http` holds the token and serves MCP on `127.0.0.1:43918`
+  without one of its own, so while you run that transport a local process can
+  drive Plonk through it. The stdio transport the install instructions set up
+  opens no such port.
+- The token is a file, not a keychain item. Anything running as you reads it.
+
+If something hostile is already running locally with your privileges, Plonk is
+not the weakest thing it has access to. The token is there so it is not the
+easiest, either.
 
 Optional strict mode narrows it further: only the agent you have made active can
 change anything, and everyone else gets a 409 on any call that moves a window or

--- a/docs/index.html
+++ b/docs/index.html
@@ -292,9 +292,14 @@ plonk … TCP 127.0.0.1:43917 (LISTEN)</pre>
 curl -so /dev/null -w '%{http_code}\n' \
   -H 'Origin: https://example.com' \
   http://127.0.0.1:43917/state
-403</pre>
-        <p class="dim" style="font-size:14.5px">No account, no cloud, no analytics, no crash reporter.
-          Config is plain JSON in your Application Support folder.
+403
+<span class="c"># and nor can another program on your Mac</span>
+curl -so /dev/null -w '%{http_code}\n' \
+  http://127.0.0.1:43917/state
+401</pre>
+        <p class="dim" style="font-size:14.5px">The API is gated on a token only you can read, so a
+          script cannot borrow Plonk's Screen Recording by asking the port. No account, no cloud, no
+          analytics, no crash reporter.
           <a href="https://github.com/ostapondo/plonk/blob/main/SECURITY.md">SECURITY.md →</a></p>
       </div>
     </div>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -40,7 +40,10 @@ server. One-pagers for
 
 A client that cannot spawn a process connects over HTTP instead:
 `npx -y plonk-mcp --http` serves Streamable HTTP at
-`http://127.0.0.1:43918/mcp` (loopback only, `--port` to change).
+`http://127.0.0.1:43918/mcp` (loopback only, `--port` to change). Requests to
+it carry the same token as the app's own API — send the contents of
+`~/Library/Application Support/Plonk/token` as an `X-Plonk-Token` header. The
+stdio transport reads that file itself and needs no configuration.
 
 Several clients may be connected at once. Set `PLONK_AGENT_NAME` in a client's
 config to tell two sessions of the same client apart.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -70,5 +70,10 @@ The server talks to the app over loopback HTTP on `127.0.0.1:43917` and nowhere
 else. No account, no cloud, no telemetry. It depends only on the official MCP
 SDK and zod.
 
+The app gates that API on a token it writes to
+`~/Library/Application Support/Plonk/token`. This server reads the file itself,
+so there is nothing to configure — but it does have to run as the same user
+Plonk is running as.
+
 MIT. Source, screenshots and the rest of the documentation are in the
 [repository](https://github.com/ostapondo/plonk).

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -176,6 +176,46 @@ function agentHeaders(): Record<string, string> {
   };
 }
 
+// The app gates its API on a secret it writes to a file only this user can
+// read, because binding to loopback keeps the network out and does nothing
+// about the machine. Reading it is the whole handshake: anything that can read
+// the file could ask macOS for the screen directly.
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const TOKEN_PATH = join(homedir(), "Library", "Application Support", "Plonk", "token");
+
+let cachedToken: string | undefined;
+
+/** Only a successful read is cached: a client started before the app has ever
+ * run would otherwise never see the token the app writes on first launch. */
+function apiToken(): string | undefined {
+  if (cachedToken) return cachedToken;
+  try {
+    const token = readFileSync(TOKEN_PATH, "utf8").trim();
+    if (token) cachedToken = token;
+  } catch {
+    // No app yet, or a file this user cannot read. The request goes without a
+    // token and the app's own 401 explains it better than a guess here would.
+  }
+  return cachedToken;
+}
+
+function tokenHeader(): Record<string, string> {
+  const token = apiToken();
+  return token ? { "x-plonk-token": token } : {};
+}
+
+/** Drops the cached token and reads again, true only when a different one
+ * turned up — the one case where repeating a refused request can help. */
+function refreshToken(): boolean {
+  const stale = cachedToken;
+  cachedToken = undefined;
+  const fresh = apiToken();
+  return fresh !== undefined && fresh !== stale;
+}
+
 export interface CallOptions {
   method?: "GET" | "POST";
   body?: unknown;
@@ -190,14 +230,20 @@ export async function call<T extends object = ApiResponse>(
   const { method = "GET", body, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
   const timeout = AbortSignal.timeout(timeoutMs);
 
-  let res: Response;
-  try {
-    res = await fetch(BASE + path, {
+  const send = () =>
+    fetch(BASE + path, {
       method,
-      headers: { "content-type": "application/json", ...agentHeaders() },
+      headers: { "content-type": "application/json", ...agentHeaders(), ...tokenHeader() },
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: timeout,
     });
+
+  let res: Response;
+  try {
+    res = await send();
+    // A long-lived client outlives the token if the file is ever replaced.
+    // One re-read makes that a hiccup instead of a session to restart.
+    if (res.status === 401 && refreshToken()) res = await send();
   } catch (err) {
     if (timeout.aborted) {
       return { error: `Plonk did not answer within ${timeoutMs / 1000}s. It may be waiting on a dialog.` };

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -202,6 +202,12 @@ function apiToken(): string | undefined {
   return cachedToken;
 }
 
+/** The token as the HTTP transport needs it: to demand of its own callers what
+ * the app demands of this process. Undefined when there is no readable file. */
+export function localApiToken(): string | undefined {
+  return apiToken();
+}
+
 function tokenHeader(): Record<string, string> {
   const token = apiToken();
   return token ? { "x-plonk-token": token } : {};

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -208,18 +208,19 @@ export function localApiToken(): string | undefined {
   return apiToken();
 }
 
-function tokenHeader(): Record<string, string> {
-  const token = apiToken();
-  return token ? { "x-plonk-token": token } : {};
-}
-
-/** Drops the cached token and reads again, true only when a different one
- * turned up — the one case where repeating a refused request can help. */
-function refreshToken(): boolean {
-  const stale = cachedToken;
+/** Drops the cache and reads again, true only when the file now holds
+ * something other than what this request actually sent — the one case where
+ * repeating a refused request can help.
+ *
+ * `sent` rather than the cache, because the cache is shared: the hello
+ * heartbeat and the inbox long-poll are always in flight beside a tool call,
+ * so after a rotation the first 401 refreshes the cache and every other
+ * request in the air would find it already fresh and give up, handing the
+ * model a token error for a token that had just been fixed. */
+function refreshToken(sent: string | undefined): boolean {
   cachedToken = undefined;
   const fresh = apiToken();
-  return fresh !== undefined && fresh !== stale;
+  return fresh !== undefined && fresh !== sent;
 }
 
 export interface CallOptions {
@@ -236,20 +237,29 @@ export async function call<T extends object = ApiResponse>(
   const { method = "GET", body, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
   const timeout = AbortSignal.timeout(timeoutMs);
 
-  const send = () =>
-    fetch(BASE + path, {
+  // Captured per attempt, so the retry can tell "the token changed" from
+  // "somebody else refreshed the cache while this request was in the air".
+  let sent: string | undefined;
+  const send = () => {
+    sent = apiToken();
+    return fetch(BASE + path, {
       method,
-      headers: { "content-type": "application/json", ...agentHeaders(), ...tokenHeader() },
+      headers: {
+        "content-type": "application/json",
+        ...agentHeaders(),
+        ...(sent ? { "x-plonk-token": sent } : {}),
+      },
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: timeout,
     });
+  };
 
   let res: Response;
   try {
     res = await send();
     // A long-lived client outlives the token if the file is ever replaced.
     // One re-read makes that a hiccup instead of a session to restart.
-    if (res.status === 401 && refreshToken()) res = await send();
+    if (res.status === 401 && refreshToken(sent)) res = await send();
   } catch (err) {
     if (timeout.aborted) {
       return { error: `Plonk did not answer within ${timeoutMs / 1000}s. It may be waiting on a dialog.` };

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -188,24 +188,39 @@ const TOKEN_PATH = join(homedir(), "Library", "Application Support", "Plonk", "t
 
 let cachedToken: string | undefined;
 
+function readTokenFile(): string | undefined {
+  try {
+    return readFileSync(TOKEN_PATH, "utf8").trim() || undefined;
+  } catch {
+    // No app yet, or a file this user cannot read. The request goes without a
+    // token and the app's own 401 explains it better than a guess here would.
+    return undefined;
+  }
+}
+
 /** Only a successful read is cached: a client started before the app has ever
  * run would otherwise never see the token the app writes on first launch. */
 function apiToken(): string | undefined {
   if (cachedToken) return cachedToken;
-  try {
-    const token = readFileSync(TOKEN_PATH, "utf8").trim();
-    if (token) cachedToken = token;
-  } catch {
-    // No app yet, or a file this user cannot read. The request goes without a
-    // token and the app's own 401 explains it better than a guess here would.
-  }
+  cachedToken = readTokenFile();
   return cachedToken;
 }
 
-/** The token as the HTTP transport needs it: to demand of its own callers what
- * the app demands of this process. Undefined when there is no readable file. */
+/** The token the HTTP transport gates its own callers on, read from disk every
+ * time rather than from the cache above.
+ *
+ * A cache here would be a gate on a secret the app may already have replaced:
+ * it would keep accepting the token a restored backup leaked — the exact one
+ * the app rotated away from — and keep refusing the current one, until this
+ * process was restarted. Nothing else could fix it, because the retry that
+ * refreshes the cache lives on the far side of this check and never runs when
+ * no session gets in. It is one small read per request on a transport that
+ * handles few. */
 export function localApiToken(): string | undefined {
-  return apiToken();
+  const fresh = readTokenFile();
+  // Outgoing calls may as well learn about a rotation from the same read.
+  if (fresh !== undefined && fresh !== cachedToken) cachedToken = fresh;
+  return fresh;
 }
 
 /** Drops the cache and reads again, true only when the file now holds

--- a/mcp/src/http.ts
+++ b/mcp/src/http.ts
@@ -3,9 +3,9 @@
 // threat model as the app's own API: a web page must never be able to drive
 // the desktop, and a DNS-rebinding page must not reach the port by Host games.
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { runWithIdentity, type IdentityHolder } from "./api.js";
+import { localApiToken, runWithIdentity, type IdentityHolder } from "./api.js";
 import { createPlonkServer, startHello, startInboxLoop, watchClientInfo } from "./factory.js";
 
 interface Session {
@@ -18,6 +18,17 @@ interface Session {
 // The app's registry tells sessions apart by (name, pid). Every HTTP client
 // shares this process, so each session gets a synthetic pid instead.
 let syntheticPid = 100_000 + (process.pid % 1_000) * 100;
+
+function headerToken(req: IncomingMessage): string {
+  const value = req.headers["x-plonk-token"];
+  return (Array.isArray(value) ? value[0] : value) ?? "";
+}
+
+/** Length is not the secret; which byte differed would be. */
+function timingSafeEqualString(presented: string, token: string): boolean {
+  const a = Buffer.from(presented, "utf8"), b = Buffer.from(token, "utf8");
+  return a.length === b.length && a.length > 0 && timingSafeEqual(a, b);
+}
 
 function reject(res: ServerResponse, status: number, error: string): void {
   res.writeHead(status, { "content-type": "application/json" });
@@ -41,6 +52,20 @@ export async function serveHttp(port: number): Promise<void> {
     }
     if (new URL(req.url ?? "/", `http://${host}`).pathname !== "/mcp") {
       reject(res, 404, "the MCP endpoint is /mcp");
+      return;
+    }
+    // This process holds the app's token, so without a gate of its own it is a
+    // way around the app's: anything local could call take_screenshot through
+    // it and borrow Screen Recording. Same secret, same header, same file —
+    // there is nothing extra for a client to be given.
+    const token = localApiToken();
+    if (!token) {
+      reject(res, 503, "no Plonk API token could be read, so this transport is answering nothing");
+      return;
+    }
+    if (!timingSafeEqualString(headerToken(req), token)) {
+      reject(res, 401, "this request carried no valid token; send the contents of " +
+        "~/Library/Application Support/Plonk/token as the X-Plonk-Token header");
       return;
     }
 

--- a/scripts/screencast.sh
+++ b/scripts/screencast.sh
@@ -19,14 +19,29 @@ root=$(cd "$(dirname "$0")/.." && pwd)
 api=${PLONK_API:-http://127.0.0.1:43917}
 command=${1:-stage}
 
+# Every route but /ping is gated on the token Plonk writes on first launch.
+token_file=${PLONK_TOKEN_FILE:-$HOME/Library/Application Support/Plonk/token}
+token=$(cat "$token_file" 2>/dev/null || true)
+
+# -f so a 401 or a 503 is a failure and not a silent no-op: without it this
+# script cheerfully printed the run sheet for a desk it had never staged.
 post() {
-  curl -sS -X POST "$api$1" -H 'Content-Type: application/json' -d "$2" >/dev/null
+  curl -fsS -X POST "$api$1" -H 'Content-Type: application/json' \
+    -H "X-Plonk-Token: $token" -d "$2" >/dev/null || {
+    echo "screencast: $1 was refused. Is Plonk running, and is $token_file readable?"
+    exit 1
+  }
 }
 
 require_app() {
   curl -sS -m 2 "$api/ping" >/dev/null 2>&1 || {
     echo "screencast: Plonk is not running (no answer on $api)."
     echo "            Open Plonk.app, grant Accessibility, and try again."
+    exit 1
+  }
+  [ -n "$token" ] || {
+    echo "screencast: no API token at $token_file."
+    echo "            Launch Plonk once to have it written, then try again."
     exit 1
   }
 }


### PR DESCRIPTION
Two things: the loopback API stops answering anything that has not read a file in this user's home directory, and the repository gains the documents a first contributor needs.

## The token

Binding to `127.0.0.1` keeps the network out. It does nothing about the machine itself — every process running as you can reach the port, and Plonk holds Screen Recording, so an unauthenticated `/shot/capture` handed a caller with no such grant a picture of the screen. That permission was the thing being lent out, not the window layout.

Now every route but `/ping` needs the token Plonk writes to `~/Library/Application Support/Plonk/token` at mode 0600. The MCP server and the `plonk` command read it themselves, so nothing has to be configured; `/ping` stays open so a client can tell a closed app from a stale token, and it answers nothing else.

Decisions worth naming, because each one costs something:

- **It fails closed.** No usable token means `503` on everything but `/ping`, with the path to look at in the body. The cost is an agent that goes quiet until a permissions problem is fixed. The alternative was a screenshot for anything on the machine that can open a socket.
- **A file that arrives readable by others is replaced, not repaired.** Tightening a restored backup fixes the permissions and does nothing about a secret that has already sat there in the open.
- **`plonk-mcp --http` demands the same token from its own callers**, read from disk on every request. It holds the app's token, so without a gate of its own it was a way around the gate rather than through it — and a cached gate would keep honouring a token the app had already rotated away from. Clients on that transport now need an `X-Plonk-Token` header; README, mcp/README and SECURITY.md say so.
- **`/ping` no longer registers agents.** It answers without a token, so it could otherwise be used to invent agents that show up in the menu bar selector and in `/state`.

The file is created with `open(2)` and `O_CREAT|O_EXCL|O_NOFOLLOW`, not `FileManager`, which applies permissions after writing: a stat loop caught a new token at mode 0644 with the secret already inside, three times in four thousand samples.

## The documents

CONTRIBUTING, a code of conduct, issue forms and discussion templates — the parts of a repository that decide whether somebody who is not me can get from a clone to a first change, and whether a bug report arrives with what it needs.

## Checking it

```sh
curl -so /dev/null -w '%{http_code}\n' http://127.0.0.1:43917/state          # 401
curl -so /dev/null -w '%{http_code}\n' \
  -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
  http://127.0.0.1:43917/state                                               # 200
```

306 unit tests, most of the new ones about what the gate must refuse: a symlink at the token path, a file owned by another user, a token file that will not stay private, `/ping?t=1`, and an app with no token at all.

Four review passes went over this branch; the last one turned up the stale-cache hole in `--http` described above.