### PR TITLE
chore: 0.2.0 in server.json too

### DIFF
--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "subfolder": "mcp"
   },
   "websiteUrl": "https://ostapondo.github.io/Plonk/",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "plonk-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
The 0.2.0 bump moved `version.env`, `mcp/package.json` and the README, but not
`mcp/server.json` — which carries the version twice, once for the server and
once for the npm package it points at. The release workflow checks both, so the
`mcp` job stopped before publishing and v0.2.0 never reached npm.

The v0.2.0 tag and its draft release have been deleted (zero downloads, nothing
published to npm); the tag goes back up once this is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)