### PR TITLE
The smallest thing anyone can send is one JSON file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,15 @@ jobs:
         working-directory: mcp
       - run: npm run typecheck
         working-directory: mcp
+
+  # Deliberately the cheapest job in the file: a pull request that adds one
+  # layout to zone-sets/ gets an answer in seconds, on a runner that is not
+  # queueing behind a Swift build it did not touch.
+  zone-sets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - run: node scripts/check-zone-sets.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,14 @@ Everyone taking part is expected to follow the
 
 `scripts/build.sh` refuses to run without one, which makes the repo look closed
 on first clone. It is not: the certificate is needed only to produce and launch
-`Plonk.app`. Everything else works on a plain checkout, and these three commands
+`Plonk.app`. Everything else works on a plain checkout, and these four commands
 are exactly what CI runs:
 
 ```sh
 (cd App && swift build)                      # the app compiles
 ./scripts/test.sh                            # the unit suite
 (cd mcp && npm ci && npm run typecheck)      # the MCP server
+node scripts/check-zone-sets.mjs             # the layouts in zone-sets/
 ```
 
 Each line is a subshell, so all three run from the repository root as written —
@@ -47,18 +48,48 @@ looks built and then silently cannot move a window.
 
 ## Places to start
 
+Roughly in order of how much of the repo you have to hold in your head. The
+first two need no Swift at all, and the third needs no Swift on your machine.
+
+- **A zone set.** One JSON file in [`zone-sets/`](zone-sets/), which is a
+  gallery of layouts people keep going back to. Draw it in the app, read the
+  numbers back out of `plonk state --json`, drop them in a file. CI for that
+  folder is its own job and answers in about twenty seconds. Good ones end up
+  shipping as built-ins. [`zone-sets/README.md`](zone-sets/README.md) has the
+  format and the rules.
 - **A one-pager for an MCP client.** `docs/clients/` has Cursor, Zed and Cline.
   Any client that can run a stdio server works; the page is the missing part.
-- **A zone set.** If you have drawn a layout you keep going back to, post it
-  under Show and tell. Good ones end up shipping as built-ins.
+  If you use a client that is not there, you already know the one thing this
+  repo does not.
+- **Something in `mcp/`.** The MCP server and the `plonk` CLI are TypeScript, a
+  thin proxy over the app's HTTP API, and they typecheck on any machine — Linux
+  included, without a Mac in sight. `npm ci && npm run typecheck` in `mcp/` is
+  the whole loop.
 - **A voice command.** `VoiceCommands.swift` maps spoken phrases to actions
   that run in the app, with no agent and no network. Adding a phrase is a small
-  change with a unit test next to it in `VoiceCommandTests.swift`.
+  change with a unit test next to it in `VoiceCommandTests.swift`, and the
+  parser is pure — the tests run with no desktop session.
 - **A bug with a reproduction.** Window managers break on hardware nobody else
   has: unusual monitor arrangements, mixed scale factors, apps that fight back.
   A report that says which is often worth more than a patch.
 - **A new module.** The seam is described under "Adding a module" in AGENTS.md.
   Open an issue first so two people do not build the same thing.
+
+The issues tagged [good first issue][gfi] are the same idea, written out: each
+one names the file to open, what done looks like, and the command that proves
+it. Comment on one to claim it, so nobody writes it twice.
+
+[gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+
+## What happens after you send it
+
+There is one maintainer, so this is a promise about attention, not about speed:
+**a pull request gets a real answer within 48 hours**, even when the answer is
+that it needs another week of thought. A change that is declined is declined
+with the reason, and "What this project will not take" below is there so that
+happens as rarely as possible.
+
+Anyone whose change lands is listed in the release notes it ships in.
 
 ## Sending a change
 

--- a/README.md
+++ b/README.md
@@ -364,13 +364,14 @@ stops being one.
 
 ## Build
 
-Three commands, and they are exactly what CI runs on every pull request. Each
+Four commands, and they are exactly what CI runs on every pull request. Each
 line is a subshell, so paste the block from the repository root and it works:
 
 ```sh
 (cd App && swift build)                    # the app compiles
 ./scripts/test.sh                          # 306 unit tests
 (cd mcp && npm ci && npm run typecheck)    # the MCP server
+node scripts/check-zone-sets.mjs           # the layouts in zone-sets/
 ```
 
 None of that needs a signing certificate. Zone geometry, config decoding, HTTP
@@ -436,9 +437,17 @@ carry to be reproducible, where a new module seams in, and the handful of
 directions this project will not take, so nobody writes a patch that was never
 going to land.
 
+The smallest useful change here is one JSON file. [`zone-sets/`](zone-sets/) is
+a gallery of layouts worth copying — an ultrawide split, a rotated monitor, the
+one built around a recurring meeting. Draw it in the app, read the numbers out
+of `plonk state --json`, open a pull request; that folder has its own CI job and
+answers in about twenty seconds. Nothing to build, nothing to sign, no Swift.
+
 The issues tagged [good first issue][gfi] are written to be picked up cold —
-each one says where the code is and how to tell it worked. Questions,
-half-formed ideas and layouts worth showing off go to
+each one says where the code is and how to tell it worked, and carries a prompt
+you can hand straight to an agent, since [AGENTS.md](AGENTS.md) already tells
+one how this repo is put together. Questions, half-formed ideas and layouts
+worth showing off go to
 [Discussions](https://github.com/ostapondo/plonk/discussions); a security
 problem goes through [SECURITY.md](SECURITY.md) instead of a public issue.
 

--- a/scripts/check-zone-sets.mjs
+++ b/scripts/check-zone-sets.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Validates every set in zone-sets/ against the same rules the app enforces in
+// ZoneRect(dict:), so a layout that passes here cannot be refused by /zones/save.
+//
+// It runs on its own CI job with no macOS runner and no Swift toolchain, which
+// is the point: a pull request that adds one JSON file gets an answer in
+// seconds instead of waiting on a build it did not touch.
+//
+// Usage:
+//   node scripts/check-zone-sets.mjs             validate
+//   node scripts/check-zone-sets.mjs --preview   validate, then draw each set
+
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "zone-sets");
+
+// Kept in step with BuiltinZoneSets.all in App/Sources/plonk/Zones.swift. A
+// contributed set that shadows one of these would be unreachable: the built-in
+// wins in Config.zones(named:).
+const BUILTINS = ["Halves", "Thirds", "60 / 40", "Quarters", "Priority"];
+const SCREENS = ["any", "wide", "ultrawide", "portrait", "laptop"];
+// ZoneGeometry.minSide: the editor cannot draw a zone smaller than this, so a
+// set with one could not be adjusted after it was installed.
+const MIN_SIDE = 0.1;
+
+const errors = [];
+const warnings = [];
+const sets = [];
+
+/** The filename a set must use, derived from its name so the two cannot drift. */
+const slug = (name) => name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+const files = readdirSync(DIR).filter((f) => f.endsWith(".json") && f !== "schema.json").sort();
+if (files.length === 0) errors.push("zone-sets/ has no sets in it");
+
+for (const file of files) {
+  const fail = (message) => errors.push(`${file}: ${message}`);
+  const raw = readFileSync(join(DIR, file), "utf8");
+
+  if (/[^\x00-\x7F]/.test(raw)) fail("non-ASCII character; the repo has no emoji and no smart quotes anywhere");
+  if (!raw.endsWith("\n")) fail("no newline at end of file");
+
+  let set;
+  try {
+    set = JSON.parse(raw);
+  } catch (e) {
+    fail(`not valid JSON (${e.message})`);
+    continue;
+  }
+
+  const allowed = ["name", "description", "screen", "author", "zones"];
+  for (const key of allowed) if (!(key in set)) fail(`missing "${key}"`);
+  for (const key of Object.keys(set)) {
+    if (!allowed.includes(key)) fail(`unknown key "${key}"; schema.json lists what a set may carry`);
+  }
+
+  if (typeof set.name === "string") {
+    if (set.name.trim() !== set.name || set.name.length === 0 || set.name.length > 40) {
+      fail("name must be 1 to 40 characters with no padding");
+    }
+    if (BUILTINS.includes(set.name)) fail(`"${set.name}" is a built-in set name and would be shadowed by it`);
+    if (slug(set.name) !== file.replace(/\.json$/, "")) {
+      fail(`name "${set.name}" wants the filename ${slug(set.name)}.json`);
+    }
+    const clash = sets.find((s) => s.name === set.name);
+    if (clash) fail(`name "${set.name}" is already used by ${clash.file}`);
+  }
+
+  if (typeof set.description !== "string" || set.description.length === 0 || set.description.length > 200) {
+    fail("description must be one line of 1 to 200 characters");
+  }
+  if (!SCREENS.includes(set.screen)) fail(`screen must be one of ${SCREENS.join(", ")}`);
+  if (typeof set.author !== "string" || !/^@[A-Za-z0-9][A-Za-z0-9-]{0,38}$/.test(set.author)) {
+    fail("author must be a GitHub handle with the at sign, e.g. @ostapondo");
+  }
+
+  if (!Array.isArray(set.zones) || set.zones.length < 1 || set.zones.length > 24) {
+    fail("zones must be an array of 1 to 24 rectangles");
+    continue;
+  }
+
+  set.zones.forEach((zone, i) => {
+    const n = i + 1;
+    const keys = Object.keys(zone ?? {}).sort().join(",");
+    if (keys !== "h,w,x,y") {
+      fail(`zone ${n} must have exactly x, y, w and h`);
+      return;
+    }
+    for (const [key, value] of Object.entries(zone)) {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        fail(`zone ${n}: ${key} is not a number`);
+        return;
+      }
+      // Four decimals is past anything the editor can produce, so more of them
+      // means a fraction was pasted in from a division rather than drawn.
+      if (Math.abs(value * 10000 - Math.round(value * 10000)) > 1e-9) {
+        fail(`zone ${n}: ${key} has more than four decimals; round it`);
+      }
+    }
+    const { x, y, w, h } = zone;
+    if (x < 0 || y < 0) fail(`zone ${n} starts off the screen`);
+    if (w < MIN_SIDE || h < MIN_SIDE) fail(`zone ${n} is under ${MIN_SIDE} on a side; the editor could not redraw it`);
+    if (x + w > 1.0001 || y + h > 1.0001) fail(`zone ${n} runs past the edge of the screen`);
+  });
+
+  sets.push({ file, ...set });
+
+  // Overlaps are legal and sometimes deliberate, but they make a drag
+  // ambiguous, so they are worth saying out loud rather than failing on.
+  for (let i = 0; i < set.zones.length; i++) {
+    for (let j = i + 1; j < set.zones.length; j++) {
+      const a = set.zones[i], b = set.zones[j];
+      const over = Math.max(0, Math.min(a.x + a.w, b.x + b.w) - Math.max(a.x, b.x))
+        * Math.max(0, Math.min(a.y + a.h, b.y + b.h) - Math.max(a.y, b.y));
+      if (over > 0.0001) warnings.push(`${file}: zones ${i + 1} and ${j + 1} overlap`);
+    }
+  }
+}
+
+/** A set drawn on a character grid, so a review can see the layout in the diff. */
+function draw(set, cols = 48, rows = 14) {
+  const grid = Array.from({ length: rows }, () => Array(cols).fill(" "));
+  set.zones.forEach((z, i) => {
+    const x0 = Math.round(z.x * cols), y0 = Math.round(z.y * rows);
+    const x1 = Math.max(x0 + 1, Math.round((z.x + z.w) * cols)) - 1;
+    const y1 = Math.max(y0 + 1, Math.round((z.y + z.h) * rows)) - 1;
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) {
+        const edge = y === y0 || y === y1 || x === x0 || x === x1;
+        grid[y][x] = edge ? (y === y0 || y === y1 ? "-" : "|") : " ";
+      }
+    }
+    for (const [y, x] of [[y0, x0], [y0, x1], [y1, x0], [y1, x1]]) grid[y][x] = "+";
+    const label = String(i + 1);
+    const cy = Math.floor((y0 + y1) / 2), cx = Math.floor((x0 + x1) / 2);
+    for (let k = 0; k < label.length; k++) grid[cy][cx + k] = label[k];
+  });
+  return grid.map((row) => row.join("").replace(/\s+$/, "")).join("\n");
+}
+
+if (process.argv.includes("--preview")) {
+  for (const set of sets) {
+    console.log(`\n${set.name}  (${set.screen}, ${set.zones.length} zones)  ${set.file}`);
+    console.log(draw(set));
+  }
+  console.log("");
+}
+
+for (const warning of warnings) console.log(`warning  ${warning}`);
+for (const error of errors) console.error(`error    ${error}`);
+
+if (errors.length > 0) {
+  console.error(`\n${errors.length} problem(s) in zone-sets/. The rules are in zone-sets/README.md.`);
+  process.exit(1);
+}
+console.log(`${sets.length} zone set(s) valid.`);

--- a/zone-sets/README.md
+++ b/zone-sets/README.md
@@ -1,0 +1,205 @@
+# Zone sets
+
+A zone set is a layout, drawn once and assigned to a monitor. These are ones
+people keep going back to. Every file here is valid input to the app's own
+`/zones/save` route, so trying one takes a single command and no build.
+
+The app ships five built-ins — Halves, Thirds, 60 / 40, Quarters, Priority —
+which cover the common cases and are deliberately dull. This folder is for the
+rest: the ultrawide split that only makes sense at 34 inches, the rotated
+monitor, the layout that exists because of one recurring meeting.
+
+**Adding yours is the smallest useful contribution this repo takes.** It is one
+JSON file, it needs no Swift, no Xcode and no signing certificate, and CI
+answers in about twenty seconds. Good ones end up shipping as built-ins.
+
+## Trying one
+
+With Plonk running:
+
+```sh
+curl -s -X POST 127.0.0.1:43917/zones/save \
+  -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
+  -d @zone-sets/writing.json
+```
+
+The route reads `name` and `zones` and ignores the rest, which is why the file
+can be posted as it stands. Then assign it to a monitor:
+
+```sh
+plonk zones "Writing"          # or the Zones page, or ask an agent
+```
+
+To go back, pick another set on the Zones page — `Halves` is the default.
+
+## The gallery
+
+Numbers are what the overlay draws and what `⌃⌥1`–`⌃⌥9` fill. Redraw these any
+time with `node scripts/check-zone-sets.mjs --preview`.
+
+### Ultrawide 25 / 50 / 25 · [`ultrawide-25-50-25.json`](ultrawide-25-50-25.json)
+
+A wide middle for the thing being worked on, with a rail either side.
+
+```
++----------++----------------------++----------+
+|          ||                      ||          |
+|    1     ||          2           ||    3     |
+|          ||                      ||          |
++----------++----------------------++----------+
+```
+
+### Ultrawide Quarters · [`ultrawide-quarters.json`](ultrawide-quarters.json)
+
+Four full-height columns. At 34 inches each is about a laptop wide.
+
+```
++----------++----------++----------++----------+
+|          ||          ||          ||          |
+|    1     ||    2     ||    3     ||    4     |
+|          ||          ||          ||          |
++----------++----------++----------++----------+
+```
+
+### Focus and Stack · [`focus-and-stack.json`](focus-and-stack.json)
+
+The editor is zone 1, a narrow rail is zone 2, and 3 and 4 stack.
+
+```
++--------++----------------------++------------+
+|        ||                      ||     3      |
+|        ||                      |+------------+
+|   2    ||          1           |+------------+
+|        ||                      ||     4      |
++--------++----------------------++------------+
+```
+
+### Writing · [`writing.json`](writing.json)
+
+A centred column at a readable line length, with margins for notes and sources.
+
+```
++------------++------------------++------------+
+|            ||                  ||            |
+|     2      ||        1         ||     3      |
+|            ||                  ||            |
++------------++------------------++------------+
+```
+
+### Call and Work · [`call-and-work.json`](call-and-work.json)
+
+The work fills zone 1, the call sits top right, notes take the rest.
+
+```
++----------------------------------++----------+
+|                                  ||    2     |
+|                                  |+----------+
+|                1                 |+----------+
+|                                  ||    3     |
++----------------------------------++----------+
+```
+
+### Strip and Four · [`strip-and-four.json`](strip-and-four.json)
+
+A full-width band for a log or a build, and four cells under it.
+
+```
++----------------------------------------------+
+|                      1                       |
++----------------------------------------------+
++----------++----------++----------++----------+
+|          ||          ||          ||          |
+|    2     ||    3     ||    4     ||    5     |
++----------++----------++----------++----------+
+```
+
+### Portrait 70 / 30 · [`portrait-70-30.json`](portrait-70-30.json)
+
+A rotated monitor: the file being read on top, a terminal along the bottom.
+
+```
++-------------------+
+|                   |
+|         1         |
+|                   |
++-------------------+
++-------------------+
+|         2         |
++-------------------+
+```
+
+### Portrait Thirds · [`portrait-thirds.json`](portrait-thirds.json)
+
+Three stacked rows, the tall middle one for whatever is being read.
+
+```
++-------------------+
+|         1         |
++-------------------+
++-------------------+
+|         2         |
+|                   |
++-------------------+
++-------------------+
+|         3         |
++-------------------+
+```
+
+## Adding one
+
+1. Draw it in the app, on the Zones page. Nothing here has to be typed by hand.
+2. Read it back out: `plonk state --json` prints `zone_sets`, with the exact
+   numbers the editor produced.
+3. Save it as `zone-sets/<slug>.json` in the shape below, where the slug is the
+   name lowercased with everything that is not a letter or a digit turned into
+   a hyphen. The check enforces this, and tells you the filename it wants.
+4. `node scripts/check-zone-sets.mjs --preview` — it validates every set and
+   draws yours, which is the fastest way to see you got the numbers right.
+5. Open a pull request with the drawing in it. Say which monitor it is for and
+   what each zone holds. That sentence is most of what makes a layout worth
+   copying.
+
+```json
+{
+  "name": "Writing",
+  "description": "One line on what it is for, and which zone holds what.",
+  "screen": "wide",
+  "author": "@your-handle",
+  "zones": [
+    { "x": 0.3, "y": 0, "w": 0.4, "h": 1 }
+  ]
+}
+```
+
+## The rules, and why
+
+[`schema.json`](schema.json) is the formal version;
+[`scripts/check-zone-sets.mjs`](../scripts/check-zone-sets.mjs) is what CI runs.
+
+- **Fractions of the visible area, origin top left.** A set is screen-agnostic:
+  the same numbers stretch to a laptop and to a 49 inch monitor. That is why
+  `screen` is only a hint about what it was drawn for.
+- **Order is the numbering.** Zone 1 is the first in the array and the one
+  `⌃⌥1` fills. Read left to right, top to bottom — unless the set is built
+  around one main zone, in which case put that first and say so in the
+  description, the way Focus and Stack and Writing do.
+- **Nothing smaller than 0.1 on a side.** That is `ZoneGeometry.minSide`: the
+  editor cannot draw a zone below it, so a smaller one could not be adjusted
+  after it was installed.
+- **At most four decimals.** More of them means a number came out of a division
+  rather than the editor. A third of a screen is `0.3333`, and the rounding is
+  invisible.
+- **A name no built-in uses.** `Config.zones(named:)` prefers the built-in, so a
+  set called Quarters would install and then never be reachable.
+- **ASCII only.** Same rule as the rest of the repo: no emoji, no smart quotes.
+- **Overlaps warn rather than fail.** They are legal, and occasionally what you
+  want, but two zones under one cursor make a drag ambiguous.
+
+## Still missing
+
+Layouts nobody has contributed yet, if you have the desk for it:
+
+- A laptop screen on its own, where the built-in Halves is genuinely too coarse.
+- Two monitors of different shapes, as a pair of sets meant to be used together.
+- A 5K in portrait beside a laptop.
+- Anything built around one app that is fussy about its width.

--- a/zone-sets/call-and-work.json
+++ b/zone-sets/call-and-work.json
@@ -1,0 +1,11 @@
+{
+  "name": "Call and Work",
+  "description": "For the hours spent on a call while doing something else: the work fills zone 1, the call sits top right where a camera notch does not cover it, and notes take the rest of the column.",
+  "screen": "any",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0, "y": 0, "w": 0.75, "h": 1 },
+    { "x": 0.75, "y": 0, "w": 0.25, "h": 0.35 },
+    { "x": 0.75, "y": 0.35, "w": 0.25, "h": 0.65 }
+  ]
+}

--- a/zone-sets/focus-and-stack.json
+++ b/zone-sets/focus-and-stack.json
@@ -1,0 +1,12 @@
+{
+  "name": "Focus and Stack",
+  "description": "Numbered main zone first: the editor is zone 1, a narrow rail for files or chat is zone 2, and zones 3 and 4 stack a terminal under a browser.",
+  "screen": "ultrawide",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0.2, "y": 0, "w": 0.5, "h": 1 },
+    { "x": 0, "y": 0, "w": 0.2, "h": 1 },
+    { "x": 0.7, "y": 0, "w": 0.3, "h": 0.5 },
+    { "x": 0.7, "y": 0.5, "w": 0.3, "h": 0.5 }
+  ]
+}

--- a/zone-sets/portrait-70-30.json
+++ b/zone-sets/portrait-70-30.json
@@ -1,0 +1,10 @@
+{
+  "name": "Portrait 70 / 30",
+  "description": "The rotated monitor most people actually use: a tall window on top for the file being read, a terminal or a log along the bottom.",
+  "screen": "portrait",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0, "y": 0, "w": 1, "h": 0.7 },
+    { "x": 0, "y": 0.7, "w": 1, "h": 0.3 }
+  ]
+}

--- a/zone-sets/portrait-thirds.json
+++ b/zone-sets/portrait-thirds.json
@@ -1,0 +1,11 @@
+{
+  "name": "Portrait Thirds",
+  "description": "Three stacked rows for a rotated monitor, with the tall middle one for whatever is being read.",
+  "screen": "portrait",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0, "y": 0, "w": 1, "h": 0.3 },
+    { "x": 0, "y": 0.3, "w": 1, "h": 0.4 },
+    { "x": 0, "y": 0.7, "w": 1, "h": 0.3 }
+  ]
+}

--- a/zone-sets/schema.json
+++ b/zone-sets/schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/ostapondo/plonk/blob/main/zone-sets/schema.json",
+  "title": "Plonk zone set",
+  "description": "A layout of fractional rectangles over one screen's visible area. Screen-agnostic: the same set is assigned to any monitor and stretches to it.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "description", "screen", "author", "zones"],
+  "properties": {
+    "name": {
+      "description": "What the set is called in the app, the menu and get_state. Unique across this folder and not one of the built-ins.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 40
+    },
+    "description": {
+      "description": "One line on what the layout is for, and which zone is meant to hold what.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "screen": {
+      "description": "The shape of monitor this was drawn for. Advisory: any set works on any screen, but a 25% column is a sidebar on an ultrawide and a sliver on a laptop.",
+      "enum": ["any", "wide", "ultrawide", "portrait", "laptop"]
+    },
+    "author": {
+      "description": "GitHub handle, with the at sign.",
+      "type": "string",
+      "pattern": "^@[A-Za-z0-9][A-Za-z0-9-]{0,38}$"
+    },
+    "zones": {
+      "description": "The zones, in the order they are numbered: zone 1 is the first, and it is the one CTRL+OPT+1 fills.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 24,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["x", "y", "w", "h"],
+        "properties": {
+          "x": { "type": "number", "minimum": 0, "maximum": 0.9 },
+          "y": { "type": "number", "minimum": 0, "maximum": 0.9 },
+          "w": { "type": "number", "minimum": 0.1, "maximum": 1 },
+          "h": { "type": "number", "minimum": 0.1, "maximum": 1 }
+        }
+      }
+    }
+  }
+}

--- a/zone-sets/strip-and-four.json
+++ b/zone-sets/strip-and-four.json
@@ -1,0 +1,13 @@
+{
+  "name": "Strip and Four",
+  "description": "A full-width band across the top for a log, a chart or a build, and four cells under it for the things being watched.",
+  "screen": "wide",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0, "y": 0, "w": 1, "h": 0.3 },
+    { "x": 0, "y": 0.3, "w": 0.25, "h": 0.7 },
+    { "x": 0.25, "y": 0.3, "w": 0.25, "h": 0.7 },
+    { "x": 0.5, "y": 0.3, "w": 0.25, "h": 0.7 },
+    { "x": 0.75, "y": 0.3, "w": 0.25, "h": 0.7 }
+  ]
+}

--- a/zone-sets/ultrawide-25-50-25.json
+++ b/zone-sets/ultrawide-25-50-25.json
@@ -1,0 +1,11 @@
+{
+  "name": "Ultrawide 25 / 50 / 25",
+  "description": "A wide middle for the thing being worked on, with a rail either side for chat, a terminal or documentation.",
+  "screen": "ultrawide",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0, "y": 0, "w": 0.25, "h": 1 },
+    { "x": 0.25, "y": 0, "w": 0.5, "h": 1 },
+    { "x": 0.75, "y": 0, "w": 0.25, "h": 1 }
+  ]
+}

--- a/zone-sets/ultrawide-quarters.json
+++ b/zone-sets/ultrawide-quarters.json
@@ -1,0 +1,12 @@
+{
+  "name": "Ultrawide Quarters",
+  "description": "Four full-height columns. On a 34 inch screen each one is about the width of a laptop, so four real windows fit without overlapping.",
+  "screen": "ultrawide",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0, "y": 0, "w": 0.25, "h": 1 },
+    { "x": 0.25, "y": 0, "w": 0.25, "h": 1 },
+    { "x": 0.5, "y": 0, "w": 0.25, "h": 1 },
+    { "x": 0.75, "y": 0, "w": 0.25, "h": 1 }
+  ]
+}

--- a/zone-sets/writing.json
+++ b/zone-sets/writing.json
@@ -1,0 +1,11 @@
+{
+  "name": "Writing",
+  "description": "Numbered main zone first: a centred column at a readable line length is zone 1, and the two margins hold the notes and the sources being quoted.",
+  "screen": "wide",
+  "author": "@ostapondo",
+  "zones": [
+    { "x": 0.3, "y": 0, "w": 0.4, "h": 1 },
+    { "x": 0, "y": 0, "w": 0.3, "h": 1 },
+    { "x": 0.7, "y": 0, "w": 0.3, "h": 1 }
+  ]
+}


### PR DESCRIPTION
Contributors come out of users, and the step before either is having somewhere
to land. The repo already reads well and has issues written to be picked up
cold, but every one of them still asks for Swift. This adds the rung below that.

**`zone-sets/`** is a gallery of layouts: eight to start with, covering the
shapes the built-ins deliberately do not — ultrawide splits, a rotated monitor,
one built around a call that happens every day.

Each file is valid input to `/zones/save` as it stands, because the route reads
`name` and `zones` and ignores the rest. So trying one is a curl, and the format
needed no new code to be usable:

```sh
curl -s -X POST 127.0.0.1:43917/zones/save \
  -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
  -d @zone-sets/writing.json
```

**`scripts/check-zone-sets.mjs`** enforces the same rules `ZoneRect(dict:)` does,
so a set that passes here cannot be refused by the app. It also enforces the
house rules that are easy to trip over — no built-in name (`Config.zones(named:)`
prefers the built-in, so the set would install and then be unreachable), nothing
under `ZoneGeometry.minSide` on a side, ASCII only. `--preview` draws every set
on a character grid, which is the fastest way to see the numbers are right, and
is where the drawings in the README came from.

It runs as its own ubuntu job, which is the point: a pull request that adds one
JSON file gets an answer in about twenty seconds instead of queueing behind a
Swift build it did not touch.

**CONTRIBUTING** now orders "Places to start" by how much of the repo you have
to hold in your head, and says out loud that `mcp/` is TypeScript that
typechecks on any machine — the current text does not, and a TypeScript
developer reading it has no reason to think there is anything here for them.
It also promises a real answer on a pull request within 48 hours, which is the
one thing a stranger cannot find out by reading the repo.

Ran `node scripts/check-zone-sets.mjs` (8 valid) and the failure path against a
deliberately broken file. No Swift or TypeScript changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)