### PR TITLE
The door was unlocked and nothing said so

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+CONTRIBUTING.md has the long version. Delete any line that does not apply.
+-->
+
+## What changed, and why
+
+<!-- One paragraph. The why matters more than the what; the diff has the what. -->
+
+## What you ran
+
+<!--
+The loop CI runs, from the repository root. Paste the ones you ran:
+
+  (cd App && swift build)
+  ./scripts/test.sh
+  (cd mcp && npm ci && npm run typecheck)
+
+None of them need a signing certificate. Say so if you also built and launched
+Plonk.app, and on which macOS version and monitor arrangement.
+-->
+
+## Checks
+
+- [ ] `swift build` passes on every commit in the branch, not just the last one
+- [ ] New logic is covered in `App/Tests/plonkTests/`, or it is not the kind that can be
+- [ ] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
+- [ ] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — fixed in this PR if not
+- [ ] Screenshots below for anything visual

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,13 +36,19 @@ when a display is unplugged.
 
 ## Build & verify
 
+Each line is a subshell, so the block runs as written from the repository root:
+
 ```sh
-cd App && swift build          # must pass before any commit
-./scripts/test.sh              # unit tests — must pass
-cd mcp && npm run typecheck    # must pass when mcp/ changed
-./scripts/build.sh             # produces Plonk.app
-curl -s 127.0.0.1:43917/ping   # smoke test while the app is running
+(cd App && swift build)          # must pass before any commit
+./scripts/test.sh                # unit tests — must pass
+(cd mcp && npm run typecheck)    # must pass when mcp/ changed
+./scripts/build.sh               # produces Plonk.app; needs a signing identity
+curl -s 127.0.0.1:43917/ping     # smoke test while the app is running
 ```
+
+The first three need no signing certificate. `build.sh` does, and refuses
+rather than produce a bundle that cannot hold its permissions; see
+[CONTRIBUTING.md](CONTRIBUTING.md) for why and how to make one.
 
 The release number lives in `version.env`, and only there. `scripts/build.sh`
 reads `MARKETING_VERSION` and `BUILD_NUMBER` into `Info.plist`. Bump them to cut

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+For this project, community spaces are the issue tracker, pull requests,
+Discussions, and any private channel opened to continue one of them.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at the email address on
+[ostapondo](https://github.com/ostapondo)'s GitHub profile — the same route
+[SECURITY.md](SECURITY.md) uses for anything that should not be posted in
+public. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla]: https://github.com/mozilla/inclusion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,13 @@
 
 Bug reports, zone sets, client one-pagers and code are all welcome. This page is
 the short version; [AGENTS.md](AGENTS.md) is the long one and is worth reading
-before you write anything, even though it is addressed to agents. It has the
-repo layout, the five places a new module touches, which coordinate space each
-number is in, and the mistakes that have already cost someone an hour.
+before you write anything. It is phrased as instructions to an agent because
+that is what most often reads it, but it is the engineering guide either way:
+the repo layout, the five places a new module touches, which coordinate space
+each number is in, and the mistakes that have already cost someone an hour.
+
+Everyone taking part is expected to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## You do not need a signing certificate
 
@@ -62,6 +66,10 @@ looks built and then silently cannot move a window.
   maintainer.
 - Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`.
   Imperative subject under 72 characters, body only when the why is not obvious.
+  The rule is about the commits on your branch. A pull request with more than
+  one of them is squashed under the pull request title, which is written as a
+  sentence — that is why `git log` on `main` has subjects with no prefix, and
+  not a sign the rule lapsed.
 - One logical change per commit, and `swift build` passes on every one of them.
 - Put new logic somewhere testable. `ZoneGeometry`, `Config`, `ImageFit`,
   `Router` and `ControlServer.parseIfComplete` exist to be reachable without a

--- a/README.md
+++ b/README.md
@@ -364,15 +364,30 @@ stops being one.
 
 ## Build
 
+Three commands, and they are exactly what CI runs on every pull request. Each
+line is a subshell, so paste the block from the repository root and it works:
+
 ```sh
-cd App && swift build     # the app
-./scripts/test.sh         # 283 unit tests
-./scripts/build.sh        # produces Plonk.app
-cd mcp && npm run build   # the MCP server
+(cd App && swift build)                    # the app compiles
+./scripts/test.sh                          # 306 unit tests
+(cd mcp && npm ci && npm run typecheck)    # the MCP server
 ```
 
+None of that needs a signing certificate. Zone geometry, config decoding, HTTP
+routing, MCP tools, voice command parsing, the CLI and every document here are
+reachable from that loop, and most changes never need more.
+
 `App/` is the Swift menu bar app, `mcp/` the TypeScript MCP server. Point an
-agent at [AGENTS.md](AGENTS.md) before it touches either.
+agent at [AGENTS.md](AGENTS.md) before it touches either, and read
+[CONTRIBUTING.md](CONTRIBUTING.md) before you send a change.
+
+Producing a launchable `Plonk.app` is the one step that does need a certificate.
+Make your own once:
+
+```sh
+./scripts/make-signing-cert.sh   # creates one and prints how to trust it
+./scripts/build.sh               # produces Plonk.app
+```
 
 `build.sh` signs with a `Plonk Signing` identity and stops if it is missing.
 macOS ties Accessibility and Screen Recording to the signature, and an ad-hoc
@@ -411,6 +426,26 @@ with anything else cannot be updated to and takes Accessibility and Screen
 Recording away from everyone who installs it by hand. It notarizes when a
 Developer ID certificate is in the keychain and says so when there is not;
 Plonk's releases are not notarized, which costs a paid Apple account.
+
+## Contributing
+
+Bug reports, zone sets, client one-pagers and code are all welcome, and none of
+them need a signing certificate — the loop above is the whole requirement.
+[CONTRIBUTING.md](CONTRIBUTING.md) has the rest: what a window bug report has to
+carry to be reproducible, where a new module seams in, and the handful of
+directions this project will not take, so nobody writes a patch that was never
+going to land.
+
+The issues tagged [good first issue][gfi] are written to be picked up cold —
+each one says where the code is and how to tell it worked. Questions,
+half-formed ideas and layouts worth showing off go to
+[Discussions](https://github.com/ostapondo/plonk/discussions); a security
+problem goes through [SECURITY.md](SECURITY.md) instead of a public issue.
+
+Everyone taking part is expected to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+[gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 
 ## License
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,6 +107,7 @@
   section:first-of-type { border-top: 0; }
   h2 { font-size: clamp(24px, 3.4vw, 31px); letter-spacing: -.018em; margin: 0 0 10px; }
   h2 + p.sub { color: var(--dim); margin: 0 0 26px; max-width: 640px; }
+  p.note { color: var(--dim); font-size: 14.5px; margin: 22px 0 0; max-width: 640px; }
 
   .cards { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
   .card {
@@ -315,6 +316,12 @@ curl -so /dev/null -w '%{http_code}\n' \
       </div>
       <a class="ghost" href="https://github.com/ostapondo/plonk">Star it on GitHub</a>
     </div>
+    <p class="note">Or help build it. It compiles and tests on a plain checkout
+      with no signing certificate and no account —
+      <a href="https://github.com/ostapondo/plonk/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>
+      is three commands long, and the
+      <a href="https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">good first issues</a>
+      each say where the code is and how to tell it worked.</p>
   </section>
 
 </div>
@@ -325,6 +332,7 @@ curl -so /dev/null -w '%{http_code}\n' \
     <nav>
       <a href="https://github.com/ostapondo/plonk">Source</a>
       <a href="https://github.com/ostapondo/plonk/issues">Issues</a>
+      <a href="https://github.com/ostapondo/plonk/blob/main/CONTRIBUTING.md">Contributing</a>
       <a href="https://github.com/ostapondo/plonk/blob/main/ROADMAP.md">Roadmap</a>
       <a href="https://www.npmjs.com/package/plonk-mcp">plonk-mcp on npm</a>
     </nav>


### PR DESCRIPTION
Closes #22.

A second agent read this repository and concluded it was not open to
contributors. That conclusion was wrong but it was earned: PR #24 added
CONTRIBUTING.md, twelve labelled issues and a token, and then nothing linked to
any of it. The word "contributing" did not appear in README.md once, and the
site footer listed Source, Issues, Roadmap and npm.

So the reachable path was: read the README, hit `./scripts/build.sh` in the
Build section, watch it exit because there is no `Plonk Signing` identity in the
keychain, and leave. The page written to answer exactly that objection —
CONTRIBUTING.md, whose first heading is "You do not need a signing certificate"
— was only findable by someone who had already gotten past it.

## What changed

- **README.md** — the Build section leads with the three commands CI runs and
  says they need no certificate; `build.sh` moves below with the one-time
  `make-signing-cert.sh` next to it. A new Contributing section before the
  licence links CONTRIBUTING.md, the `good first issue` query, Discussions and
  SECURITY.md.
- **docs/index.html** — Contributing in the footer, and a line under "Put it on
  your Mac" saying it builds on a plain checkout with no certificate and no
  account. The GitHub Pages site is the repository's homepage URL and had no
  route in at all.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1. GitHub's community
  checklist reported this one missing; enforcement points at the same private
  route SECURITY.md uses, as there is no public address to give.
- **.github/pull_request_template.md** — CONTRIBUTING asks a PR to say what
  changed, why and which commands were run, and nothing carried that over.
- **CONTRIBUTING.md** — records that a multi-commit PR is squashed under the PR
  title, so `git log` on `main` showing subjects with no `feat:`/`fix:` prefix
  is the merge strategy and not the rule lapsing. Reframes the AGENTS.md
  pointer as the engineering guide rather than a document for agents.

## Two things that were broken rather than missing

`cd App && swift build` followed by `./scripts/test.sh` leaves the shell in
`App/`, where neither that script nor `mcp/` exists — the blocks in README.md
and AGENTS.md could not be pasted as printed. CONTRIBUTING.md already used
subshells; the other two now match.

The suite is 306 tests, not the 283 the README claimed. That README stakes its
credibility on claims being checkable from a terminal, so a number that is not
costs more than it looks.

## What I ran

```sh
(cd App && swift build)                    # Build complete
./scripts/test.sh                          # 306 tests in 37 suites, passed
(cd mcp && npm ci && npm run typecheck)    # exit 0
```

Documentation only — no source file changed. I also confirmed the three
Discussions categories the issue-template contact links point at (`q-a`,
`ideas`, `show-and-tell`) exist, and parsed `docs/index.html` after the edit.

## Not in this PR

`main` has no branch protection and no rulesets, while CONTRIBUTING.md says
"Nothing is pushed to `main` directly, including by the maintainer".
`delete_branch_on_merge` is also off. Both are repository settings rather than
files, and they change how you push, so they are yours to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)