### PR TITLE
feat: ship an .mcpb bundle, so installing the server is opening a file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,3 +266,48 @@ jobs:
             | tar xz mcp-publisher
           ./mcp-publisher login github-oidc
           cd mcp && ../mcp-publisher publish
+
+  # The .mcpb bundle is how Claude Desktop installs an MCP server: open the
+  # file, confirm, done — no config file to find, no command to paste, which is
+  # where most people give up. It is built here rather than on a laptop for the
+  # same reason the zip is: it carries the compiled server and a vendored copy
+  # of its dependencies, so a bundle packed from a dirty checkout would ship
+  # whatever happened to be lying around, signed by nothing.
+  bundle:
+    runs-on: ubuntu-latest
+    # The draft release this uploads to is created by the app job.
+    needs: app
+    permissions:
+      contents: write # upload the bundle to the release
+      id-token: write # sign the attestation
+      attestations: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+
+      - run: npm ci
+        working-directory: mcp
+
+      - name: Read the version
+        id: version
+        run: |
+          set -eu
+          . ./version.env
+          echo "version=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
+
+      - run: ./scripts/build-mcpb.sh
+
+      - uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: mcp/plonk-${{ steps.version.outputs.version }}.mcpb
+
+      - name: Publish the bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh release upload "v$VERSION" "mcp/plonk-$VERSION.mcpb" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,9 @@ App/*.swiftmodule
 Plonk.app/
 mcp/node_modules/
 mcp/dist/
+# Build products of scripts/build-mcpb.sh: the staging tree it vendors
+# dependencies into, and the bundle it packs from it.
+mcp/.mcpb-build/
+mcp/*.mcpb
 Plonk-*.zip
 *.p12

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Any MCP client works the same way, over stdio or HTTP.
 [Cursor](docs/clients/cursor.md), [Zed](docs/clients/zed.md) and
 [Cline](docs/clients/cline.md).
 
+For Claude Desktop there is nothing to type: download `plonk-<version>.mcpb`
+from the [latest release](https://github.com/ostapondo/plonk/releases/latest)
+and open it. The bundle carries the server and its dependencies, so no config
+file gets edited and nothing is fetched at launch.
+
 <details>
 <summary><strong>Installing it by hand, and why macOS holds a downloaded copy</strong></summary>
 

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Builds plonk-<version>.mcpb, the bundle format Claude Desktop installs in two
+# clicks and Smithery distributes for local servers.
+#
+# It exists because the alternative is a paragraph of instructions. Without it,
+# installing the MCP server means finding the client's JSON config, writing a
+# command and an args array into it by hand, and restarting the client — which
+# is where most people stop. An .mcpb is a zip carrying the server, its
+# dependencies and a manifest, so the client can do all of that itself.
+#
+# The dependencies are vendored on purpose. `npx -y plonk-mcp` is still the
+# documented way in, but it resolves the package at every launch; a bundle that
+# already contains what it needs starts offline and cannot be changed under the
+# user by a later publish.
+#
+# Usage: ./scripts/build-mcpb.sh [output-directory] [--smithery]
+#
+# --smithery writes plonk-<version>-smithery.mcpb instead: the same bundle with
+# each tool's inputSchema in the manifest, which the MCPB schema forbids and
+# Smithery's registry requires. It is the only build that skips MCPB
+# validation, because it is the only one that cannot pass it. See
+# make-mcpb-manifest.mjs for the whole story.
+set -eu
+cd "$(dirname "$0")/.."
+
+OUT=mcp
+FLAGS=
+SUFFIX=
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--smithery)
+		FLAGS=--input-schemas
+		SUFFIX=-smithery
+		;;
+	-*)
+		printf 'unknown option: %s\n' "$1" >&2
+		exit 2
+		;;
+	*) OUT=$1 ;;
+	esac
+	shift
+done
+
+STAGE=mcp/.mcpb-build
+VERSION=$(node -p 'require("./mcp/package.json").version')
+
+rm -rf "$STAGE"
+mkdir -p "$STAGE/server" "$OUT"
+
+# The compiled server, and nothing else from mcp/: no sources, no tests, no
+# tsconfig. A bundle is read by clients, not by contributors.
+(cd mcp && npm run --silent build)
+cp mcp/dist/*.js "$STAGE/server/"
+mkdir -p "$STAGE/server/tools"
+cp mcp/dist/tools/*.js "$STAGE/server/tools/"
+
+# package.json comes along for two reasons: "type": "module", without which
+# node reads the server as CommonJS and every import fails, and the lockfile it
+# pairs with, which is what makes the vendored tree reproducible.
+cp mcp/package.json mcp/package-lock.json "$STAGE/"
+(cd "$STAGE" && npm ci --omit=dev --ignore-scripts --silent)
+
+cp docs/logo-400.png "$STAGE/icon.png"
+node scripts/make-mcpb-manifest.mjs mcp/dist "$STAGE/manifest.json" $FLAGS
+
+# Validate before packing. The manifest is generated, so a failure here is a
+# bug in the generator, and finding it now beats finding it in a client that
+# refuses the bundle with no reason given.
+BUNDLE=$(cd "$OUT" && pwd)/plonk-$VERSION$SUFFIX.mcpb
+rm -f "$BUNDLE"
+
+if [ -z "$SUFFIX" ]; then
+	npx --yes @anthropic-ai/mcpb validate "$STAGE/manifest.json"
+	npx --yes @anthropic-ai/mcpb pack "$STAGE" "$BUNDLE"
+else
+	# `mcpb pack` validates too, so the off-spec build cannot go through it.
+	# An .mcpb is a zip with manifest.json at the root, which is all the
+	# Smithery CLI reads, so zip it directly rather than teach the packer to
+	# make an exception. -X keeps the archive free of macOS extended
+	# attributes, which nothing downstream reads and every extractor warns on.
+	printf 'packing without MCPB validation: this build is deliberately off-spec for Smithery\n' >&2
+	(cd "$STAGE" && zip -q -r -X "$BUNDLE" .)
+fi
+
+rm -rf "$STAGE"
+printf "\nwrote %s/plonk-%s%s.mcpb\n" "$OUT" "$VERSION" "$SUFFIX"

--- a/scripts/make-mcpb-manifest.mjs
+++ b/scripts/make-mcpb-manifest.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Writes the manifest.json that goes inside the MCPB bundle, taking every
+// field from something that already exists rather than from a second copy.
+//
+// The tool list is the reason this is a script and not a checked-in file. A
+// manifest that lists tools is what Claude Desktop and Smithery show before
+// anyone installs anything, so a stale list is a promise the server does not
+// keep. Here the list comes from the built server itself: we start it, call
+// tools/list over stdio, and write down what it answered. It cannot drift.
+//
+// Usage:
+//   node scripts/make-mcpb-manifest.mjs <server-dir> <output-file> [--input-schemas]
+//
+// <server-dir> holds the compiled server (mcp/dist), <output-file> is where
+// the manifest goes. The server is never asked to do any work — tools/list is
+// answered from the schema, so Plonk itself does not have to be running.
+//
+// --input-schemas puts each tool's inputSchema in the manifest, which the MCPB
+// schema forbids: it declares tool entries "additionalProperties": false, so
+// only name and description are allowed there. It exists for one consumer.
+// The Smithery CLI copies manifest.tools into a server card and validates it
+// against the MCP tool schema, where inputSchema is *required*; leaving the
+// array out instead gets the release rejected as "No values to set". Their two
+// checks cannot both be satisfied, so the bundle we publish to Smithery is
+// built with this flag and skips MCPB validation, and the one we ship
+// everywhere else stays conformant. Drop the flag once Smithery validates
+// server cards built from MCPB manifests against the MCPB schema.
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const argv = process.argv.slice(2);
+const inputSchemas = argv.includes("--input-schemas");
+const [serverDir, output] = argv.filter((arg) => !arg.startsWith("--"));
+
+if (!serverDir || !output) {
+  console.error("usage: make-mcpb-manifest.mjs <server-dir> <output-file> [--input-schemas]");
+  process.exit(1);
+}
+
+const pkg = JSON.parse(readFileSync(join(ROOT, "mcp", "package.json"), "utf8"));
+
+/**
+ * Starts the compiled server, speaks just enough MCP to get past the
+ * handshake, and resolves with the tools it declares.
+ *
+ * The timeout is not politeness: a server that never answers would otherwise
+ * hang a release build, and a bundle is better not built than built with no
+ * tools in its manifest.
+ */
+function listTools(entry) {
+  return new Promise((resolve, reject) => {
+    const server = spawn(process.execPath, [entry], { stdio: ["pipe", "pipe", "ignore"] });
+    const timer = setTimeout(() => {
+      server.kill();
+      reject(new Error(`${entry} did not answer tools/list within 15s`));
+    }, 15_000);
+
+    const send = (message) => server.stdin.write(`${JSON.stringify(message)}\n`);
+    let buffered = "";
+
+    server.on("error", reject);
+    server.stdout.on("data", (chunk) => {
+      buffered += chunk;
+      const lines = buffered.split("\n");
+      buffered = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue; // Not every line has to be ours.
+        }
+        if (message.id === 1) {
+          send({ jsonrpc: "2.0", method: "notifications/initialized" });
+          send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+        }
+        if (message.id === 2) {
+          clearTimeout(timer);
+          server.kill();
+          resolve(message.result?.tools ?? []);
+        }
+      }
+    });
+
+    send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "make-mcpb-manifest", version: pkg.version },
+      },
+    });
+  });
+}
+
+const tools = await listTools(join(serverDir, "server.js"));
+if (tools.length === 0) throw new Error("the server declared no tools — refusing to write a manifest that says so");
+
+// Descriptions in the server are written for a model deciding whether to call
+// the tool, so they run long. A directory listing shows one line, so take the
+// first sentence and leave the rest to the server itself.
+const summarize = (text = "") => text.split(/(?<=\.)\s/)[0].trim();
+
+const manifest = {
+  manifest_version: "0.3",
+  name: "plonk",
+  display_name: "Plonk",
+  version: pkg.version,
+  description: pkg.description,
+  long_description:
+    "Plonk is a macOS window manager with snap zones you draw yourself and workspaces that reopen your apps on the " +
+    "right monitor. This bundle installs its MCP server, which lets an agent do the same things you can: place " +
+    "windows, launch a saved workspace, hold sleep off, take a screenshot, read text off the screen with on-device " +
+    "OCR.\n\n" +
+    "The server is a bridge, not the app. It talks to Plonk over a loopback API on your own Mac, so **Plonk has to " +
+    "be installed and running** for the tools to do anything: `brew install --cask ostapondo/plonk/plonk`. Nothing " +
+    "leaves the machine — no account, no cloud, no telemetry.",
+  author: {
+    name: "ostapondo",
+    url: "https://github.com/ostapondo",
+  },
+  repository: {
+    type: "git",
+    url: "https://github.com/ostapondo/plonk",
+  },
+  homepage: "https://ostapondo.github.io/Plonk/",
+  documentation: "https://github.com/ostapondo/plonk#readme",
+  support: "https://github.com/ostapondo/plonk/issues",
+  icon: "icon.png",
+  server: {
+    type: "node",
+    entry_point: "server/server.js",
+    mcp_config: {
+      command: "node",
+      args: ["${__dirname}/server/server.js"],
+    },
+  },
+  tools: tools.map((tool) => ({
+    name: tool.name,
+    description: summarize(tool.description),
+    // Off-spec, and only ever set for Smithery — see the note above the flag.
+    ...(inputSchemas ? { inputSchema: tool.inputSchema } : {}),
+  })),
+  keywords: pkg.keywords,
+  license: pkg.license,
+  compatibility: {
+    // Everything here goes through the macOS Accessibility API. On another
+    // platform the bundle would install and every call would fail, so say so
+    // in the manifest instead of in a support thread.
+    platforms: ["darwin"],
+    runtimes: { node: ">=18.0.0" },
+  },
+};
+
+writeFileSync(output, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`manifest.json: ${tools.length} tools${inputSchemas ? " with input schemas" : ""}, version ${pkg.version}`);

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,7 +1,0 @@
-startCommand:
-  type: stdio
-  configSchema:
-    type: object
-    properties: {}
-  commandFunction: |-
-    () => ({ command: 'npx', args: ['-y', 'plonk-mcp'] })


### PR DESCRIPTION
Installing the MCP server meant `npx -y plonk-mcp` plus a hand-edited client config. This adds the bundle format that removes both steps: Claude Desktop installs an `.mcpb` in two clicks, and Smithery distributes it for local servers.

**What is here**

- `scripts/build-mcpb.sh` — compiles the server, vendors production dependencies with `npm ci --omit=dev` against the lockfile, validates and packs.
- `scripts/make-mcpb-manifest.mjs` — generates `manifest.json`. The tool list comes from the built server over a real `tools/list` call, so it cannot drift from the code.
- `release.yml` — a `bundle` job that builds the `.mcpb`, attests its provenance like the zip and the npm tarball, and uploads it to the release.
- README — four lines on installing into Claude Desktop.
- `smithery.yaml` deleted: it described a format their current docs no longer mention, and nothing in the repo referenced it.

**Why one build is deliberately off-spec**

The two validators contradict each other. The MCPB schema declares tool entries `"additionalProperties": false`, so only `name` and `description` are allowed. The Smithery CLI copies `manifest.tools` into a server card and validates it against the MCP tool schema, where `inputSchema` is required — and omitting the array instead gets the release rejected as `No values to set`. Both were reproduced against `ostapondo/plonk`.

So `--smithery` adds the schemas and zips directly, since `mcpb pack` validates too; the canonical bundle stays conformant. The flag goes away once Smithery validates server cards built from MCPB manifests against the MCPB schema.

**Checks**

- `./scripts/lint.sh` clean.
- Both bundles unpacked and the bundled entry point started: 19 tools over stdio, with the vendored dependencies and no `npm install`.
- `ostapondo/plonk` is live on Smithery, published from this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)