### PR TITLE
docs: lead with the window manager, not with the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 <h1 align="center">Plonk</h1>
 
-<p align="center"><strong>Ten menu bar utilities in one app, and an agent can drive
-every one of them.</strong><br>
-<sub>A window manager with zones you draw yourself, workspaces that put the desk
-back, text lifted off the screen, keep-awake, screenshots you can draw on,
-pointer tools, a shortcut guide, voice. On a Mac each of those is its own
-download. To plonk is to set a thing down exactly where it belongs: you drag it
-there, you press a key, or you say where.</sub></p>
+<p align="center"><strong>A window manager with zones you draw yourself, and nine
+more menu bar utilities behind the same icon.</strong><br>
+<sub>Workspaces that put the desk back, text lifted off the screen, keep-awake,
+screenshots you can draw on, pointer tools, a shortcut guide, voice. On a Mac
+each of those is its own download. To plonk is to set a thing down exactly where
+it belongs: you drag it there, you press a key, or you say where.</sub></p>
 
 <p align="center">
   <img alt="Version" src="https://img.shields.io/badge/version-0.2.1-8b7cf6?style=flat-square">
   <img alt="macOS 13+" src="https://img.shields.io/badge/macOS-13%2B-111?style=flat-square">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?style=flat-square">
-  <img alt="MCP" src="https://img.shields.io/badge/MCP-19_tools-8957e5?style=flat-square">
   <img alt="No dependencies" src="https://img.shields.io/badge/dependencies-0-2ea043?style=flat-square">
   <img alt="MIT" src="https://img.shields.io/badge/license-MIT-blue?style=flat-square">
+  <img alt="MCP" src="https://img.shields.io/badge/MCP-19_tools-8957e5?style=flat-square">
 </p>
 
 <p align="center">
@@ -36,7 +35,9 @@ pull a window from anywhere inside it, instead of aiming for the title bar.
 that screen, `⌃⌥0` to put a window back exactly where it was before Plonk ever
 touched it.
 
-**Say it.** Plonk speaks MCP, so any agent can drive the whole thing:
+**Say it.** Hold `⌃⌥V` and name where it goes — "snap this left", "zone three".
+That runs inside the app, offline, with on-device recognition. Plonk also speaks
+MCP, so a whole desk at once can go to an agent you already have open:
 
 > browser on the left 60%, terminal top right, notes bottom right
 >
@@ -62,7 +63,7 @@ Grant Accessibility when it asks, then relaunch. Screen Recording is asked for
 separately, the first time you capture. Nothing else — no Full Disk Access, no
 Automation, no Keychain.
 
-To let an agent drive it (Node 18+):
+Optional, and only if you want the `plonk` CLI or an agent driving it (Node 18+):
 
 ```sh
 claude mcp add plonk -- npx -y plonk-mcp   # Claude Code

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 210" width="760" height="210" role="img" aria-label="Claude talks to the MCP server over stdio, which calls the loopback HTTP API of the Plonk app, which drives Accessibility, IOKit and screencapture">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 210" width="760" height="210" role="img" aria-label="An MCP client talks to the MCP server over stdio, which calls the loopback HTTP API of the Plonk app, which drives Accessibility, IOKit and screencapture">
   <defs>
     <marker id="tip" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b949e"/>
@@ -14,8 +14,8 @@
   </style>
 
   <rect class="box" x="14" y="40" width="150" height="66" rx="10"/>
-  <text class="t" x="89" y="68">Claude</text>
-  <text class="s" x="89" y="86">Code, Desktop</text>
+  <text class="t" x="89" y="68">MCP client</text>
+  <text class="s" x="89" y="86">or the CLI</text>
 
   <line class="link" x1="170" y1="73" x2="222" y2="73" marker-end="url(#tip)"/>
   <text class="l" x="196" y="62">stdio</text>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Plonk — ten Mac menu bar utilities in one app</title>
-<meta name="description" content="One macOS menu bar app doing what ten usually do: a window manager with snap zones you draw yourself, workspaces that reopen your apps on the right monitor, text lifted off the screen, keep-awake, screenshot annotation, pointer tools and a shortcut guide. An agent can drive all of it over MCP. No cloud, no telemetry.">
+<meta name="description" content="A macOS window manager with snap zones you draw yourself and workspaces that reopen your apps on the right monitor — plus text lifted off the screen, keep-awake, screenshot annotation, pointer tools and a shortcut guide, in one menu bar app. Everything runs on your Mac. No cloud, no telemetry.">
 <link rel="icon" href="logo-400.png">
 <meta property="og:title" content="Plonk — ten Mac menu bar utilities in one app">
-<meta property="og:description" content="Zones and workspaces, text off the screen, keep-awake, screenshots you can draw on, pointer tools, a shortcut guide — ten utilities in one menu bar app, and an agent can drive every one of them. Everything runs on your Mac.">
+<meta property="og:description" content="Zones and workspaces, text off the screen, keep-awake, screenshots you can draw on, pointer tools, a shortcut guide — ten utilities in one menu bar app. Drag a window there, press a key, or say where it goes. Everything runs on your Mac.">
 <meta property="og:image" content="https://ostapondo.github.io/Plonk/social-preview.png">
 <meta property="og:url" content="https://ostapondo.github.io/Plonk/">
 <meta property="og:type" content="website">
@@ -227,7 +227,7 @@
     <p class="lede">One menu bar app doing what ten usually do: a window manager with zones you
       draw yourself and workspaces that reopen your apps on the right monitor, plus text lifted
       off the screen, keep-awake, screenshots you can draw on, pointer tools and a shortcut guide.
-      Drag a window there, press a key — or describe the whole desk and let your agent build it.</p>
+      Drag a window there, press a key, or hold a shortcut and say where it goes.</p>
     <div class="install">
       <div class="cmd">
         <span class="prompt">$</span>
@@ -264,8 +264,8 @@
       </div>
       <div class="card">
         <h3>Say it</h3>
-        <p>Plonk speaks MCP, so any agent can place every window on every monitor in one call —
-          and save the result as a workspace you can launch from nothing.</p>
+        <p>Hold <kbd>⌃⌥V</kbd> and name the zone. Recognition is on-device, and the common
+          commands run in the app itself — offline, and instantly.</p>
       </div>
     </div>
   </section>
@@ -313,7 +313,7 @@
     <img class="diagram" src="zones.svg" width="720" height="300"
          alt="A screen divided into three zones, with a window being dragged into the highlighted top-right zone">
     <p class="dim" style="font-size:14.5px;margin:22px 0 10px">Five sets ship with it. Everything
-      past that you draw yourself — or describe, and let the agent build it.</p>
+      past that you draw yourself.</p>
     <img class="diagram" src="zone-sets.svg" width="720" height="112"
          alt="Five built-in zone sets — Halves, Thirds, 60/40, Quarters, Priority — and a sixth, irregular one drawn by hand">
   </section>


### PR DESCRIPTION
The README headline, the site's `description`/`og:description`, the "Say it" card and the zones caption all opened on MCP. That is one of four ways into the app, and not the largest one — zones, hotkeys, workspaces, OCR, keep-awake and voice all work with the MCP server switched off. The framing oversold one interface and undersold the other nine utilities.

**What changed**

- README headline now leads with the window manager; the "Say it" section leads with the on-device voice recognition that actually ships in the app, then mentions MCP.
- Site `description`, `og:description`, hero lede, the "Say it" card and the zone-sets caption, same treatment.
- Install snippet relabelled optional, since it is.
- `architecture.svg` says "MCP client" rather than naming one vendor — any of them works.
- MCP badge moved to the end of the badge row.

**What did not change**

The "For agents" section, in full, here and on the site. The MCP badge. Both client install lines. `docs/agents.md` and the client one-pagers. Nothing about the agent surface is removed or hidden — it is documented exactly as before, just no longer the first thing said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)