### PR TITLE
docs: link the site from the README, and settle on one casing

### DIFF
--- a/App/Sources/plonk/Release.swift
+++ b/App/Sources/plonk/Release.swift
@@ -112,7 +112,7 @@ struct Release {
         )
     }
 
-    static let repository = "ostapondo/Plonk"
+    static let repository = "ostapondo/plonk"
     static let latestURL = URL(string: "https://api.github.com/repos/\(repository)/releases/latest")!
     static let releasesPageURL = URL(string: "https://github.com/\(repository)/releases/latest")!
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ a key, or you say where.</sub></p>
 </p>
 
 <p align="center">
+  <a href="https://ostapondo.github.io/Plonk/"><strong>ostapondo.github.io/Plonk</strong></a>
+  <br><sub>The same thing on one page, if you would rather look than read.</sub>
+</p>
+
+<p align="center">
   <img src="docs/demo.gif" alt="An eight-zone grid is cut out of one screen with seven clicks in the zone editor, then filled: one window dragged in, one sent by shortcut, and the remaining six placed at once from a sentence typed to an agent. A command palette then switches the screen to a four-zone set, and the theme changes from dark to light" width="720">
 </p>
 


### PR DESCRIPTION
## What changed, and why

The Pages site was reachable only from the repo's About sidebar, which is the one place a visitor arriving from a directory listing never looks. It now has a line in the README's first screen, between the badges and the demo.

`Release.swift` built its update-check URLs from `ostapondo/Plonk`, while every document in the repo, the cask, the npm package and the registry entry say `plonk`. github.com resolves either — verified `api.github.com/repos/ostapondo/plonk/releases/latest` returns 200 — so this is only about there being one spelling. The test fixture keeps the capital on purpose: it imitates a real API response, and that is the casing GitHub returns, so the test now also shows the parser does not lean on our own.

Not done, and deliberately: renaming the repository to lowercase. GitHub Pages paths are case-sensitive — `/Plonk/` is 200, `/plonk/` is 404 — and `https://ostapondo.github.io/Plonk/` is already published as the `websiteUrl` of the 0.2.0 MCP Registry entry, which cannot be edited.

## What you ran

    (cd App && swift build)
    ./scripts/test.sh      # 313 tests, 38 suites
    ./scripts/lint.sh      # clean

## Checks

- [x] `swift build` passes on every commit in the branch, not just the last one
- [x] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be
- [x] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [x] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — fixed in this PR if not
- [ ] Screenshots below for anything visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)