### PR TITLE
feat: install from Claude Code without touching a config file

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "plonk",
+  "owner": {
+    "name": "ostapondo",
+    "url": "https://github.com/ostapondo"
+  },
+  "metadata": {
+    "description": "Plonk, the macOS window manager, as a Claude Code plugin"
+  },
+  "plugins": [
+    {
+      "name": "plonk",
+      "displayName": "Plonk",
+      "source": "./plugins/plonk",
+      "description": "Drive the Plonk window manager from Claude Code: place windows, launch saved workspaces, hold sleep off, take screenshots, read text off the screen with on-device OCR.",
+      "version": "0.2.3",
+      "homepage": "https://ostapondo.github.io/Plonk/",
+      "license": "MIT",
+      "keywords": ["macos", "window-manager", "workspaces", "screenshots", "ocr", "productivity"]
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,19 @@ jobs:
             echo "::error::mcp/server.json says $SERVER / $SERVER_PACKAGE but version.env says $MARKETING_VERSION"
             exit 1
           fi
+          # The Claude Code plugin carries the version twice as well, and there
+          # it decides something: a plugin pinned to a version users already
+          # have is a plugin that never updates, however much the code moved.
+          PLUGIN=$(node -p "require('./plugins/plonk/.claude-plugin/plugin.json').version")
+          CATALOG=$(node -p "require('./.claude-plugin/marketplace.json').plugins[0].version")
+          # And a third time in the server it launches, which is the one that
+          # decides what actually runs: a plugin that says 0.2.3 while running
+          # whatever npm serves as latest is pinned in name only.
+          PINNED=$(node -p "require('./plugins/plonk/.mcp.json').mcpServers.plonk.args.at(-1).split('@').at(-1)")
+          if [ "$PLUGIN" != "$MARKETING_VERSION" ] || [ "$CATALOG" != "$MARKETING_VERSION" ] || [ "$PINNED" != "$MARKETING_VERSION" ]; then
+            echo "::error::the plugin says $PLUGIN / $CATALOG / $PINNED but version.env says $MARKETING_VERSION"
+            exit 1
+          fi
           echo "version=$PACKAGE" >> "$GITHUB_OUTPUT"
           # Re-running the workflow for a version already on npm is not a
           # failure, it is a no-op — publishing again would be the failure.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ claude mcp add plonk -- npx -y plonk-mcp   # Claude Code
 codex mcp add plonk -- npx -y plonk-mcp    # Codex CLI
 ```
 
+In Claude Code it can also come as a plugin — the same server, pinned to the
+release it shipped with rather than to whatever npm serves as latest:
+
+```
+/plugin marketplace add ostapondo/plonk
+/plugin install plonk@plonk
+```
+
 Any MCP client works the same way, over stdio or HTTP.
 [For agents](docs/agents.md) has the rest, plus one-pagers for
 [Cursor](docs/clients/cursor.md), [Zed](docs/clients/zed.md) and

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,10 +16,14 @@
     "mcp",
     "model-context-protocol",
     "claude",
+    "claude-code",
     "macos",
     "window-manager",
     "workspaces",
-    "screenshots"
+    "zones",
+    "screenshots",
+    "ocr",
+    "accessibility"
   ],
   "engines": {
     "node": ">=18"

--- a/plugins/plonk/.claude-plugin/plugin.json
+++ b/plugins/plonk/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "plonk",
+  "description": "Drive the Plonk window manager from Claude Code. Needs the app installed: brew install --cask ostapondo/plonk/plonk",
+  "version": "0.2.3",
+  "author": {
+    "name": "ostapondo",
+    "url": "https://github.com/ostapondo"
+  },
+  "homepage": "https://ostapondo.github.io/Plonk/",
+  "repository": "https://github.com/ostapondo/plonk",
+  "license": "MIT",
+  "keywords": ["macos", "window-manager", "workspaces", "screenshots", "ocr", "productivity"]
+}

--- a/plugins/plonk/.mcp.json
+++ b/plugins/plonk/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "plonk": {
+      "command": "npx",
+      "args": ["-y", "plonk-mcp@0.2.3"]
+    }
+  }
+}

--- a/plugins/plonk/README.md
+++ b/plugins/plonk/README.md
@@ -1,0 +1,36 @@
+# Plonk, as a Claude Code plugin
+
+Two commands instead of finding a JSON config and restarting the client:
+
+```sh
+/plugin marketplace add ostapondo/plonk
+/plugin install plonk@plonk
+```
+
+That registers the MCP server, and Claude Code starts it whenever the plugin is
+enabled. The nineteen tools then appear scoped as `mcp__plugin_plonk_plonk__*`,
+which matters if you write hooks against them.
+
+## It needs the app
+
+The plugin is a bridge, not the thing itself. The server talks to Plonk over a
+loopback API on your own Mac, so the app has to be installed and running or
+every call fails with nothing listening:
+
+```sh
+brew install --cask ostapondo/plonk/plonk
+```
+
+Grant Accessibility when it asks, then relaunch. Screen Recording is asked for
+separately, the first time you capture.
+
+## What it does not do
+
+Nothing leaves the machine. There is no account, no cloud and no telemetry, and
+the server holds no state of its own — the app is the single source of truth.
+The zones, workspaces, OCR, keep-awake and voice all work with the MCP server
+switched off; this plugin only adds a fourth way in, next to drag, shortcut and
+voice.
+
+[Tools and arguments](../../docs/agents.md) · [Zones](../../docs/zones.md) ·
+[Workspaces](../../docs/workspaces.md)


### PR DESCRIPTION
`/plugin marketplace add ostapondo/plonk` then `/plugin install plonk@plonk`. No JSON config to find, no restart, and the repository is its own marketplace — so unlike every directory we are waiting on, this channel needs nobody's approval. The curated plugin marketplaces can list it afterwards.

**What is here**

- `.claude-plugin/marketplace.json` — the catalog. Validated against the published SchemaStore schema.
- `plugins/plonk/` — the plugin: manifest, `.mcp.json`, and a README that says plainly it needs the app installed, since the server is a bridge to a loopback API and does nothing without it.
- `release.yml` — the version guard extended to all three new places the version lives, including the pinned npx argument.
- `mcp/package.json` — keywords widened: they listed neither `ocr` nor `zones` nor `claude-code`.

**Why the npm version is pinned**

`npx -y plonk-mcp@0.2.3`, not `npx -y plonk-mcp`. A plugin manifest that says 0.2.3 while launching whatever npm serves as latest is pinned in name only, and the mismatch would only show up as a bug report about tools that do not exist yet.

**Checks**

- `./scripts/lint.sh` clean.
- Marketplace manifest validates against `json.schemastore.org/claude-code-marketplace.json`.
- Plugin name matches the catalog entry, the source path resolves, and all four version fields agree with `version.env`.

Not verified end-to-end: installing it in a live Claude Code session is a UI flow I cannot drive from here. Worth someone running the two commands before the next release goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)