### PR TITLE
Rules that check themselves, and a first change that takes fifteen minutes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.{ts,js,json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+# Two trailing spaces are a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 <!--
-CONTRIBUTING.md has the long version. Delete any line that does not apply.
+CONTRIBUTING.md has the long version. Delete any section that does not apply —
+a one-line docs fix should not carry a geometry checklist.
+
+The title does not have to be clever. `fix: nil display UUID on unplug` is a
+good title. So is `Add a setup page for Windsurf`.
 -->
 
 ## What changed, and why
@@ -13,16 +17,57 @@ The loop CI runs, from the repository root. Paste the ones you ran:
 
   (cd App && swift build)
   ./scripts/test.sh
-  (cd mcp && npm ci && npm run typecheck)
+  ./scripts/lint.sh
+  (cd mcp && npm ci && npm test)
 
-None of them need a signing certificate. Say so if you also built and launched
-Plonk.app, and on which macOS version and monitor arrangement.
+None of them need a signing certificate.
 -->
 
 ## Checks
 
 - [ ] `swift build` passes on every commit in the branch, not just the last one
-- [ ] New logic is covered in `App/Tests/plonkTests/`, or it is not the kind that can be
+- [ ] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be
 - [ ] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
 - [ ] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — fixed in this PR if not
 - [ ] Screenshots below for anything visual
+
+<!-- ===================================================================== -->
+
+## If this moves windows
+
+<!--
+Delete this whole section unless the change touches zones, snapping, drag,
+workspaces, focus, or anything else that decides where a window ends up.
+
+Nothing in the unit suite can see a real desktop, so this is the only evidence
+there is. `scripts/testbench.sh` opens throwaway TextEdit windows so you never
+have to move your real ones:
+
+  ./scripts/testbench.sh up 4     open four windows
+  ./scripts/testbench.sh state    print where they landed, as fractions
+  ./scripts/testbench.sh down     close them, delete the files
+
+Run `state` before and after and paste both. Fractions travel between machines;
+pixels do not.
+
+You are not expected to own every arrangement below. Tick what you ran, and
+write "no hardware" against the rest — an honest gap is more useful than a
+blank, and it is what the `needs-hardware` label is for.
+-->
+
+**Setup:** macOS <!-- 15.2 -->, <!-- 1 built-in display @ 2x -->
+
+- [ ] **One screen.** Snap into a zone by drag and by `⌃⌥1`–`⌃⌥9`. Both land in the same place.
+- [ ] **Put it back.** `⌃⌥0` returns the window to the frame it had before Plonk first touched it.
+- [ ] **A second monitor.** A window snapped on each screen stays on its own, and the zone numbers follow the screen the cursor is on.
+- [ ] **Mixed scale factors.** A Retina screen beside a 1x one, a window snapped on each. Nothing is half-size or double-size.
+- [ ] **Unplug and plug back in.** Windows return to the monitor they were on, not to index 0.
+- [ ] **An excluded app.** A window of an app on the exclusions list is left alone by drag and by shortcut, and still moves when an agent names it on purpose.
+
+<details>
+<summary>Before / after from <code>testbench.sh state</code></summary>
+
+```
+```
+
+</details>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
 
 jobs:
+  # First, and on the cheapest runner there is: style is the half of review a
+  # script can do, and nobody should hear about a trailing space from a person.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: ./scripts/lint.sh
+
   app:
     # macos-14 still ships Swift 5.10; Package.swift needs tools version 6.0.
     runs-on: macos-15
@@ -30,15 +38,5 @@ jobs:
         working-directory: mcp
       - run: npm run typecheck
         working-directory: mcp
-
-  # Deliberately the cheapest job in the file: a pull request that adds one
-  # layout to zone-sets/ gets an answer in seconds, on a runner that is not
-  # queueing behind a Swift build it did not touch.
-  zone-sets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 20
-      - run: node scripts/check-zone-sets.mjs
+      - run: npm test
+        working-directory: mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,15 @@ jobs:
         working-directory: mcp
       - run: npm test
         working-directory: mcp
+
+  # Deliberately the cheapest job in the file: a pull request that adds one
+  # layout to zone-sets/ gets an answer in seconds, on a runner that is not
+  # queueing behind a Swift build it did not touch.
+  zone-sets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+      - run: node scripts/check-zone-sets.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Each line is a subshell, so the block runs as written from the repository root:
 ./scripts/test.sh                # unit tests — must pass
 ./scripts/lint.sh                # style rules — must pass
 (cd mcp && npm test)             # must pass when mcp/ changed
+node scripts/check-zone-sets.mjs # must pass when zone-sets/ changed
 ./scripts/build.sh               # produces Plonk.app; needs a signing identity
 curl -s 127.0.0.1:43917/ping     # smoke test while the app is running
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Rules for AI agents working in this repo.
 ## Layout
 
 - `App/` — Swift package, the menu bar app. One type per file, files stay under ~300 lines.
-- `mcp/` — TypeScript MCP server: `src/server.ts` compiled to `dist/` via `npm run build`. Keep it a thin proxy; logic belongs in the app. Tool description rules are in `mcp/AGENTS.md`.
+- `mcp/` — TypeScript MCP server: `src/server.ts` compiled to `dist/` via `npm run build`. Keep it a thin proxy; logic belongs in the app. Tests are `mcp/test/*.test.js`, run against `dist/` on the Node test runner with no extra dependencies. Tool description rules are in `mcp/AGENTS.md`.
 - `scripts/build.sh` — the only build entry point.
 
 Inside `App/Sources/plonk/`, the pieces that are easy to get lost in:
@@ -41,14 +41,26 @@ Each line is a subshell, so the block runs as written from the repository root:
 ```sh
 (cd App && swift build)          # must pass before any commit
 ./scripts/test.sh                # unit tests — must pass
-(cd mcp && npm run typecheck)    # must pass when mcp/ changed
+./scripts/lint.sh                # style rules — must pass
+(cd mcp && npm test)             # must pass when mcp/ changed
 ./scripts/build.sh               # produces Plonk.app; needs a signing identity
 curl -s 127.0.0.1:43917/ping     # smoke test while the app is running
 ```
 
-The first three need no signing certificate. `build.sh` does, and refuses
+The first four need no signing certificate. `build.sh` does, and refuses
 rather than produce a bundle that cannot hold its permissions; see
 [CONTRIBUTING.md](CONTRIBUTING.md) for why and how to make one.
+
+`scripts/lint.sh` enforces the file-length rule above, plus no emoji, no
+trailing whitespace and a final newline. Files already over 300 lines are
+recorded in `scripts/line-limit-baseline` with the length they had that day:
+they may shrink, never grow, and a new file has to come in under the limit
+outright. Shortening one means lowering its number in the same commit.
+
+Anything that decides where a window lands is checked by hand, because none of
+it is reachable from the unit suite. `scripts/testbench.sh up 4` opens
+throwaway TextEdit windows, `state` prints where each landed as fractions, and
+`down` clears them away. Use it instead of moving the user's real windows.
 
 The release number lives in `version.env`, and only there. `scripts/build.sh`
 reads `MARKETING_VERSION` and `BUILD_NUMBER` into `Info.plist`. Bump them to cut
@@ -84,10 +96,12 @@ Put new logic there and cover it in `App/Tests/plonkTests/`.
   entirely when the user says so. Anything else that wants the network needs
   the README's privacy section rewritten first, which is the point of the rule.
 - Do not commit build artifacts (`.build/`, `Plonk.app`, `node_modules/`).
-- The claims in `README.md` and `SECURITY.md` are checkable, and have to stay
-  that way. Any change to the network, the permissions, the entitlements or the
-  update path makes one of them false — fix the document in the same commit,
-  and never widen a claim past what the code actually does.
+- The claims in `README.md`, `docs/verify.md` and `SECURITY.md` are checkable,
+  and have to stay that way. Any change to the network, the permissions, the
+  entitlements or the update path makes one of them false — fix the document in
+  the same commit, and never widen a claim past what the code actually does.
+- Anything a user would notice goes in `CHANGELOG.md` under Unreleased, in the
+  same commit that changes it.
 
 ## Agent notes
 
@@ -146,6 +160,9 @@ Things that have already cost someone an hour.
 - Imperative subject under 72 chars, body only when the why is not obvious.
 - One logical change per commit. `swift build` must pass on every commit.
 - A PR states what changed and why, plus the commands you ran. Screenshots for
-  anything visual.
+  anything visual, and the geometry checklist in the PR template filled in for
+  anything that moves a window.
 - Never push directly to `main`; branch and open a PR.
 - No generated marketing prose in PR descriptions: state what changed and why, in plain language.
+- Never push to somebody else's branch. Review asks for changes; it does not
+  make them. CONTRIBUTING.md promises this, so it is a rule, not a courtesy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ one of those.
 
 ### Added
 
+- `zone-sets/` — a gallery of layouts as JSON the app's own `/zones/save` route
+  accepts unmodified, so trying one is a single command and no build. Adding
+  one is the smallest useful change this repo takes, and
+  `scripts/check-zone-sets.mjs` validates the folder in its own CI job.
 - `scripts/lint.sh` — checks the rules AGENTS.md states and nothing enforced:
   file length, no emoji, no trailing whitespace, a newline at the end of every
   file. No dependencies; it runs on a plain checkout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+# Changelog
+
+What changed in each release, from a user's side. The commit log has the rest.
+
+Versions before 0.1.0 shipped in two days and are summarized rather than
+itemized. The dates are real; the tidiness is not — most of what is listed
+under 0.0.4 was written the same afternoon it went out.
+
+Releases up to and including 0.0.4 were zipped by hand and carry no build
+attestation, so `gh attestation verify` fails on them. That is the whole reason
+[the release workflow](.github/workflows/release.yml) exists now. Do not install
+one of those.
+
+## Unreleased
+
+### Added
+
+- `scripts/lint.sh` — checks the rules AGENTS.md states and nothing enforced:
+  file length, no emoji, no trailing whitespace, a newline at the end of every
+  file. No dependencies; it runs on a plain checkout.
+- `scripts/line-limit-baseline` — the files that were already over the
+  300-line limit, with the length each had that day. They may shrink, never
+  grow. New files come in under the limit outright.
+- `scripts/testbench.sh` — throwaway TextEdit windows to demonstrate a window
+  fix on, and `state` to print where each one landed as fractions. Nobody has
+  to move their real windows to prove a patch works.
+- A test suite for `mcp/`: `npm test`, on the Node test runner, no new
+  dependencies. Covers CLI argument parsing, the identity holders that keep one
+  MCP session's name out of another's, and the tool input schemas.
+- `.editorconfig`.
+- This file.
+
+### Changed
+
+- `mcp`: `options()` moved out of `cli.ts` into `args.ts`, so it can be tested
+  without running the CLI.
+- README is shorter, and the reference sections it carried now live in `docs/`.
+- CONTRIBUTING leads with the loop that needs no signing certificate, and says
+  how long a review takes.
+
+## 0.1.0 — 2026-08-08
+
+The first release that is signed, attested and installable with one command.
+
+### Added
+
+- **Homebrew.** `brew install --cask ostapondo/plonk/plonk`.
+- **Voice commands that run in the app.** The dozen most common ones — "snap
+  this left", "zone three", "put it back", "keep awake for an hour", "launch my
+  review workspace" — are handled on the Mac, offline, with no agent and no
+  round trip. Anything less clear-cut still goes to the agent.
+- **A Home page** with the three steps a new install needs, and a shortcut
+  guide read from the front app's own menus.
+- **A landing page** at [ostapondo.github.io/Plonk](https://ostapondo.github.io/Plonk/).
+
+### Changed
+
+- The zone gap is typed rather than dragged for, and excluded apps are picked
+  from a list instead of typed.
+- Notarization is off the roadmap, and the README says so plainly instead of
+  promising a stamp that needs a paid Apple account.
+
+### Fixed
+
+- Around twenty ways the overlays, the grab handler and the new modules stepped
+  on each other or on the rest of the desk: a grab that was really a click ate
+  the click, `⌘` was read as `⇧`, and a disabled feature still held its tap.
+
+## 0.0.5 — 2026-08-08
+
+### Added
+
+- **Releases are built on GitHub's runners**, signed there, and ship with a
+  provenance attestation: `gh attestation verify Plonk-<version>.zip -R
+  ostapondo/plonk`. `plonk-mcp` publishes to npm over OIDC with provenance.
+  Nothing ships from a laptop, which is what makes either check mean anything.
+- An update's checksum is verified against what GitHub published before
+  anything is unpacked.
+
+### Fixed
+
+- Signing uses a key that can leave the machine it was made on, so the release
+  workflow can hold one.
+- The release refuses to overwrite an asset that has already been published.
+
+## 0.0.4 — 2026-08-08
+
+The release most of the app arrived in.
+
+### Added
+
+- **Everything PowerToys' FancyZones does with a zone**, rebuilt for the Mac:
+  zones by number (`⌃⌥1`–`⌃⌥9`), put-it-back (`⌃⌥0`), spanning two zones,
+  excluded apps, focus by geometry, zone appearance, and windows that return to
+  their monitor after a display change.
+- **Grab and move** — hold a key and drag a window from anywhere inside it.
+- **Pin part of the screen** above everything, live or frozen.
+- **Text off the screen** (`⌃⌥T`), on-device.
+- **Pointer tools** and a **shortcut guide**.
+- **Push-to-talk voice** (`⌃⌥V`), recognized on the Mac.
+- **Updates from inside Plonk**, installing a build only when it is signed with
+  the same certificate as the running copy — the same test macOS applies, so
+  Accessibility and Screen Recording carry over.
+- **Streamable HTTP transport** (`plonk-mcp --http`) for clients that cannot
+  spawn a process, a **live-state SSE stream** at `/events`, and a
+  **back-channel** so Plonk can reach the active agent.
+- Setup pages for Cursor, Zed and Cline, and `llms-install.md`.
+
+### Fixed
+
+- Rebuilding no longer drops Accessibility and Screen Recording:
+  `scripts/build.sh` refuses to run without a stable signing identity, because
+  macOS pins those grants to the code signature.
+
+## 0.0.3 — 2026-08-07
+
+### Added
+
+- **Several agents at once.** Every client registers itself, `get_state` lists
+  who is online, and the user picks an active one from the menu bar or the
+  settings. An optional strict mode locks changes to that agent; everyone else
+  keeps reading state and gets a 409 on anything that moves a window.
+- Workspace rename.
+
+## 0.0.2 — 2026-08-07
+
+### Added
+
+- Listed on the MCP Registry, Glama and Smithery.
+- The demo animation the README opens with.
+- `ROADMAP.md`.
+
+## 0.0.1 — 2026-08-07
+
+First release. The menu bar app, snap zones, workspaces, keep-awake,
+screenshots, and `plonk-mcp` on npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,14 @@ Bug reports, zone sets, client one-pagers and code are all welcome.
 Two things worth saying before anything else, because both are usually left to
 be guessed at:
 
-**You will get an answer within three days.** If a pull request sits longer than
-that, it is an oversight rather than a verdict — say so on the thread. A change
-that is not going to land will be told so quickly, and why.
+**A pull request gets a real answer within 48 hours**, even when the answer is
+that it needs another week of thought. There is one maintainer, so that is a
+promise about attention rather than about speed. If something sits longer, it is
+an oversight rather than a verdict — say so on the thread. A change that is
+declined is declined with the reason, and "What this project will not take"
+below exists so that happens as rarely as possible.
+
+Anyone whose change lands is listed in the release notes it ships in.
 
 **Your branch is yours.** Review comments will ask for changes rather than push
 them. If a pull request is nearly there and you would rather it were finished
@@ -27,6 +32,7 @@ git clone https://github.com/ostapondo/plonk && cd plonk
 ./scripts/test.sh                          # the unit suite
 ./scripts/lint.sh                          # style rules, no dependencies
 (cd mcp && npm ci && npm test)             # the MCP server
+node scripts/check-zone-sets.mjs           # the layouts in zone-sets/
 ```
 
 Each line is a subshell, so the block runs as written from the repository root.
@@ -44,27 +50,43 @@ That is the shape of most of the work here: one file, one seam, one test.
 
 ## Where the work is
 
-- **[good first issue][gfi]** — written to be picked up cold. Each says where
-  the code is and how to tell it worked.
-- **[reserved][res]** — issues deliberately left alone. If one is labelled
-  `reserved-for-contributors`, the maintainer is not working on it and will not
-  start; it is yours if you say so on the thread. Nothing here moves fast enough
-  to be worth racing.
+Roughly in order of how much of the repo you have to hold in your head. The
+first two need no Swift at all, and the third needs no Swift on your machine.
+
+- **A zone set.** One JSON file in [`zone-sets/`](zone-sets/), which is a
+  gallery of layouts people keep going back to. Draw it in the app, read the
+  numbers back out of `plonk state --json`, drop them in a file. CI for that
+  folder is its own job and answers in about twenty seconds. Good ones end up
+  shipping as built-ins. [`zone-sets/README.md`](zone-sets/README.md) has the
+  format and the rules.
 - **[needs-hardware][hw]** — see below. The single most useful thing you can
   send, and it needs neither Swift nor a certificate.
+- **Something in `mcp/`.** The MCP server and the `plonk` CLI are TypeScript, a
+  thin proxy over the app's HTTP API, and they build and test on any machine —
+  Linux included, without a Mac in sight. `npm ci && npm test` in `mcp/` is the
+  whole loop.
 - **A one-pager for an MCP client.** `docs/clients/` has Cursor, Zed and Cline.
   Any client that can run a stdio server works; the page is the missing part.
-- **A zone set.** If you have drawn a layout you keep going back to, post it
-  under Show and tell. Good ones end up shipping as built-ins.
+  If you use a client that is not there, you already know the one thing this
+  repo does not.
 - **A voice command.** `VoiceCommands.swift` maps spoken phrases to actions that
   run in the app, with no agent and no network. Adding a phrase is a small
-  change with a unit test next to it in `VoiceCommandTests.swift`.
+  change with a unit test next to it in `VoiceCommandTests.swift`, and the
+  parser is pure — the tests run with no desktop session.
 - **A file off `scripts/line-limit-baseline`.** Every line in that file is a
   type waiting to be lifted out of something too big. [Issue #17][17] is the
   first one, and it comes with tests that cannot be written until it moves.
 - **A new module.** The seam is described under "Adding a module" in
   [AGENTS.md](AGENTS.md). Open an issue first so two people do not build the
   same thing.
+
+The issues tagged **[good first issue][gfi]** are the same idea, written out:
+each one names the file to open, what done looks like, and the command that
+proves it. Comment on one to claim it, so nobody writes it twice.
+
+The ones tagged **[reserved][res]** are deliberately left alone: the maintainer
+is not working on them and will not start, so they are yours if you say so on
+the thread. Nothing here moves fast enough to be worth racing.
 
 [gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [res]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Areserved-for-contributors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,107 @@
 # Contributing
 
-Bug reports, zone sets, client one-pagers and code are all welcome. This page is
-the short version; [AGENTS.md](AGENTS.md) is the long one and is worth reading
-before you write anything. It is phrased as instructions to an agent because
-that is what most often reads it, but it is the engineering guide either way:
-the repo layout, the five places a new module touches, which coordinate space
-each number is in, and the mistakes that have already cost someone an hour.
+Bug reports, zone sets, client one-pagers and code are all welcome.
+
+Two things worth saying before anything else, because both are usually left to
+be guessed at:
+
+**You will get an answer within three days.** If a pull request sits longer than
+that, it is an oversight rather than a verdict — say so on the thread. A change
+that is not going to land will be told so quickly, and why.
+
+**Your branch is yours.** Review comments will ask for changes rather than push
+them. If a pull request is nearly there and you would rather it were finished
+for you than iterated on, say so and it will be; otherwise nothing is pushed to
+your branch.
 
 Everyone taking part is expected to follow the
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
-## You do not need a signing certificate
+## Your first change, in about fifteen minutes
 
-`scripts/build.sh` refuses to run without one, which makes the repo look closed
-on first clone. It is not: the certificate is needed only to produce and launch
-`Plonk.app`. Everything else works on a plain checkout, and these four commands
-are exactly what CI runs:
+You do not need a signing certificate, an Apple account, or the app running.
 
 ```sh
-(cd App && swift build)                      # the app compiles
-./scripts/test.sh                            # the unit suite
-(cd mcp && npm ci && npm run typecheck)      # the MCP server
-node scripts/check-zone-sets.mjs             # the layouts in zone-sets/
+git clone https://github.com/ostapondo/plonk && cd plonk
+(cd App && swift build)                    # the app compiles
+./scripts/test.sh                          # the unit suite
+./scripts/lint.sh                          # style rules, no dependencies
+(cd mcp && npm ci && npm test)             # the MCP server
 ```
 
-Each line is a subshell, so all three run from the repository root as written —
-paste the block and it works.
+Each line is a subshell, so the block runs as written from the repository root.
+That is exactly what CI runs, and if it passes, the mechanical half of review is
+already done.
 
-Zone geometry, config decoding, HTTP routing, MCP tools, voice command parsing,
-the CLI and every document in the repo are all reachable from that loop, and
-most changes never need more.
+Now pick something. [Issue #21][21] is a good one to read first: `plonk state`
+tells a person to "ask the user to launch Plonk.app" — which, in a shell, means
+asking themselves. The fix is a message in `mcp/src/api.ts`, a test in
+`mcp/test/`, and `npm test`. Nothing else.
 
-To actually run the app, make your own certificate once:
+That is the shape of most of the work here: one file, one seam, one test.
+
+[21]: https://github.com/ostapondo/plonk/issues/21
+
+## Where the work is
+
+- **[good first issue][gfi]** — written to be picked up cold. Each says where
+  the code is and how to tell it worked.
+- **[reserved][res]** — issues deliberately left alone. If one is labelled
+  `reserved-for-contributors`, the maintainer is not working on it and will not
+  start; it is yours if you say so on the thread. Nothing here moves fast enough
+  to be worth racing.
+- **[needs-hardware][hw]** — see below. The single most useful thing you can
+  send, and it needs neither Swift nor a certificate.
+- **A one-pager for an MCP client.** `docs/clients/` has Cursor, Zed and Cline.
+  Any client that can run a stdio server works; the page is the missing part.
+- **A zone set.** If you have drawn a layout you keep going back to, post it
+  under Show and tell. Good ones end up shipping as built-ins.
+- **A voice command.** `VoiceCommands.swift` maps spoken phrases to actions that
+  run in the app, with no agent and no network. Adding a phrase is a small
+  change with a unit test next to it in `VoiceCommandTests.swift`.
+- **A file off `scripts/line-limit-baseline`.** Every line in that file is a
+  type waiting to be lifted out of something too big. [Issue #17][17] is the
+  first one, and it comes with tests that cannot be written until it moves.
+- **A new module.** The seam is described under "Adding a module" in
+  [AGENTS.md](AGENTS.md). Open an issue first so two people do not build the
+  same thing.
+
+[gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[res]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Areserved-for-contributors
+[hw]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-hardware
+[17]: https://github.com/ostapondo/plonk/issues/17
+
+## Hardware nobody here has
+
+This is the honest weak point of the project, and the easiest place to help.
+
+A window manager breaks on arrangements the author cannot see: three monitors,
+an ultrawide, a Retina screen beside a 1x one, a display that comes and goes,
+Sidecar, a vertical panel. Placement needs a real desktop session, so none of it
+is reachable from the unit suite — the whole of `App/Tests/plonkTests/` runs
+without one on purpose.
+
+So a report from a desk that is not this one is worth more than a patch. The
+[needs-hardware][hw] label is exactly that list, and answering one means running
+a few shortcuts and pasting what happened.
+
+`scripts/testbench.sh` opens throwaway TextEdit windows so you never have to
+move your real ones:
+
+```sh
+./scripts/testbench.sh up 4     # four windows with known titles
+./scripts/testbench.sh state    # where each one landed, as fractions
+./scripts/testbench.sh down     # close them, delete the files
+```
+
+Fractions rather than pixels, because those travel between machines. The pull
+request template has the six arrangements worth running through, and you are not
+expected to own all six — tick what you ran and write "no hardware" against the
+rest.
+
+## Running the app
+
+Only needed to change something you can see. Make your own certificate once:
 
 ```sh
 ./scripts/make-signing-cert.sh   # creates one and prints how to trust it
@@ -41,80 +111,48 @@ open Plonk.app
 
 That certificate is yours, not the one releases are signed with, so a local
 build will not auto-update and macOS asks for Accessibility and Screen Recording
-again the first time it runs. Both are expected. Do not work around `build.sh`
-by ad-hoc signing: macOS pins those two permissions to the code signature, an
-ad-hoc signature is a different one every build, and the result is a bundle that
-looks built and then silently cannot move a window.
+again the first time it runs. Both are expected.
 
-## Places to start
-
-Roughly in order of how much of the repo you have to hold in your head. The
-first two need no Swift at all, and the third needs no Swift on your machine.
-
-- **A zone set.** One JSON file in [`zone-sets/`](zone-sets/), which is a
-  gallery of layouts people keep going back to. Draw it in the app, read the
-  numbers back out of `plonk state --json`, drop them in a file. CI for that
-  folder is its own job and answers in about twenty seconds. Good ones end up
-  shipping as built-ins. [`zone-sets/README.md`](zone-sets/README.md) has the
-  format and the rules.
-- **A one-pager for an MCP client.** `docs/clients/` has Cursor, Zed and Cline.
-  Any client that can run a stdio server works; the page is the missing part.
-  If you use a client that is not there, you already know the one thing this
-  repo does not.
-- **Something in `mcp/`.** The MCP server and the `plonk` CLI are TypeScript, a
-  thin proxy over the app's HTTP API, and they typecheck on any machine — Linux
-  included, without a Mac in sight. `npm ci && npm run typecheck` in `mcp/` is
-  the whole loop.
-- **A voice command.** `VoiceCommands.swift` maps spoken phrases to actions
-  that run in the app, with no agent and no network. Adding a phrase is a small
-  change with a unit test next to it in `VoiceCommandTests.swift`, and the
-  parser is pure — the tests run with no desktop session.
-- **A bug with a reproduction.** Window managers break on hardware nobody else
-  has: unusual monitor arrangements, mixed scale factors, apps that fight back.
-  A report that says which is often worth more than a patch.
-- **A new module.** The seam is described under "Adding a module" in AGENTS.md.
-  Open an issue first so two people do not build the same thing.
-
-The issues tagged [good first issue][gfi] are the same idea, written out: each
-one names the file to open, what done looks like, and the command that proves
-it. Comment on one to claim it, so nobody writes it twice.
-
-[gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
-
-## What happens after you send it
-
-There is one maintainer, so this is a promise about attention, not about speed:
-**a pull request gets a real answer within 48 hours**, even when the answer is
-that it needs another week of thought. A change that is declined is declined
-with the reason, and "What this project will not take" below is there so that
-happens as rarely as possible.
-
-Anyone whose change lands is listed in the release notes it ships in.
+Do not work around `build.sh` by ad-hoc signing. macOS pins those two
+permissions to the code signature, an ad-hoc signature is a different one every
+build, and the result is a bundle that looks built and then silently cannot move
+a window.
 
 ## Sending a change
 
 - Branch off `main`. Nothing is pushed to `main` directly, including by the
   maintainer.
-- Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`.
-  Imperative subject under 72 characters, body only when the why is not obvious.
-  The rule is about the commits on your branch. A pull request with more than
-  one of them is squashed under the pull request title, which is written as a
-  sentence — that is why `git log` on `main` has subjects with no prefix, and
-  not a sign the rule lapsed.
+- **The pull request title is a sentence, and it does not have to be clever.**
+  `fix: nil display UUID after unplug` is a good title. So is `Add a setup page
+  for Windsurf`. The essayistic subjects in `git log` on `main` are one person's
+  habit, not a standard anyone is held to.
+- Conventional commits on your branch: `feat:`, `fix:`, `docs:`, `chore:`,
+  `refactor:`. Imperative subject under 72 characters, body only when the why is
+  not obvious. A pull request with more than one commit is squashed under its
+  title, which is why `main` has subjects with no prefix.
 - One logical change per commit, and `swift build` passes on every one of them.
 - Put new logic somewhere testable. `ZoneGeometry`, `Config`, `ImageFit`,
   `Router` and `ControlServer.parseIfComplete` exist to be reachable without a
-  desktop session; cover what you add in `App/Tests/plonkTests/`.
+  desktop session; cover what you add in `App/Tests/plonkTests/` or `mcp/test/`.
 - A pull request says what changed, why, and which commands you ran.
   Screenshots for anything visual.
 - Match the surrounding code. Swift API design guidelines, comments only for
   constraints that are not obvious from the code, no emoji anywhere including
-  user-facing strings, and user-facing text in English.
+  user-facing strings, and user-facing text in English. `./scripts/lint.sh`
+  checks the part of that a script can check, so style is not something to find
+  out about at review time.
 
 If a change touches the network, the permissions, the entitlements or the update
-path, it makes a claim in `README.md` or `SECURITY.md` false. Fix the document
-in the same commit. Those claims are meant to be checkable from a terminal, and
-that is the only reason they are worth anything.
+path, it makes a claim in `README.md` or `SECURITY.md` false. Fix the document in
+the same commit. Those claims are meant to be checkable from a terminal, and that
+is the only reason they are worth anything.
+
+[AGENTS.md](AGENTS.md) is the long version of all of this: the repo layout, the
+five places a new module touches, which coordinate space each number is in, and
+the mistakes that have already cost someone an hour. It is phrased as
+instructions to an agent because that is what most often reads it, but it is the
+engineering guide either way. Read it before a second change, not before a
+first.
 
 ## Reporting a bug
 
@@ -142,12 +180,17 @@ to hold, which is the useful thing to check a finding against.
 ## What this project will not take
 
 Some directions are settled, and a pull request in them will be declined however
-good it is:
+good it is. This list exists so nobody spends a weekend on one:
 
 - Accounts, cloud sync, telemetry, analytics or crash reporting.
 - Third-party Swift dependencies in `App/`.
 - Any outbound connection other than the existing update check.
 - CORS headers on the local API, or binding it to anything but loopback.
+
+Everything outside that list is open, including things already built. If you
+think a decision here is wrong, the place to say so is a
+[discussion](https://github.com/ostapondo/plonk/discussions), and it will get a
+real answer rather than a link back to this page.
 
 `ROADMAP.md` has the rest, including the features that were considered and
 deliberately left out.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <h1 align="center">Plonk</h1>
 
-<p align="center"><strong>The Mac window manager that puts your desk back together.</strong><br>
-<sub>To plonk is to set a thing down exactly where it belongs. This menu bar does it to your
-windows — you drag them there, you press a key, or your agent says where.</sub></p>
+<p align="center"><strong>The Mac window manager your agent can drive.</strong><br>
+<sub>Snap zones, hotkeys and workspaces, like every other one — and a full MCP
+surface, like none of them. To plonk is to set a thing down exactly where it
+belongs. This menu bar does it to your windows: you drag them there, you press
+a key, or you say where.</sub></p>
 
 <p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-0.1.0-58a6ff?style=flat-square">
@@ -38,23 +40,8 @@ touched it.
 > read the error out of that dialog and tell me what it says
 
 Everything runs on your Mac. No account, no cloud, no telemetry — and
-[none of that is a promise you have to take](#check-it-yourself), it is all
+[none of that is a promise you have to take](docs/verify.md), it is all
 checkable from a terminal.
-
-## What you get
-
-| | |
-| --- | --- |
-| **Zones** | Draw any layout you like, per monitor. Snap by dragging, by number, or by asking. Windows come back to their zone when a display is unplugged and plugged in again |
-| **Workspaces** | A desk you can put away: the apps, every window's frame, the monitor each belongs on, and what each app opens on the way up. Launch it onto an empty desktop and it rebuilds itself |
-| **Focus that follows the layout** | `⌃⌥⇧←` goes to the window that is actually on the left, not the one you used last. `` ⌃⌥` `` cycles the windows stacked in one zone |
-| **Text off the screen** | `⌃⌥T` selects an area and copies the words in it — from a screenshot, a paused video, a dialog that will not let you select. On-device, nothing uploaded |
-| **Pin part of the screen** | Float a live crop of anything above everything else: a build log, a chart, a call, visible in a corner while you work over it |
-| **Keep awake** | Real power assertions, not a jiggler — and a session that ends by itself: after N minutes, at a wall-clock time, or the moment a process exits |
-| **Screenshots** | Region, window or screen, then pen, arrow, rectangle, ellipse and highlighter. Saved at native resolution |
-| **A shortcut guide** | Every shortcut the app in front actually has, read from its own menus, so it is never out of date |
-| **Pointer tools** | Find the cursor, ring every click for a screen recording, crosshairs, jump to the next display |
-| **Voice** | Hold `⌃⌥V` and say it. The common ones — "snap this left", "zone three", "keep awake for an hour", "launch my review workspace" — run in the app itself, offline and instantly; anything bigger goes to your agent. Recognition is on-device |
 
 ## Install
 
@@ -67,6 +54,18 @@ brew install --cask ostapondo/plonk/plonk
 Grant Accessibility when it asks, then relaunch. Screen Recording is asked for
 separately, the first time you capture. Nothing else — no Full Disk Access, no
 Automation, no Keychain.
+
+To let an agent drive it (Node 18+):
+
+```sh
+claude mcp add plonk -- npx -y plonk-mcp   # Claude Code
+codex mcp add plonk -- npx -y plonk-mcp    # Codex CLI
+```
+
+Any MCP client works the same way, over stdio or HTTP.
+[For agents](docs/agents.md) has the rest, plus one-pagers for
+[Cursor](docs/clients/cursor.md), [Zed](docs/clients/zed.md) and
+[Cline](docs/clients/cline.md).
 
 <details>
 <summary><strong>Installing it by hand, and why macOS holds a downloaded copy</strong></summary>
@@ -91,8 +90,8 @@ That prints the commit and the GitHub Actions run this exact archive was built
 by. Apple's stamp would tell you a build passed a malware scan; this tells you
 the binary on your Mac came from the source in this repository, and nothing
 went through a laptop on the way. It is the first of
-[several such checks](#check-it-yourself) — none of what this README claims
-about privacy has to be taken on trust.
+[several such checks](docs/verify.md) — none of what this README claims about
+privacy has to be taken on trust.
 
 Without Homebrew: download [the latest release](https://github.com/ostapondo/plonk/releases/latest),
 unzip, and drop Plonk.app into Applications. Then either do the Gatekeeper
@@ -110,65 +109,38 @@ Remove Plonk from Privacy & Security → Accessibility and grant it again.
 
 </details>
 
-To let an agent drive it (Node 18+):
+## What you get
 
-```sh
-claude mcp add plonk -- npx -y plonk-mcp   # Claude Code
-codex mcp add plonk -- npx -y plonk-mcp    # Codex CLI
-```
+| | |
+| --- | --- |
+| **[Zones](docs/zones.md)** | Draw any layout you like, per monitor. Snap by dragging, by number, or by asking. Windows come back to their zone when a display is unplugged and plugged in again |
+| **[Workspaces](docs/workspaces.md)** | A desk you can put away: the apps, every window's frame, the monitor each belongs on, and what each app opens on the way up. Launch it onto an empty desktop and it rebuilds itself |
+| **Focus that follows the layout** | `⌃⌥⇧←` goes to the window that is actually on the left, not the one you used last. `` ⌃⌥` `` cycles the windows stacked in one zone |
+| **Text off the screen** | `⌃⌥T` selects an area and copies the words in it — from a screenshot, a paused video, a dialog that will not let you select. On-device, nothing uploaded |
+| **Pin part of the screen** | Float a live crop of anything above everything else: a build log, a chart, a call, visible in a corner while you work over it |
+| **Keep awake** | Real power assertions, not a jiggler — and a session that ends by itself: after N minutes, at a wall-clock time, or the moment a process exits |
+| **Screenshots** | Region, window or screen, then pen, arrow, rectangle, ellipse and highlighter. Saved at native resolution |
+| **A shortcut guide** | Every shortcut the app in front actually has, read from its own menus, so it is never out of date |
+| **Pointer tools** | Find the cursor, ring every click for a screen recording, crosshairs, jump to the next display |
+| **Voice** | Hold `⌃⌥V` and say it. The common ones — "snap this left", "zone three", "keep awake for an hour", "launch my review workspace" — run in the app itself, offline and instantly; anything bigger goes to your agent. Recognition is on-device |
 
-The same package carries a `plonk` command for shells and scripts —
-`npm i -g plonk-mcp`, then see [For agents](#for-agents).
-
-Any MCP client works the same way — give it `npx -y plonk-mcp` as a stdio
-server. One-pagers: [Cursor](docs/clients/cursor.md) (with a one-click
-install button), [Zed](docs/clients/zed.md), [Cline](docs/clients/cline.md).
-Several clients at once is fine; see [Agents](#for-agents) below.
-
-A client that cannot spawn a process connects over HTTP instead:
-`npx -y plonk-mcp --http` serves Streamable HTTP at
-`http://127.0.0.1:43918/mcp` (loopback only, many clients per process,
-`--port` to change). That port asks for the same token the app does, so give
-the client an `X-Plonk-Token` header holding the contents of
-`~/Library/Application Support/Plonk/token` — otherwise the transport would be
-a way around the gate rather than through it.
-
-Or build everything from source: clone the repo, run `./scripts/build.sh`, and
-point `claude mcp add plonk -- node …/mcp/dist/server.js` at a locally built
-server (`cd mcp && npm install && npm run build`).
+The long version: [Zones](docs/zones.md) · [Workspaces](docs/workspaces.md) ·
+[Hotkeys](docs/hotkeys.md) · [Everything else](docs/features.md)
 
 ## For agents
 
 This is the part no other Mac window manager has. Plonk exposes its whole
 surface over MCP, so an agent can read the desk, rearrange it, save the result
 and read the screen back — without a screenshot round trip for anything that is
-really just words.
+really just words. Frames are fractions of a monitor's visible area, origin
+top-left, which is why "left 60%" is just `{x: 0, y: 0, w: 0.6, h: 1}`.
 
-Frames are fractions of a monitor's visible area, origin top-left — which is why
-"left 60%" is just `{x: 0, y: 0, w: 0.6, h: 1}`.
+Nineteen tools, across state, layouts, workspaces, zones, keep-awake,
+screenshots and on-device OCR. Several agents can be connected at once, each
+registering itself, with an optional mode that locks changes to the active one.
 
-| Tool | |
-| --- | --- |
-| `get_state` | Monitors, every open window and where it sits, zone sets, saved workspaces, awake status |
-| `apply_layout` | Place any set of windows, across any number of monitors, in one call |
-| `save_workspace` · `launch_workspace` · `delete_workspace` | Named desktops, launched from nothing |
-| `snap_window` | Drop a window into a numbered zone |
-| `save_zone_set` · `assign_zone_set` · `delete_zone_set` | Snap zones, per monitor |
-| `set_awake` | Keep-awake — for N minutes, until a time, or until a process exits |
-| `take_screenshot` · `annotate_screenshot` | Capture, mark up, hand the image back |
-| `extract_text` | Read the words off the screen and hand back text, with a box for every line in the same coordinates `annotate_screenshot` draws in |
-| `select_agent` | Make an agent the user's active one, optionally the only one allowed to control |
-
-Several agents can be connected at once. Every client registers itself, so
-`get_state` lists who is online; the user picks an active agent from the menu
-bar or the settings — or an agent does it with `select_agent`. An optional
-strict mode locks changes to the active agent: everyone else keeps reading
-state and taking screenshots, but gets a clear 409 on anything that moves
-windows or edits config. Set `PLONK_AGENT_NAME` in a client's MCP config to
-tell two sessions of the same client apart.
-
-There is a `plonk` command too, for the things that are neither an agent nor a
-settings window — a Makefile, a Raycast script, a shell alias:
+The same package carries a `plonk` command, for the things that are neither an
+agent nor a settings window — a Makefile, a Raycast script, a shell alias:
 
 ```sh
 plonk state                      # screens, zone sets, workspaces, windows
@@ -177,178 +149,25 @@ plonk awake while npm run build  # awake for exactly as long as the build
 plonk text | pbcopy              # OCR a region straight into the clipboard
 ```
 
-## Zones
+**[For agents](docs/agents.md)** has every tool, the multi-agent rules, the HTTP
+transport and the rest of the CLI.
 
-<p align="center">
-  <img src="docs/zones.svg" alt="A screen split into three zones, with a window being dragged into the highlighted one" width="720">
-</p>
+## Privacy
 
-<p align="center">
-  <img src="docs/zone-sets.svg" alt="Five built-in zone sets and a sixth, irregular one drawn by hand" width="720">
-</p>
-
-Five sets ship with it. Everything past that you draw yourself: any number of
-zones, any size, overlapping if you want — a narrow rail for chat, a wide middle
-split in two, a strip for the terminal. Or describe it and let the agent build
-it.
-
-| | |
-| --- | --- |
-| **Editor** | Click to split, `⇧`-click to split vertically, drag a divider to resize neighbours, `✕` to delete and let them heal over the gap |
-| **Per monitor** | Each screen gets its own set, remembered by display, not by index |
-| **Overlap** | Allowed — the smallest zone under the cursor wins |
-| **Trigger** | On drag, or only with a modifier held. Holding it inverts the mode, so a free move stays one keypress away |
-| **Span** | Hold `⌘` as well: the zone you started over and the one under the cursor become a single drop, so two columns make one wide window without editing the set |
-| **By number** | `⌃⌥1`–`⌃⌥9` drop the front window into the zone the overlay draws that number on. `⌃⌥0` gives it back the frame it had before Plonk first moved it |
-| **Or none** | Edge snapping instead: middles are halves, top is maximize, corners are quarters |
-| **Or hover the line** | Bring the cursor near the border between two zones and both light up, no modifier at all |
-| **Whole sets** | `⌃⌥⇧1`–`⌃⌥⇧9` swap the set on the screen the cursor is on. Windows already sitting in a numbered zone move to where that number is now |
-| **Looks** | Gap, colour, opacity, numbers on or off, every monitor's zones shown while dragging. The gap is real — a window keeps that much space around it |
-| **Exceptions** | A list of apps Plonk keeps its hands off — games, remote desktops, anything that manages its own geometry. Asking an agent to place one still works; that names the window on purpose |
-| **New windows** | Optionally, a window that opens goes where that app's last one went |
-
-## Workspaces
-
-<p align="center">
-  <img src="docs/workspaces.svg" alt="A workspace of four windows, saved, closed to an empty desktop, then launched back into place" width="720">
-</p>
-
-A workspace is a desk you can put away. It remembers the apps, the frame of
-every window, the monitor each one belongs on, and what each app should open on
-the way up. Launching one opens whatever is closed, waits for the windows, and
-puts them back — from the Workspaces page, or right-click the menu bar icon.
-Rename, recapture or delete from the workspace's `⋯` menu.
-
-| | |
-| --- | --- |
-| **Per app** | Files, folders or URLs to open with it: a project folder for an editor, a set of tabs for a browser |
-| **Per monitor** | Windows return to the display they were captured on, keyed by display UUID so unplugging a monitor does not scramble them. Or pull the whole workspace onto one screen |
-| **Already open** | Running apps get moved, not relaunched. Turn that off to leave them alone and only open what is missing |
-| **The catch** | macOS cannot open an app straight into a position, so windows appear first and jump a moment later. A second window of the same app cannot be conjured — give it a file to open instead |
-
-## Hotkeys
-
-<p align="center">
-  <img src="docs/hotkeys.svg" alt="Where each hotkey puts the front window" width="720">
-</p>
-
-<p align="center">
-  All on <code>⌃⌥</code>. Every one of them is rebindable, and any of them can be unbound.
-</p>
-
-| | |
-| --- | --- |
-| `⌃⌥` arrows, `U I J K`, `↩`, `C` | Halves, quarters, maximize, centre |
-| `⌃⌥1`–`⌃⌥9`, `⌃⌥0` | Into a numbered zone, or back where it was |
-| `⌃⌥⇧1`–`⌃⌥⇧9` | Swap the whole zone set on this screen |
-| `⌃⌥⇧` arrows | Focus the window that is actually in that direction |
-| `` ⌃⌥` `` | Next window in this zone |
-| `⌃⌥Z` | Flash the zones |
-| `⌃⌥S` · `⌃⌥T` | Grab a region · lift the text out of one |
-| `⌃⌥P` · `⌃⌥⇧P` | Pin a live crop on top · pin a still one |
-| `⌃⌥⇧/` | Every shortcut the front app has |
-| `⌃⌥/` · `⌃⌥\` | Find the pointer · jump it to the next screen |
-| `⌃⌥V` | Hold to talk |
-
-## And the rest
-
-| | |
-| --- | --- |
-| **Keep awake** | IOKit power assertions, not a jiggler. Display-on or system-only, pause on battery, auto while charging, and a session that ends when you say: after N minutes, at a wall-clock time, or the moment a process exits — `plonk awake while npm run build` holds the Mac up for exactly as long as the build lasts and not a second longer |
-| **Screenshots** | Region, window or screen through the native picker, then pen, arrow, rectangle, ellipse and highlighter. Saves at native resolution |
-| **Text** | `⌃⌥T` selects an area and copies the words in it, including text that is only pixels — a screenshot, a paused video, a PDF that will not let you select. Recognition is on-device; `plonk text \| grep …` works too |
-| **Pinned crops** | `⌃⌥P` drags out a region and floats it above everything, mirroring whatever is underneath. `⌃⌥⇧P` freezes it instead. Streamed, never written down |
-| **Shortcut guide** | `⌃⌥⇧/` lists every shortcut the front app has, read from its own menus rather than from a table someone has to keep up to date |
-| **Pointer** | Find the cursor, ring every click for a screen recording, crosshairs, and a key that warps the pointer to the next display |
-| **Grab and move** | Hold a key and drag a window from anywhere inside it; right-drag resizes from the nearest edge. Off by default, because option-drag already means something in plenty of apps |
-| **Notices** | A panel in the top-right corner, not Notification Center: no permission to ask for, nothing left in your history, and it can show the screenshot instead of describing it |
-| **Updates** | One button on the Updates page. The download is checked against the checksum GitHub published for it before it is unpacked, and Plonk installs a build only if it is signed with the same certificate as the copy you are running — the same test macOS applies, so your Accessibility and Screen Recording grants carry over instead of being asked for again. Anything that fails is discarded and nothing is replaced. Switch the check off and the app never looks |
-
-## Check it yourself
-
-Accessibility is the only way macOS lets one app move another's windows, and
-Screen Recording is what a screenshot costs. That is a lot to hand something you
-installed a minute ago, so none of this is a promise — it is all checkable.
-
-**The binary comes from the source.** Releases are built, signed and zipped by
-[a workflow](.github/workflows/release.yml) on GitHub's runners, never on a
-laptop, and ship with a provenance attestation GitHub signs:
+Everything runs on your Mac, and none of it is a promise you have to take. The
+API binds to `127.0.0.1`, refuses anything carrying headers a browser cannot
+suppress, and is gated on a token only you can read. The one outbound connection
+is the update check, which carries no identifier and can be switched off.
+Releases are built and signed on GitHub's runners and ship with an attestation,
+so the binary on your Mac can be tied to the commit it came from:
 
 ```sh
 gh attestation verify Plonk-<version>.zip -R ostapondo/plonk
 ```
 
-That prints the commit and the workflow run the archive was built by. It is the
-step that makes reading the rest of this repo worth anything — without it, the
-code here and the app on your Mac are two separate claims. (Releases up to and
-including 0.0.4 were zipped by hand and carry no attestation, so the command
-fails on those. That is the whole reason it exists now.)
-
-The MCP server is published the same way, which matters more, because `npx -y
-plonk-mcp` fetches it every time: `npm view plonk-mcp dist.attestations`, or the
-Provenance panel on [its npm page](https://www.npmjs.com/package/plonk-mcp).
-
-**One thing dials out, and you can switch it off.** Every socket the app has
-open:
-
-```sh
-lsof -nP -i -a -p "$(pgrep -f 'Plonk.app/Contents/MacOS/plonk')"
-plonk  …  TCP 127.0.0.1:43917 (LISTEN)
-```
-
-One listener on loopback. The only outbound connection Plonk makes is the
-update check: on launch and once a day it asks `api.github.com` for the latest
-release, and sends nothing but a User-Agent naming the app and its version — no
-identifier, no account, no analytics, no crash reporter. Turn it off under
-Updates and it stops happening — including for agents, which get a 409 rather
-than a connection made on your behalf, so the buttons on that page are the only
-thing that can trigger one. `nettop` or Little Snitch will then show a process
-that only ever listens. The URLs compiled into the app are that endpoint, the
-releases page, and the issue tracker that opens when you click Report a bug —
-[Release.swift](App/Sources/plonk/Release.swift) has all three.
-
-**A web page cannot drive it.** The API is loopback-only, so it refuses anything
-carrying headers a browser cannot suppress:
-
-```sh
-curl -so /dev/null -w '%{http_code}\n' -H 'Origin: https://example.com' \
-  http://127.0.0.1:43917/state
-403
-```
-
-**Neither can another program on your Mac.** Loopback keeps the network out and
-does nothing about the machine, so the API is gated on a token Plonk writes to
-`~/Library/Application Support/Plonk/token`, readable by you and nobody else.
-The MCP server and the `plonk` command read it for themselves; you never handle
-it. Without it, a request gets a 401:
-
-```sh
-curl -so /dev/null -w '%{http_code}\n' http://127.0.0.1:43917/state
-401
-curl -so /dev/null -w '%{http_code}\n' \
-  -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
-  http://127.0.0.1:43917/state
-200
-```
-
-This matters most for the screenshot routes. Plonk holds Screen Recording; a
-script running as you may well not, and before the token it could borrow
-Plonk's by asking the port. Where it stops: anything that can read that file
-can read your screen by asking macOS itself, so this is a fence around the
-port, not around your account.
-
-**There is not much else to hide.** [Package.swift](App/Package.swift) declares
-no third-party dependencies, so a build from source is this repo and nothing
-else. Config is plain JSON at `~/Library/Application Support/Plonk/config.json`.
-Screenshots go where you send them. There is no account to make.
-
-The MCP server is a separate npm package that depends only on the official MCP
-SDK and zod. It speaks to `127.0.0.1:43917` and nowhere else.
-
-[SECURITY.md](SECURITY.md) has the rest: the entitlements the bundle ships with
-(none), every step the updater takes before it replaces anything, what the
-signing certificate does and does not prove, and where each of these checks
-stops being one.
+**[Check it yourself](docs/verify.md)** is every one of those claims with the
+command that tests it, and [SECURITY.md](SECURITY.md) is where each of them
+stops.
 
 ## Under the hood
 
@@ -357,9 +176,7 @@ stops being one.
 </p>
 
 - The app is the single source of truth; the MCP server is a stateless bridge.
-- The API binds to `127.0.0.1` and refuses anything carrying browser headers, so
-  an open web page cannot drive your desktop — see
-  [Check it yourself](#check-it-yourself).
+- `App/` is the Swift menu bar app, `mcp/` the TypeScript MCP server.
 - Config is plain JSON at `~/Library/Application Support/Plonk/config.json`.
 
 ## Build
@@ -369,92 +186,45 @@ line is a subshell, so paste the block from the repository root and it works:
 
 ```sh
 (cd App && swift build)                    # the app compiles
-./scripts/test.sh                          # 306 unit tests
-(cd mcp && npm ci && npm run typecheck)    # the MCP server
-node scripts/check-zone-sets.mjs           # the layouts in zone-sets/
+./scripts/test.sh                          # the unit suite
+./scripts/lint.sh                          # style rules, no dependencies
+(cd mcp && npm ci && npm test)             # the MCP server
 ```
 
 None of that needs a signing certificate. Zone geometry, config decoding, HTTP
 routing, MCP tools, voice command parsing, the CLI and every document here are
 reachable from that loop, and most changes never need more.
 
-`App/` is the Swift menu bar app, `mcp/` the TypeScript MCP server. Point an
-agent at [AGENTS.md](AGENTS.md) before it touches either, and read
-[CONTRIBUTING.md](CONTRIBUTING.md) before you send a change.
-
-Producing a launchable `Plonk.app` is the one step that does need a certificate.
-Make your own once:
-
-```sh
-./scripts/make-signing-cert.sh   # creates one and prints how to trust it
-./scripts/build.sh               # produces Plonk.app
-```
-
-`build.sh` signs with a `Plonk Signing` identity and stops if it is missing.
-macOS ties Accessibility and Screen Recording to the signature, and an ad-hoc
-one changes every build, so a stable certificate is what stops rebuilds from
-resetting permissions. [scripts/make-signing-cert.sh](scripts/make-signing-cert.sh)
-creates one and prints how to import and trust it; set `PLONK_SIGN_IDENTITY` to
-sign with a different one.
-
-It writes a `.p12` rather than adding a certificate to the keychain directly,
-which looks like the long way round until you need the key somewhere else: a
-key created by Certificate Assistant cannot be exported except through the
-Keychain Access window, and the release workflow needs it as a file it can put
-in a secret. Keep that `.p12` somewhere safe. Every installed copy accepts an
-update only if it is signed with that key, and there is nobody to reissue it.
-
-If a permission was first granted while the app was ad-hoc signed, the old
-grant is pinned to a signature that no longer exists and every rebuild looks
-like a reset. Clear it once and grant again:
-
-```sh
-tccutil reset ScreenCapture dev.plonk.app
-tccutil reset Accessibility dev.plonk.app
-```
-
-Releases: bump `MARKETING_VERSION` and `BUILD_NUMBER` in
-[version.env](version.env) and `version` in `mcp/package.json`, then push a
-`v<version>` tag. [The release workflow](.github/workflows/release.yml) builds,
-signs and attests the app on GitHub's runners, uploads the zip to a draft
-release, and publishes the MCP server to npm with provenance. Nothing ships from
-a laptop, which is what makes `gh attestation verify` mean anything.
-
-`scripts/release.sh` is what that workflow runs, and it works locally too. It
-holds every build to the requirement in
-[scripts/release-requirement](scripts/release-requirement) — a release signed
-with anything else cannot be updated to and takes Accessibility and Screen
-Recording away from everyone who installs it by hand. It notarizes when a
-Developer ID certificate is in the keychain and says so when there is not;
-Plonk's releases are not notarized, which costs a paid Apple account.
+Producing a launchable `Plonk.app` is the one step that does need one. Make your
+own once with `./scripts/make-signing-cert.sh`, then `./scripts/build.sh`. macOS
+ties Accessibility and Screen Recording to the code signature, and an ad-hoc one
+changes every build, so a stable certificate is what stops rebuilds from
+resetting permissions. [CONTRIBUTING.md](CONTRIBUTING.md) has the details;
+[AGENTS.md](AGENTS.md) has the release process, which runs on GitHub's runners
+and never from a laptop.
 
 ## Contributing
 
 Bug reports, zone sets, client one-pagers and code are all welcome, and none of
 them need a signing certificate — the loop above is the whole requirement.
-[CONTRIBUTING.md](CONTRIBUTING.md) has the rest: what a window bug report has to
-carry to be reproducible, where a new module seams in, and the handful of
-directions this project will not take, so nobody writes a patch that was never
-going to land.
-
-The smallest useful change here is one JSON file. [`zone-sets/`](zone-sets/) is
-a gallery of layouts worth copying — an ultrawide split, a rotated monitor, the
-one built around a recurring meeting. Draw it in the app, read the numbers out
-of `plonk state --json`, open a pull request; that folder has its own CI job and
-answers in about twenty seconds. Nothing to build, nothing to sign, no Swift.
+[CONTRIBUTING.md](CONTRIBUTING.md) opens with a first change you can send in
+about fifteen minutes, and says how long a review takes.
 
 The issues tagged [good first issue][gfi] are written to be picked up cold —
-each one says where the code is and how to tell it worked, and carries a prompt
-you can hand straight to an agent, since [AGENTS.md](AGENTS.md) already tells
-one how this repo is put together. Questions, half-formed ideas and layouts
-worth showing off go to
+each one says where the code is and how to tell it worked. The ones tagged
+[needs-hardware][hw] need neither Swift nor a certificate, and are the most
+useful thing anyone can send: a window manager breaks on arrangements the author
+cannot see, and a report from three monitors or an ultrawide is worth more than
+a patch.
+
+Questions, half-formed ideas and layouts worth showing off go to
 [Discussions](https://github.com/ostapondo/plonk/discussions); a security
 problem goes through [SECURITY.md](SECURITY.md) instead of a public issue.
-
 Everyone taking part is expected to follow the
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
 [gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[hw]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-hardware
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ stops.
 
 ## Build
 
-Four commands, and they are exactly what CI runs on every pull request. Each
+Five commands, and they are exactly what CI runs on every pull request. Each
 line is a subshell, so paste the block from the repository root and it works:
 
 ```sh
@@ -189,6 +189,7 @@ line is a subshell, so paste the block from the repository root and it works:
 ./scripts/test.sh                          # the unit suite
 ./scripts/lint.sh                          # style rules, no dependencies
 (cd mcp && npm ci && npm test)             # the MCP server
+node scripts/check-zone-sets.mjs           # the layouts in zone-sets/
 ```
 
 None of that needs a signing certificate. Zone geometry, config decoding, HTTP
@@ -210,12 +211,19 @@ them need a signing certificate — the loop above is the whole requirement.
 [CONTRIBUTING.md](CONTRIBUTING.md) opens with a first change you can send in
 about fifteen minutes, and says how long a review takes.
 
+The smallest useful change here is one JSON file. [`zone-sets/`](zone-sets/) is
+a gallery of layouts worth copying — an ultrawide split, a rotated monitor, the
+one built around a recurring meeting. Draw it in the app, read the numbers out
+of `plonk state --json`, open a pull request; that folder has its own CI job and
+answers in about twenty seconds. Nothing to build, nothing to sign, no Swift.
+
 The issues tagged [good first issue][gfi] are written to be picked up cold —
-each one says where the code is and how to tell it worked. The ones tagged
-[needs-hardware][hw] need neither Swift nor a certificate, and are the most
-useful thing anyone can send: a window manager breaks on arrangements the author
-cannot see, and a report from three monitors or an ultrawide is worth more than
-a patch.
+each one says where the code is and how to tell it worked, and carries a prompt
+you can hand straight to an agent, since [AGENTS.md](AGENTS.md) already tells
+one how this repo is put together. The ones tagged [needs-hardware][hw] need
+neither Swift nor a certificate, and are the most useful thing anyone can send:
+a window manager breaks on arrangements the author cannot see, and a report
+from three monitors or an ultrawide is worth more than a patch.
 
 Questions, half-formed ideas and layouts worth showing off go to
 [Discussions](https://github.com/ostapondo/plonk/discussions); a security

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,68 @@
+# For agents
+
+This is the part no other Mac window manager has. Plonk exposes its whole
+surface over MCP, so an agent can read the desk, rearrange it, save the result
+and read the screen back — without a screenshot round trip for anything that is
+really just words.
+
+Frames are fractions of a monitor's visible area, origin top-left — which is why
+"left 60%" is just `{x: 0, y: 0, w: 0.6, h: 1}`.
+
+## The tools
+
+| Tool | |
+| --- | --- |
+| `get_state` | Monitors, every open window and where it sits, zone sets, saved workspaces, awake status |
+| `apply_layout` | Place any set of windows, across any number of monitors, in one call |
+| `save_workspace` · `launch_workspace` · `delete_workspace` | Named desktops, launched from nothing |
+| `snap_window` | Drop a window into a numbered zone |
+| `save_zone_set` · `assign_zone_set` · `delete_zone_set` | Snap zones, per monitor |
+| `set_awake` | Keep-awake — for N minutes, until a time, or until a process exits |
+| `take_screenshot` · `annotate_screenshot` | Capture, mark up, hand the image back |
+| `extract_text` | Read the words off the screen and hand back text, with a box for every line in the same coordinates `annotate_screenshot` draws in |
+| `select_agent` | Make an agent the user's active one, optionally the only one allowed to control |
+
+## Several agents at once
+
+Every client registers itself, so `get_state` lists who is online; the user
+picks an active agent from the menu bar or the settings — or an agent does it
+with `select_agent`. An optional strict mode locks changes to the active agent:
+everyone else keeps reading state and taking screenshots, but gets a clear 409
+on anything that moves windows or edits config. Set `PLONK_AGENT_NAME` in a
+client's MCP config to tell two sessions of the same client apart.
+
+## Connecting
+
+```sh
+claude mcp add plonk -- npx -y plonk-mcp   # Claude Code
+codex mcp add plonk -- npx -y plonk-mcp    # Codex CLI
+```
+
+Any MCP client works the same way — give it `npx -y plonk-mcp` as a stdio
+server. One-pagers: [Cursor](clients/cursor.md) (with a one-click install
+button), [Zed](clients/zed.md), [Cline](clients/cline.md).
+
+A client that cannot spawn a process connects over HTTP instead:
+`npx -y plonk-mcp --http` serves Streamable HTTP at
+`http://127.0.0.1:43918/mcp` (loopback only, many clients per process,
+`--port` to change). That port asks for the same token the app does, so give
+the client an `X-Plonk-Token` header holding the contents of
+`~/Library/Application Support/Plonk/token` — otherwise the transport would be
+a way around the gate rather than through it.
+
+## From a shell
+
+The same package carries a `plonk` command, for the things that are neither an
+agent nor a settings window — a Makefile, a Raycast script, a shell alias.
+`npm i -g plonk-mcp`, then:
+
+```sh
+plonk state                      # screens, zone sets, workspaces, windows
+plonk launch review              # a saved workspace
+plonk awake while npm run build  # awake for exactly as long as the build
+plonk text | pbcopy              # OCR a region straight into the clipboard
+```
+
+---
+
+[README](../README.md) · [Check it yourself](verify.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,19 @@
+# Everything else
+
+The parts that are not zones, workspaces or hotkeys.
+
+| | |
+| --- | --- |
+| **Keep awake** | IOKit power assertions, not a jiggler. Display-on or system-only, pause on battery, auto while charging, and a session that ends when you say: after N minutes, at a wall-clock time, or the moment a process exits — `plonk awake while npm run build` holds the Mac up for exactly as long as the build lasts and not a second longer |
+| **Screenshots** | Region, window or screen through the native picker, then pen, arrow, rectangle, ellipse and highlighter. Saves at native resolution |
+| **Text** | `⌃⌥T` selects an area and copies the words in it, including text that is only pixels — a screenshot, a paused video, a PDF that will not let you select. Recognition is on-device; `plonk text \| grep …` works too |
+| **Pinned crops** | `⌃⌥P` drags out a region and floats it above everything, mirroring whatever is underneath. `⌃⌥⇧P` freezes it instead. Streamed, never written down |
+| **Shortcut guide** | `⌃⌥⇧/` lists every shortcut the front app has, read from its own menus rather than from a table someone has to keep up to date |
+| **Pointer** | Find the cursor, ring every click for a screen recording, crosshairs, and a key that warps the pointer to the next display |
+| **Grab and move** | Hold a key and drag a window from anywhere inside it; right-drag resizes from the nearest edge. Off by default, because option-drag already means something in plenty of apps |
+| **Notices** | A panel in the top-right corner, not Notification Center: no permission to ask for, nothing left in your history, and it can show the screenshot instead of describing it |
+| **Updates** | One button on the Updates page. The download is checked against the checksum GitHub published for it before it is unpacked, and Plonk installs a build only if it is signed with the same certificate as the copy you are running — the same test macOS applies, so your Accessibility and Screen Recording grants carry over instead of being asked for again. Anything that fails is discarded and nothing is replaced. Switch the check off and the app never looks |
+
+---
+
+[Zones](zones.md) · [Workspaces](workspaces.md) · [Hotkeys](hotkeys.md) · [README](../README.md)

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -1,0 +1,27 @@
+# Hotkeys
+
+<p align="center">
+  <img src="hotkeys.svg" alt="Where each hotkey puts the front window" width="720">
+</p>
+
+<p align="center">
+  All on <code>⌃⌥</code>. Every one of them is rebindable, and any of them can be unbound.
+</p>
+
+| | |
+| --- | --- |
+| `⌃⌥` arrows, `U I J K`, `↩`, `C` | Halves, quarters, maximize, centre |
+| `⌃⌥1`–`⌃⌥9`, `⌃⌥0` | Into a numbered zone, or back where it was |
+| `⌃⌥⇧1`–`⌃⌥⇧9` | Swap the whole zone set on this screen |
+| `⌃⌥⇧` arrows | Focus the window that is actually in that direction |
+| `` ⌃⌥` `` | Next window in this zone |
+| `⌃⌥Z` | Flash the zones |
+| `⌃⌥S` · `⌃⌥T` | Grab a region · lift the text out of one |
+| `⌃⌥P` · `⌃⌥⇧P` | Pin a live crop on top · pin a still one |
+| `⌃⌥⇧/` | Every shortcut the front app has |
+| `⌃⌥/` · `⌃⌥\` | Find the pointer · jump it to the next screen |
+| `⌃⌥V` | Hold to talk |
+
+---
+
+[Zones](zones.md) · [Workspaces](workspaces.md) · [Everything else](features.md) · [README](../README.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -181,7 +181,7 @@
       <a class="ghost" href="https://github.com/ostapondo/plonk/releases/latest">Download .zip</a>
     </div>
     <p class="fine">Signed, built and attested on GitHub's runners —
-      <a href="https://github.com/ostapondo/plonk#check-it-yourself">check the binary against the commit</a>
+      <a href="https://github.com/ostapondo/plonk/blob/main/docs/verify.md">check the binary against the commit</a>
       before you open it.</p>
   </div>
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -1,0 +1,97 @@
+# Check it yourself
+
+Accessibility is the only way macOS lets one app move another's windows, and
+Screen Recording is what a screenshot costs. That is a lot to hand something you
+installed a minute ago, so none of this is a promise — it is all checkable.
+
+## The binary comes from the source
+
+Releases are built, signed and zipped by
+[a workflow](../.github/workflows/release.yml) on GitHub's runners, never on a
+laptop, and ship with a provenance attestation GitHub signs:
+
+```sh
+gh attestation verify Plonk-<version>.zip -R ostapondo/plonk
+```
+
+That prints the commit and the workflow run the archive was built by. It is the
+step that makes reading the rest of this repo worth anything — without it, the
+code here and the app on your Mac are two separate claims. (Releases up to and
+including 0.0.4 were zipped by hand and carry no attestation, so the command
+fails on those. That is the whole reason it exists now.)
+
+The MCP server is published the same way, which matters more, because `npx -y
+plonk-mcp` fetches it every time: `npm view plonk-mcp dist.attestations`, or the
+Provenance panel on [its npm page](https://www.npmjs.com/package/plonk-mcp).
+
+## One thing dials out, and you can switch it off
+
+Every socket the app has open:
+
+```sh
+lsof -nP -i -a -p "$(pgrep -f 'Plonk.app/Contents/MacOS/plonk')"
+plonk  …  TCP 127.0.0.1:43917 (LISTEN)
+```
+
+One listener on loopback. The only outbound connection Plonk makes is the
+update check: on launch and once a day it asks `api.github.com` for the latest
+release, and sends nothing but a User-Agent naming the app and its version — no
+identifier, no account, no analytics, no crash reporter. Turn it off under
+Updates and it stops happening — including for agents, which get a 409 rather
+than a connection made on your behalf, so the buttons on that page are the only
+thing that can trigger one. `nettop` or Little Snitch will then show a process
+that only ever listens. The URLs compiled into the app are that endpoint, the
+releases page, and the issue tracker that opens when you click Report a bug —
+[Release.swift](../App/Sources/plonk/Release.swift) has all three.
+
+## A web page cannot drive it
+
+The API is loopback-only, so it refuses anything carrying headers a browser
+cannot suppress:
+
+```sh
+curl -so /dev/null -w '%{http_code}\n' -H 'Origin: https://example.com' \
+  http://127.0.0.1:43917/state
+403
+```
+
+## Neither can another program on your Mac
+
+Loopback keeps the network out and does nothing about the machine, so the API is
+gated on a token Plonk writes to `~/Library/Application Support/Plonk/token`,
+readable by you and nobody else. The MCP server and the `plonk` command read it
+for themselves; you never handle it. Without it, a request gets a 401:
+
+```sh
+curl -so /dev/null -w '%{http_code}\n' http://127.0.0.1:43917/state
+401
+curl -so /dev/null -w '%{http_code}\n' \
+  -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
+  http://127.0.0.1:43917/state
+200
+```
+
+This matters most for the screenshot routes. Plonk holds Screen Recording; a
+script running as you may well not, and before the token it could borrow
+Plonk's by asking the port. Where it stops: anything that can read that file
+can read your screen by asking macOS itself, so this is a fence around the
+port, not around your account.
+
+## There is not much else to hide
+
+[Package.swift](../App/Package.swift) declares no third-party dependencies, so a
+build from source is this repo and nothing else. Config is plain JSON at
+`~/Library/Application Support/Plonk/config.json`. Screenshots go where you send
+them. There is no account to make.
+
+The MCP server is a separate npm package that depends only on the official MCP
+SDK and zod. It speaks to `127.0.0.1:43917` and nowhere else.
+
+[SECURITY.md](../SECURITY.md) has the rest: the entitlements the bundle ships
+with (none), every step the updater takes before it replaces anything, what the
+signing certificate does and does not prove, and where each of these checks
+stops being one.
+
+---
+
+[README](../README.md) · [SECURITY.md](../SECURITY.md)

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,22 @@
+# Workspaces
+
+<p align="center">
+  <img src="workspaces.svg" alt="A workspace of four windows, saved, closed to an empty desktop, then launched back into place" width="720">
+</p>
+
+A workspace is a desk you can put away. It remembers the apps, the frame of
+every window, the monitor each one belongs on, and what each app should open on
+the way up. Launching one opens whatever is closed, waits for the windows, and
+puts them back — from the Workspaces page, or right-click the menu bar icon.
+Rename, recapture or delete from the workspace's `⋯` menu.
+
+| | |
+| --- | --- |
+| **Per app** | Files, folders or URLs to open with it: a project folder for an editor, a set of tabs for a browser |
+| **Per monitor** | Windows return to the display they were captured on, keyed by display UUID so unplugging a monitor does not scramble them. Or pull the whole workspace onto one screen |
+| **Already open** | Running apps get moved, not relaunched. Turn that off to leave them alone and only open what is missing |
+| **The catch** | macOS cannot open an app straight into a position, so windows appear first and jump a moment later. A second window of the same app cannot be conjured — give it a file to open instead |
+
+---
+
+[Zones](zones.md) · [Hotkeys](hotkeys.md) · [Everything else](features.md) · [README](../README.md)

--- a/docs/zones.md
+++ b/docs/zones.md
@@ -1,0 +1,33 @@
+# Zones
+
+<p align="center">
+  <img src="zones.svg" alt="A screen split into three zones, with a window being dragged into the highlighted one" width="720">
+</p>
+
+<p align="center">
+  <img src="zone-sets.svg" alt="Five built-in zone sets and a sixth, irregular one drawn by hand" width="720">
+</p>
+
+Five sets ship with it. Everything past that you draw yourself: any number of
+zones, any size, overlapping if you want — a narrow rail for chat, a wide middle
+split in two, a strip for the terminal. Or describe it and let the agent build
+it.
+
+| | |
+| --- | --- |
+| **Editor** | Click to split, `⇧`-click to split vertically, drag a divider to resize neighbours, `✕` to delete and let them heal over the gap |
+| **Per monitor** | Each screen gets its own set, remembered by display, not by index |
+| **Overlap** | Allowed — the smallest zone under the cursor wins |
+| **Trigger** | On drag, or only with a modifier held. Holding it inverts the mode, so a free move stays one keypress away |
+| **Span** | Hold `⌘` as well: the zone you started over and the one under the cursor become a single drop, so two columns make one wide window without editing the set |
+| **By number** | `⌃⌥1`–`⌃⌥9` drop the front window into the zone the overlay draws that number on. `⌃⌥0` gives it back the frame it had before Plonk first moved it |
+| **Or none** | Edge snapping instead: middles are halves, top is maximize, corners are quarters |
+| **Or hover the line** | Bring the cursor near the border between two zones and both light up, no modifier at all |
+| **Whole sets** | `⌃⌥⇧1`–`⌃⌥⇧9` swap the set on the screen the cursor is on. Windows already sitting in a numbered zone move to where that number is now |
+| **Looks** | Gap, colour, opacity, numbers on or off, every monitor's zones shown while dragging. The gap is real — a window keeps that much space around it |
+| **Exceptions** | A list of apps Plonk keeps its hands off — games, remote desktops, anything that manages its own geometry. Asking an agent to place one still works; that names the window on purpose |
+| **New windows** | Optionally, a window that opens goes where that app's last one went |
+
+---
+
+[Workspaces](workspaces.md) · [Hotkeys](hotkeys.md) · [Everything else](features.md) · [README](../README.md)

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc && node --test test/*.test.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/src/args.ts
+++ b/mcp/src/args.ts
@@ -1,0 +1,36 @@
+// Argument parsing for the `plonk` command, kept out of cli.ts so it can be
+// tested without running the CLI: importing cli.ts runs it.
+
+export interface ParsedArgs {
+  flags: Record<string, string>;
+  rest: string[];
+}
+
+/**
+ * Pulls "--name value" out of argv and returns what is left, in order.
+ *
+ * A flag with nothing usable after it — the end of argv, or another flag — is
+ * a switch and reads as "true", so `--json` and `--screen 1` parse the same
+ * way. Values are not converted here; the caller knows which of its flags are
+ * numbers and says so in the error when one is not.
+ */
+export function options(argv: string[]): ParsedArgs {
+  const flags: Record<string, string> = {};
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        flags[key] = "true";
+      } else {
+        flags[key] = next;
+        i++;
+      }
+    } else {
+      rest.push(arg);
+    }
+  }
+  return { flags, rest };
+}

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -6,6 +6,7 @@
 // every subcommand is one HTTP call to 127.0.0.1, and nothing here holds state.
 import { spawn } from "node:child_process";
 import { BASE, call, processIdentityHolder, type State } from "./api.js";
+import { options } from "./args.js";
 
 const USAGE = `plonk — drive the Plonk menu bar app from a shell
 
@@ -22,28 +23,6 @@ const USAGE = `plonk — drive the Plonk menu bar app from a shell
   plonk shot [--mode region|window|screen] [--path FILE]
 
 Everything talks to ${BASE}; Plonk.app has to be running.`;
-
-/** Pulls "--name value" out of argv and returns what is left. */
-function options(argv: string[]): { flags: Record<string, string>; rest: string[] } {
-  const flags: Record<string, string> = {};
-  const rest: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2);
-      const next = argv[i + 1];
-      if (next === undefined || next.startsWith("--")) {
-        flags[key] = "true";
-      } else {
-        flags[key] = next;
-        i++;
-      }
-    } else {
-      rest.push(arg);
-    }
-  }
-  return { flags, rest };
-}
 
 /** Unwinds to the top instead of calling process.exit, which on a pipe cuts
  * stdout off mid-write: `plonk state --json | jq` would get invalid JSON.

--- a/mcp/test/api.test.js
+++ b/mcp/test/api.test.js
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  text,
+  agentIdentityName,
+  runWithIdentity,
+  processIdentityHolder,
+} from "../dist/api.js";
+
+test("a reply carrying an error is flagged as one", () => {
+  // Without isError the model reads a refusal as a successful call and carries
+  // on as if the window had moved.
+  const result = text({ error: "Plonk menu bar app is not running." });
+  assert.equal(result.isError, true);
+});
+
+test("an ordinary reply is not flagged", () => {
+  const result = text({ ok: true, moved: 3 });
+  assert.equal(result.isError, undefined);
+});
+
+test("a reply is handed back as readable JSON", () => {
+  const result = text({ ok: true });
+  assert.equal(result.content[0].type, "text");
+  assert.deepEqual(JSON.parse(result.content[0].text), { ok: true });
+});
+
+test("an identity is visible to everything inside its holder", () => {
+  runWithIdentity({ identity: { name: "claude-code", version: "1.0", pid: 1 } }, () => {
+    assert.equal(agentIdentityName(), "claude-code");
+  });
+});
+
+test("one session's identity does not leak into another", () => {
+  // Every HTTP session runs in its own holder. If one could see another's
+  // name, exclusive mode would gate on whoever connected last.
+  runWithIdentity({ identity: { name: "first", version: "", pid: 1 } }, () => {
+    runWithIdentity({ identity: { name: "second", version: "", pid: 2 } }, () => {
+      assert.equal(agentIdentityName(), "second");
+    });
+    assert.equal(agentIdentityName(), "first");
+  });
+});
+
+test("an unidentified caller has no name rather than borrowing one", () => {
+  runWithIdentity({}, () => {
+    assert.equal(agentIdentityName(), "");
+  });
+});
+
+test("the process-wide holder is the one stdio fills", () => {
+  const holder = processIdentityHolder();
+  assert.equal(holder, processIdentityHolder());
+  holder.identity = { name: "plonk-cli", version: "", pid: 7 };
+  try {
+    assert.equal(agentIdentityName(), "plonk-cli");
+  } finally {
+    holder.identity = undefined;
+  }
+});

--- a/mcp/test/args.test.js
+++ b/mcp/test/args.test.js
@@ -1,0 +1,45 @@
+// Run against the compiled output, so what is tested is what ships.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { options } from "../dist/args.js";
+
+test("keeps positional arguments in order", () => {
+  const { flags, rest } = options(["snap", "Safari", "1"]);
+  assert.deepEqual(rest, ["snap", "Safari", "1"]);
+  assert.deepEqual(flags, {});
+});
+
+test("takes the word after a flag as its value", () => {
+  const { flags, rest } = options(["launch", "review", "--screen", "1"]);
+  assert.equal(flags.screen, "1");
+  assert.deepEqual(rest, ["launch", "review"]);
+});
+
+test("a flag at the end of argv is a switch", () => {
+  assert.equal(options(["state", "--json"]).flags.json, "true");
+});
+
+test("a flag followed by another flag is a switch, not its value", () => {
+  const { flags } = options(["shot", "--json", "--mode", "window"]);
+  assert.equal(flags.json, "true");
+  assert.equal(flags.mode, "window");
+});
+
+test("a flag value is not mistaken for a positional argument", () => {
+  // --screen 1 must not leave "1" in rest, or `plonk zones --screen 1 thirds`
+  // would assign the set named "1".
+  const { rest } = options(["zones", "--screen", "1", "thirds"]);
+  assert.deepEqual(rest, ["zones", "thirds"]);
+});
+
+test("a negative number is a value, not a flag", () => {
+  assert.equal(options(["awake", "on", "--minutes", "-1"]).flags.minutes, "-1");
+});
+
+test("the last spelling of a repeated flag wins", () => {
+  assert.equal(options(["--mode", "region", "--mode", "screen"]).flags.mode, "screen");
+});
+
+test("empty argv parses to nothing", () => {
+  assert.deepEqual(options([]), { flags: {}, rest: [] });
+});

--- a/mcp/test/schemas.test.js
+++ b/mcp/test/schemas.test.js
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { frameSchema, itemsSchema, zonesSchema, workspaceItemsSchema } from "../dist/schemas.js";
+
+// Frames are fractions of a monitor's visible area, origin top-left. The
+// bounds are the whole reason an agent can say "left 60%" without knowing how
+// many pixels wide the screen is.
+test("a frame is a fraction of the screen", () => {
+  assert.equal(frameSchema.safeParse({ x: 0, y: 0, w: 0.6, h: 1 }).success, true);
+});
+
+test("a frame in pixels is refused", () => {
+  // The mistake an agent actually makes: passing points instead of fractions.
+  assert.equal(frameSchema.safeParse({ x: 0, y: 0, w: 1440, h: 900 }).success, false);
+});
+
+test("a frame off the top or left of the screen is refused", () => {
+  assert.equal(frameSchema.safeParse({ x: -0.1, y: 0, w: 0.5, h: 1 }).success, false);
+});
+
+test("a frame missing a side is refused", () => {
+  assert.equal(frameSchema.safeParse({ x: 0, y: 0, w: 0.5 }).success, false);
+});
+
+test("a layout places at least one window", () => {
+  assert.equal(itemsSchema.safeParse([]).success, false);
+});
+
+test("a layout item needs an app and a frame", () => {
+  const ok = itemsSchema.safeParse([{ app: "Safari", frame: { x: 0, y: 0, w: 0.5, h: 1 } }]);
+  assert.equal(ok.success, true);
+  assert.equal(itemsSchema.safeParse([{ frame: { x: 0, y: 0, w: 0.5, h: 1 } }]).success, false);
+});
+
+test("a zone set is not empty", () => {
+  assert.equal(zonesSchema.safeParse([]).success, false);
+  assert.equal(zonesSchema.safeParse([{ x: 0, y: 0, w: 0.5, h: 1 }]).success, true);
+});
+
+test("a workspace item carries what it takes to launch the app again", () => {
+  const item = {
+    app: "Visual Studio Code",
+    bundle_id: "com.microsoft.VSCode",
+    screen_uuid: "37D8832A-2D66-02CA-B9F7-8F30A301B230",
+    frame: { x: 0, y: 0, w: 0.5, h: 1 },
+    urls: ["/Users/me/project"],
+  };
+  assert.equal(workspaceItemsSchema.safeParse([item]).success, true);
+});
+
+test("a workspace item with a pixel frame is refused", () => {
+  const item = { app: "Safari", frame: { x: 0, y: 0, w: 1440, h: 900 } };
+  assert.equal(workspaceItemsSchema.safeParse([item]).success, false);
+});

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -1,0 +1,22 @@
+# Files that were already over the 300-line limit when scripts/lint.sh went in,
+# with the length each had that day. A file listed here may shrink and never
+# grow; anything not listed has to come in under the limit outright.
+#
+# The point is that the rule holds from today without a refactor having to land
+# first. Every line below is a small piece of work someone can pick up, and the
+# number only goes one way. Lower it in the same commit that shortens the file;
+# delete the line once it is under the limit.
+#
+# lines  path
+1251  App/Sources/plonk/AppDelegate.swift
+759   App/Sources/plonk/Router.swift
+619   App/Sources/plonk/SettingsPages.swift
+489   App/Tests/plonkTests/ConfigTests.swift
+450   App/Tests/plonkTests/RouterTests.swift
+436   App/Sources/plonk/WindowManager.swift
+364   App/Sources/plonk/Hotkey.swift
+351   App/Sources/plonk/DragSnapManager.swift
+349   App/Sources/plonk/GrabMove.swift
+342   App/Sources/plonk/UpdateManager.swift
+312   App/Sources/plonk/WorkspaceLauncher.swift
+306   mcp/src/api.ts

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Checks the rules AGENTS.md states but nothing enforced: file length, no
+# emoji, no trailing whitespace, a newline at the end of every file.
+#
+# Deliberately dependency-free. A contributor should not have to install a
+# linter to find out whether a pull request will be accepted on style, and the
+# app itself ships with no third-party code — a tool the checkout cannot run
+# offline would be the only thing in this repo that needs the network.
+set -eu
+cd "$(dirname "$0")/.."
+
+LIMIT=300
+BASELINE=scripts/line-limit-baseline
+status=0
+
+say() {
+    printf '%s\n' "$1" >&2
+    status=1
+}
+
+sources() {
+    find App/Sources App/Tests mcp/src mcp/test -type f \
+        \( -name '*.swift' -o -name '*.ts' -o -name '*.js' \) | sort
+}
+
+# --- File length -----------------------------------------------------------
+#
+# Every file over the limit today is recorded in the baseline with the length
+# it had when the rule went in. A file may shrink, never grow, and a new file
+# has to come in under the limit outright. That way the rule holds from the
+# first commit without a refactor having to land first, and the debt can only
+# go one way.
+budget_for() {
+    awk -v path="$1" '$2 == path { print $1 }' "$BASELINE"
+}
+
+for file in $(sources); do
+    lines=$(wc -l < "$file" | tr -d ' ')
+    budget=$(budget_for "$file")
+
+    if [ -z "$budget" ]; then
+        if [ "$lines" -gt "$LIMIT" ]; then
+            say "$file: $lines lines, over the $LIMIT-line limit.
+  Split it, or put the new logic in a type of its own. AGENTS.md, 'Layout'."
+        fi
+    elif [ "$lines" -gt "$budget" ]; then
+        say "$file: $lines lines, up from $budget in $BASELINE.
+  This file is already over the $LIMIT-line limit and may only get shorter.
+  Move what you are adding into a type of its own."
+    elif [ "$lines" -lt "$budget" ]; then
+        printf '%s: down to %s lines from %s. Lower it in %s.\n' \
+            "$file" "$lines" "$budget" "$BASELINE" >&2
+    fi
+done
+
+# --- Emoji -----------------------------------------------------------------
+#
+# The pattern is built with printf rather than written as an escape, because
+# grep has no \x: "[\xF0]" is a character class of backslash, x, F and 0, which
+# quietly matches every hex escape in the repo instead. F0 9F is the lead pair
+# of the pictograph planes, and that is what this rule means by emoji.
+#
+# Deliberately not the dingbats at E2 9C. The UI draws ✓ and ✕ as glyphs, the
+# same way it draws ⌃⌥⇧, and a rule that cannot tell those from an emoji would
+# fail on correct code — the fastest way to teach someone to ignore the linter.
+pictograph=$(printf '\360\237')
+emoji=$(sources | xargs env LC_ALL=C grep -l "$pictograph" 2>/dev/null || true)
+if [ -n "$emoji" ]; then
+    say "Emoji in:
+$emoji
+  No emoji anywhere, user-facing strings included. AGENTS.md, 'Code style'."
+fi
+
+# --- Whitespace ------------------------------------------------------------
+#
+# Indentation is left to .editorconfig rather than checked here: Release.swift
+# embeds a shell script whose heredoc is tab-indented on purpose.
+trailing=$(sources | xargs grep -l ' $' 2>/dev/null || true)
+if [ -n "$trailing" ]; then
+    say "Trailing whitespace in:
+$trailing"
+fi
+
+for file in $(sources); do
+    if [ -s "$file" ] && [ "$(tail -c 1 "$file" | wc -l | tr -d ' ')" -eq 0 ]; then
+        say "$file: no newline at end of file."
+    fi
+done
+
+if [ "$status" -eq 0 ]; then
+    printf 'lint: clean\n'
+fi
+exit "$status"

--- a/scripts/testbench.sh
+++ b/scripts/testbench.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# Throwaway windows to demonstrate a window fix on, so nobody has to move their
+# real ones to prove a patch works.
+#
+# Window bugs live on hardware the maintainer does not have, so the useful part
+# of a report is rarely the patch — it is the before and after. This gives both
+# sides the same desk to talk about: N TextEdit windows with known titles, and
+# a way to print where they actually landed.
+#
+#   ./scripts/testbench.sh up [n]   open n windows (default 4)
+#   ./scripts/testbench.sh state    print where each one is now
+#   ./scripts/testbench.sh down     close them and delete the files
+#
+# TextEdit, because a second window of one app cannot be conjured — it has to
+# be given a file to open — and because these are files nobody minds losing.
+set -eu
+
+DIR="${TMPDIR:-/tmp}/plonk-testbench"
+PREFIX=plonk-bench
+API=http://127.0.0.1:43917
+TOKEN_FILE="$HOME/Library/Application Support/Plonk/token"
+
+usage() {
+    sed -n '2,12p' "$0" | cut -c 3-
+    exit "${1:-0}"
+}
+
+token() {
+    [ -r "$TOKEN_FILE" ] || return 1
+    cat "$TOKEN_FILE"
+}
+
+up() {
+    count=${1:-4}
+    case "$count" in
+        ''|*[!0-9]*) printf 'testbench: window count must be a number, got "%s"\n' "$count" >&2; exit 1 ;;
+    esac
+    [ "$count" -ge 1 ] && [ "$count" -le 9 ] || {
+        printf 'testbench: between 1 and 9 windows, so they map onto the zone keys\n' >&2
+        exit 1
+    }
+
+    mkdir -p "$DIR"
+    i=1
+    while [ "$i" -le "$count" ]; do
+        file="$DIR/$PREFIX-$i.txt"
+        printf 'Plonk test window %s.\nSafe to close; this file is a scratch file.\n' "$i" > "$file"
+        # One at a time: TextEdit places windows as they open, and opening them
+        # in a batch cascades them on top of each other.
+        open -a TextEdit "$file"
+        i=$((i + 1))
+    done
+
+    printf 'Opened %s windows titled %s-1.txt … %s-%s.txt\n' "$count" "$PREFIX" "$PREFIX" "$count"
+    printf 'Arrange them, then: ./scripts/testbench.sh state\n'
+    printf 'When you are done:  ./scripts/testbench.sh down\n'
+}
+
+# Prints one line per bench window: title, screen, and the frame in the same
+# fractions apply_layout takes, which is the form worth pasting into a pull
+# request — pixels mean nothing without knowing the monitor.
+state() {
+    tok=$(token) || {
+        printf 'testbench: no API token at %s — is Plonk.app running?\n' "$TOKEN_FILE" >&2
+        exit 1
+    }
+    body=$(curl -sf -H "X-Plonk-Token: $tok" "$API/state") || {
+        printf 'testbench: %s did not answer. Launch Plonk.app first.\n' "$API" >&2
+        exit 1
+    }
+
+    # python3 rather than node: the Command Line Tools that Swift already needs
+    # bring it, so this works for someone who never touches mcp/.
+    printf '%s\n' "$body" | PREFIX="$PREFIX" python3 -c '
+import json, os, sys
+
+state = json.load(sys.stdin)
+prefix = os.environ["PREFIX"]
+mine = [w for w in state["windows"] if w["title"].startswith(prefix)]
+
+if not mine:
+    print("No bench windows open. ./scripts/testbench.sh up")
+    sys.exit(0)
+
+for s in state["screens"]:
+    print("screen %d  %dx%d" % (s["index"], round(s["visible"]["w"]), round(s["visible"]["h"])))
+
+for w in sorted(mine, key=lambda w: w["title"]):
+    f = w.get("fraction")
+    if f:
+        at = "x %.3f  y %.3f  w %.3f  h %.3f" % (f["x"], f["y"], f["w"], f["h"])
+    else:
+        at = "%d,%d %dx%d" % (
+            round(w["frame"]["x"]), round(w["frame"]["y"]),
+            round(w["frame"]["w"]), round(w["frame"]["h"]),
+        )
+    print("  %-22s screen %d  %s" % (w["title"], w["screen"], at))
+'
+}
+
+down() {
+    # Only documents this script opened, and never saving: a bench file is
+    # scratch, and a save dialog would leave the desk worse than it found it.
+    osascript -e "tell application \"TextEdit\"
+        repeat with d in (every document whose name starts with \"$PREFIX\")
+            close d saving no
+        end repeat
+    end tell" >/dev/null 2>&1 || true
+    rm -rf "$DIR"
+    printf 'Bench windows closed and %s removed.\n' "$DIR"
+}
+
+case "${1:-}" in
+    up) shift; up "${1:-4}" ;;
+    state) state ;;
+    down) down ;;
+    ''|-h|--help|help) usage 0 ;;
+    *) printf 'testbench: unknown command "%s"\n\n' "$1" >&2; usage 1 ;;
+esac


### PR DESCRIPTION
The repo reads as finished and one-handed. Everything below is aimed at the
gap between "the documentation is excellent" and "there is room for me here".

## The rules were written down and nothing checked them

`scripts/lint.sh` enforces what AGENTS.md already states: file length, no
emoji, no trailing whitespace, a final newline. Dependency-free, because
nobody should install a linter to find out whether a change will be accepted
on style, and a tool the checkout cannot run offline would be the only thing
here that needs the network.

The twelve files already over 300 lines are recorded in
`scripts/line-limit-baseline` with the length each had today. They may shrink,
never grow. The rule holds from this commit without a refactor landing first,
and every line in that file is a piece of work someone can pick up — `AppDelegate.swift`
at 1251 lines is issue #17, left for a contributor rather than done here.

Two bugs in the linter, found by testing it against deliberate violations:
`grep` has no `\x`, so `[\xF0]` was a character class of backslash, x, F and 0
that matched every hex escape in the repo; and `[ … ] && say` under `set -e`
killed the script whenever there was nothing to report. ✓ and ✕ are glyphs
like ⌃⌥⇧ and are deliberately not treated as emoji.

## The MCP server had no tests

Twenty-four, on the Node test runner, no new dependencies. Argument parsing,
the identity holders that keep one session's name out of another's, and the
tool input schemas. `options()` moved to `args.ts` because importing `cli.ts`
runs it. Explicit file paths rather than a glob, since `node --test <glob>`
needs Node 21 and CI is on 20.

## Nobody could prove a window fix works

Placement needs a real desktop session, so it is unreachable from the unit
suite — which leaves the most valuable kind of change the one people are least
able to demonstrate. `scripts/testbench.sh` opens throwaway TextEdit windows,
prints where each landed as fractions, and clears them away. The PR template
carries the six arrangements worth running, and permission to write
"no hardware" against the ones you do not own.

## The way in was long

CONTRIBUTING now opens with two things that were left to be guessed at — how
long a review takes, and whether the maintainer will push over your branch —
then a first change in fifteen minutes on issue #21. It says plainly that a PR
title does not have to be an essay; the subjects on `main` are one person's
habit and reading them as a standard is a fair mistake.

README: 461 lines to 231. The reference sections move to `docs/` with their
wording intact, and the hook is MCP, which was sitting at line 140.

Plus a CHANGELOG (#12), `.editorconfig`, and CI jobs for the linter and the
MCP tests.

## One thing worth flagging

`b93b8bd` (the zone-set gallery) landed on this branch while `README.md`,
`CONTRIBUTING.md` and `.github/workflows/ci.yml` were being rewritten
elsewhere, and the rewrite went out over the top of it. `40e7659` restores
what was lost and merges it with what replaced it — the zone-sets CI job, the
build-loop line, and the paragraphs pointing at the gallery. Worth a look on
that commit specifically.

## What was run

```
(cd App && swift build)            Build complete
./scripts/test.sh                  306 tests passed
./scripts/lint.sh                  clean
(cd mcp && npm ci && npm test)     24 passed, typecheck clean
node scripts/check-zone-sets.mjs   8 zone set(s) valid
```

Plus `testbench.sh up 2 / state / down` against a running Plonk, and a link
check over every relative link in the repo.

Two labels the new text points at do not exist yet:

```sh
gh label create needs-hardware -c B60205 \
  -d "Needs a monitor arrangement the maintainer does not have"
gh label create reserved-for-contributors -c 0E8A16 \
  -d "Left alone on purpose. Say so on the thread and it is yours"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)