### PR TITLE
feat: notarize releases and ship a .dmg, once there is a Developer ID

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,14 @@ name: Release
 # Set the first of those five and this workflow switches paths on its own:
 # Developer ID signing, notarization, a stapled ticket and a .dmg beside the
 # zip. Leave them unset and it behaves exactly as it did before they existed.
-# There is no flag to flip and nothing to remember on release day.
+# There is no flag in here to flip.
+#
+# There is one thing to do by hand, once, and the build stops until it is done:
+# scripts/release-requirement pins the signature every release so far carries,
+# so the first Developer ID run fails that check with the old and new values
+# printed side by side. Commit the new one. release.sh makes that check before
+# it uploads anything to Apple, so finding out costs a build and not a
+# notarization.
 #
 # An API key rather than an Apple ID and an app-specific password, because
 # notarytool cannot be asked anything on a runner: a key is three values that go
@@ -228,7 +235,22 @@ jobs:
         run: |
           set -eu
           ZIP="Plonk-$VERSION.zip"
-          SHA=$(shasum -a 256 "$ZIP" | cut -d' ' -f1)
+          DMG="Plonk-$VERSION.dmg"
+
+          # The image only exists on the notarized path, so everything below
+          # names what this run actually produced rather than assuming both.
+          # Getting that wrong is not cosmetic: a digest published next to a
+          # file it does not belong to is worse than no digest, because someone
+          # checks it, sees a mismatch, and concludes the download was tampered
+          # with.
+          #
+          # The positional list rather than a space-separated string, so the
+          # loops below iterate on quoted arguments instead of on whatever the
+          # shell decides to split.
+          set -- "$ZIP"
+          if [ -f "$DMG" ]; then
+            set -- "$ZIP" "$DMG"
+          fi
 
           STATE=$(gh release view "v$VERSION" --json isDraft \
             --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo missing)
@@ -246,38 +268,40 @@ jobs:
           # New releases land as drafts, so nothing reaches the updater before
           # someone has said what changed.
           if [ "$STATE" = missing ]; then
-            gh release create "v$VERSION" --draft --title "Plonk $VERSION" --notes "$(
-              printf '%s\n' \
-                "Drafted by CI. Replace this with the release notes before publishing." \
-                "" \
-                "Built from \`$GITHUB_SHA\` by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." \
-                "Verify it against that commit before installing:" \
-                "" \
-                '```sh' \
-                "gh attestation verify $ZIP -R $GITHUB_REPOSITORY" \
-                '```' \
-                "" \
-                "sha256: \`$SHA\`"
-            )"
+            {
+              echo "Drafted by CI. Replace this with the release notes before publishing."
+              echo
+              echo "Built from \`$GITHUB_SHA\` by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+              echo "Verify what you downloaded against that commit before installing:"
+              echo
+              echo '```sh'
+              for f in "$@"; do
+                echo "gh attestation verify $f -R $GITHUB_REPOSITORY"
+              done
+              echo '```'
+              echo
+              for f in "$@"; do
+                echo "\`$f\` sha256: \`$(shasum -a 256 "$f" | cut -d' ' -f1)\`"
+              done
+            } > "$RUNNER_TEMP/notes.md"
+            gh release create "v$VERSION" --draft --title "Plonk $VERSION" \
+              --notes-file "$RUNNER_TEMP/notes.md"
           fi
-          gh release upload "v$VERSION" "$ZIP" --clobber
+
+          for f in "$@"; do
+            gh release upload "v$VERSION" "$f" --clobber
+          done
 
           {
             echo "### Plonk $VERSION"
             echo
-            echo "- zip sha256: \`$SHA\`"
+            for f in "$@"; do
+              echo "- \`$f\` sha256: \`$(shasum -a 256 "$f" | cut -d' ' -f1)\`"
+            done
+            # Named rather than implied: the cask pins the zip, and once two
+            # digests are on screen "that sha256" stops meaning anything.
+            echo "- update the cask in \`ostapondo/homebrew-plonk\` with this version and the \`$ZIP\` sha256"
           } >> "$GITHUB_STEP_SUMMARY"
-
-          # Only there on the notarized path, so its absence is the normal case
-          # rather than a missing file worth failing over.
-          DMG="Plonk-$VERSION.dmg"
-          if [ -f "$DMG" ]; then
-            gh release upload "v$VERSION" "$DMG" --clobber
-            echo "- dmg sha256: \`$(shasum -a 256 "$DMG" | cut -d' ' -f1)\`" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          echo "- update the cask in \`ostapondo/homebrew-plonk\` with that version and sha256" \
-            >> "$GITHUB_STEP_SUMMARY"
 
   mcp:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,30 @@ name: Release
 #   PLONK_SIGN_CERT_P12       the "Plonk Signing" certificate and its key, base64
 #   PLONK_SIGN_CERT_PASSWORD  the password used when exporting it
 #
+# and, once there is a paid Apple Developer account, the five that replace them:
+#
+#   APPLE_DEVELOPER_ID_P12    the "Developer ID Application" certificate, base64
+#   APPLE_DEVELOPER_ID_PASSWORD  the password used when exporting it
+#   APPLE_NOTARY_KEY          the App Store Connect .p8 API key, base64
+#   APPLE_NOTARY_KEY_ID       the key's ten-character ID
+#   APPLE_NOTARY_ISSUER       the issuer UUID the key was created under
+#
+# Set the first of those five and this workflow switches paths on its own:
+# Developer ID signing, notarization, a stapled ticket and a .dmg beside the
+# zip. Leave them unset and it behaves exactly as it did before they existed.
+# There is no flag to flip and nothing to remember on release day.
+#
+# An API key rather than an Apple ID and an app-specific password, because
+# notarytool cannot be asked anything on a runner: a key is three values that go
+# in as secrets, and it can be revoked by itself without disturbing the account
+# it belongs to.
+#
+# The switch is not free, and it is one-way. A Developer ID signature is a
+# different designated requirement, so scripts/release-requirement has to change
+# in the same commit — and every copy already installed will refuse the update,
+# the way 0.0.5 did. See SECURITY.md; the reason to do it early is that the bill
+# is proportional to how many people are already running it.
+#
 # npm needs no secret at all: plonk-mcp names this repository and this workflow
 # file as a trusted publisher (npmjs.com > the package > Settings > Trusted
 # publisher), and npm takes GitHub's OIDC token as proof. Nothing to rotate,
@@ -56,14 +80,37 @@ jobs:
             exit 1
           fi
 
+      # One step for both identities, because the keychain dance is the same
+      # either way: create, import, unlock, and tell codesign it may use the key
+      # without stopping to ask. Only two lines differ, and they are the two
+      # that matter — a self-signed root has to be trusted before macOS counts
+      # it as a valid identity at all, and a Developer ID already chains to a
+      # root every Mac ships with, so trusting it by hand would be a lie about
+      # where it came from.
       - name: Import the signing certificate
+        id: signing
         env:
+          DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          DEVELOPER_ID_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_PASSWORD }}
           P12: ${{ secrets.PLONK_SIGN_CERT_P12 }}
           P12_PASSWORD: ${{ secrets.PLONK_SIGN_CERT_PASSWORD }}
         run: |
           set -eu
-          if [ -z "${P12:-}" ]; then
-            echo "::error::PLONK_SIGN_CERT_P12 is not set — see the header of this workflow"
+          # A Developer ID wins when both are present. Having set it up, nobody
+          # means "sign the next release with the old key anyway", and a release
+          # that quietly took the lesser path would be discovered by its users.
+          if [ -n "${DEVELOPER_ID_P12:-}" ]; then
+            PAYLOAD=$DEVELOPER_ID_P12
+            PAYLOAD_PASSWORD=${DEVELOPER_ID_PASSWORD:-}
+            WANTED="Developer ID Application"
+            SELF_SIGNED=no
+          elif [ -n "${P12:-}" ]; then
+            PAYLOAD=$P12
+            PAYLOAD_PASSWORD=${P12_PASSWORD:-}
+            WANTED="Plonk Signing"
+            SELF_SIGNED=yes
+          else
+            echo "::error::neither APPLE_DEVELOPER_ID_P12 nor PLONK_SIGN_CERT_P12 is set — see the header of this workflow"
             exit 1
           fi
           KEYCHAIN="$RUNNER_TEMP/plonk-signing.keychain-db"
@@ -71,11 +118,11 @@ jobs:
           P12_FILE="$RUNNER_TEMP/signing.p12"
           CERT_FILE="$RUNNER_TEMP/signing.pem"
 
-          printf '%s' "$P12" | base64 --decode > "$P12_FILE"
+          printf '%s' "$PAYLOAD" | base64 --decode > "$P12_FILE"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
           security set-keychain-settings -lut 3600 "$KEYCHAIN"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security import "$P12_FILE" -k "$KEYCHAIN" -P "$P12_PASSWORD" \
+          security import "$P12_FILE" -k "$KEYCHAIN" -P "$PAYLOAD_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/security
 
           # "Plonk Signing" is a self-signed root, so nothing on a fresh runner
@@ -84,9 +131,11 @@ jobs:
           # certificate is read back out of the keychain rather than out of the
           # .p12, which would need an openssl new enough for -legacy and the
           # one on the runner is not it.
-          security find-certificate -c "Plonk Signing" -p "$KEYCHAIN" > "$CERT_FILE"
-          sudo security add-trusted-cert -d -r trustRoot \
-            -k /Library/Keychains/System.keychain "$CERT_FILE"
+          if [ "$SELF_SIGNED" = yes ]; then
+            security find-certificate -c "Plonk Signing" -p "$KEYCHAIN" > "$CERT_FILE"
+            sudo security add-trusted-cert -d -r trustRoot \
+              -k /Library/Keychains/System.keychain "$CERT_FILE"
+          fi
 
           # codesign would otherwise stop to ask for the key, and there is
           # nobody here to answer.
@@ -96,19 +145,67 @@ jobs:
             $(security list-keychains -d user | tr -d '"')
           rm -f "$P12_FILE" "$CERT_FILE"
 
-          if ! security find-identity -v -p codesigning | grep -q "Plonk Signing"; then
-            echo "::error::the imported certificate is not a valid codesigning identity named \"Plonk Signing\""
+          if ! security find-identity -v -p codesigning | grep -q "$WANTED"; then
+            echo "::error::the imported certificate is not a valid codesigning identity named \"$WANTED\""
             security find-identity -v -p codesigning
             exit 1
           fi
+
+          # The full name, not the prefix matched above: a Developer ID carries
+          # the account and team in it, which nothing here knows in advance, and
+          # release.sh reads the identity rather than guessing at it.
+          IDENTITY=$(security find-identity -v -p codesigning |
+            sed -n "s/.*\"\($WANTED[^\"]*\)\".*/\1/p" | head -1)
+          echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+          if [ "$SELF_SIGNED" = yes ]; then
+            echo "notarize=no" >> "$GITHUB_OUTPUT"
+          else
+            echo "notarize=yes" >> "$GITHUB_OUTPUT"
+          fi
+          echo "signing with \"$IDENTITY\""
+
+      # notarytool has nobody to prompt here, so the credentials arrive as an
+      # App Store Connect key written to a file for the length of the job. The
+      # laptop path is unchanged and still a keychain profile; release.sh picks
+      # whichever it was given.
+      - name: Write the notarization key
+        if: steps.signing.outputs.notarize == 'yes'
+        env:
+          NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+        run: |
+          set -eu
+          # Caught here rather than after the build: a Developer ID with no key
+          # beside it signs everything correctly and then fails on the upload,
+          # twenty minutes of runner later.
+          if [ -z "${NOTARY_KEY:-}" ] || [ -z "${NOTARY_KEY_ID:-}" ] || [ -z "${NOTARY_ISSUER:-}" ]; then
+            echo "::error::APPLE_DEVELOPER_ID_P12 is set, so this release has to be notarized, but APPLE_NOTARY_KEY, APPLE_NOTARY_KEY_ID and APPLE_NOTARY_ISSUER are not all there"
+            exit 1
+          fi
+          KEY_FILE="$RUNNER_TEMP/notary.p8"
+          printf '%s' "$NOTARY_KEY" | base64 --decode > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          {
+            echo "PLONK_NOTARY_KEY=$KEY_FILE"
+            echo "PLONK_NOTARY_KEY_ID=$NOTARY_KEY_ID"
+            echo "PLONK_NOTARY_ISSUER=$NOTARY_ISSUER"
+          } >> "$GITHUB_ENV"
 
       - name: Test
         run: ./scripts/test.sh
 
       - name: Build, sign and package
         env:
-          PLONK_SIGN_IDENTITY: Plonk Signing
+          PLONK_SIGN_IDENTITY: ${{ steps.signing.outputs.identity }}
         run: ./scripts/release.sh
+
+      # The key is gone from the runner before anything else runs, rather than
+      # left to the cleanup that usually happens. `always()`, because the build
+      # failing is not a reason to leave it lying there.
+      - name: Remove the notarization key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/notary.p8"
 
       # What ties Plonk-<version>.zip to this repository, this commit and this
       # workflow run. Without it the app's own promises are only checkable at
@@ -116,6 +213,13 @@ jobs:
       - uses: actions/attest-build-provenance@v4
         with:
           subject-path: Plonk-${{ steps.version.outputs.version }}.zip
+
+      # The image is a separate artifact and gets its own statement. Ticking
+      # only the zip would leave the download most people take unattested.
+      - uses: actions/attest-build-provenance@v4
+        if: steps.signing.outputs.notarize == 'yes'
+        with:
+          subject-path: Plonk-${{ steps.version.outputs.version }}.dmg
 
       - name: Publish the archive
         env:
@@ -161,9 +265,19 @@ jobs:
           {
             echo "### Plonk $VERSION"
             echo
-            echo "- sha256: \`$SHA\`"
-            echo "- update the cask in \`ostapondo/homebrew-plonk\` with that version and sha256"
+            echo "- zip sha256: \`$SHA\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+          # Only there on the notarized path, so its absence is the normal case
+          # rather than a missing file worth failing over.
+          DMG="Plonk-$VERSION.dmg"
+          if [ -f "$DMG" ]; then
+            gh release upload "v$VERSION" "$DMG" --clobber
+            echo "- dmg sha256: \`$(shasum -a 256 "$DMG" | cut -d' ' -f1)\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "- update the cask in \`ostapondo/homebrew-plonk\` with that version and sha256" \
+            >> "$GITHUB_STEP_SUMMARY"
 
   mcp:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,26 +21,13 @@ name: Release
 #
 # Set the first of those five and this workflow switches paths on its own:
 # Developer ID signing, notarization, a stapled ticket and a .dmg beside the
-# zip. Leave them unset and it behaves exactly as it did before they existed.
-# There is no flag in here to flip.
+# zip. Unset, it behaves exactly as it did before they existed.
 #
-# There is one thing to do by hand, once, and the build stops until it is done:
-# scripts/release-requirement pins the signature every release so far carries,
-# so the first Developer ID run fails that check with the old and new values
-# printed side by side. Commit the new one. release.sh makes that check before
-# it uploads anything to Apple, so finding out costs a build and not a
-# notarization.
-#
-# An API key rather than an Apple ID and an app-specific password, because
-# notarytool cannot be asked anything on a runner: a key is three values that go
-# in as secrets, and it can be revoked by itself without disturbing the account
-# it belongs to.
-#
-# The switch is not free, and it is one-way. A Developer ID signature is a
-# different designated requirement, so scripts/release-requirement has to change
-# in the same commit — and every copy already installed will refuse the update,
-# the way 0.0.5 did. See SECURITY.md; the reason to do it early is that the bill
-# is proportional to how many people are already running it.
+# One thing has to be done by hand, and the build stops until it is. A Developer
+# ID is a different designated requirement, so the first such run fails the
+# check in release.sh with the old and new values printed side by side — commit
+# the new one to scripts/release-requirement. Every installed copy will refuse
+# that update the way 0.0.5 did; SECURITY.md has why it is worth doing early.
 #
 # npm needs no secret at all: plonk-mcp names this repository and this workflow
 # file as a trusted publisher (npmjs.com > the package > Settings > Trusted
@@ -87,13 +74,10 @@ jobs:
             exit 1
           fi
 
-      # One step for both identities, because the keychain dance is the same
-      # either way: create, import, unlock, and tell codesign it may use the key
-      # without stopping to ask. Only two lines differ, and they are the two
-      # that matter — a self-signed root has to be trusted before macOS counts
-      # it as a valid identity at all, and a Developer ID already chains to a
-      # root every Mac ships with, so trusting it by hand would be a lie about
-      # where it came from.
+      # One step for both identities: the keychain dance is the same, and only
+      # the trust line differs. A self-signed root has to be trusted before
+      # macOS counts it as a valid identity at all; a Developer ID already
+      # chains to one every Mac ships with.
       - name: Import the signing certificate
         id: signing
         env:
@@ -238,15 +222,11 @@ jobs:
           DMG="Plonk-$VERSION.dmg"
 
           # The image only exists on the notarized path, so everything below
-          # names what this run actually produced rather than assuming both.
-          # Getting that wrong is not cosmetic: a digest published next to a
-          # file it does not belong to is worse than no digest, because someone
-          # checks it, sees a mismatch, and concludes the download was tampered
-          # with.
+          # names what this run produced. A digest printed next to a file it
+          # does not belong to is worse than none: it reads as tampering.
           #
-          # The positional list rather than a space-separated string, so the
-          # loops below iterate on quoted arguments instead of on whatever the
-          # shell decides to split.
+          # Positional list rather than a string, so the loops iterate on
+          # quoted arguments instead of on however the shell splits.
           set -- "$ZIP"
           if [ -f "$DMG" ]; then
             set -- "$ZIP" "$DMG"

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ mcp/dist/
 mcp/.mcpb-build/
 mcp/*.mcpb
 Plonk-*.zip
+Plonk-*.dmg
 *.p12

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -1,21 +1,13 @@
 #!/bin/sh
 # Packs an already-signed Plonk.app into the disk image a release ships.
 #
-# The zip stays the primary artifact — the Homebrew cask pins its sha256 and
-# every published release so far carries one. This is for the other half of
-# people, who arrive from the site rather than from brew, and for whom a zip
-# that expands into a bundle wherever the browser happened to put it is a worse
-# first minute than a window with an arrow pointing at Applications.
+# Deliberately hdiutil and nothing else. The usual create-dmg wrapper wants Node
+# or Homebrew and drives Finder over AppleScript to place icons, which needs a
+# logged-in session a runner does not have.
 #
-# Deliberately hdiutil and nothing else. The usual create-dmg wrapper wants
-# Node or Homebrew and drives Finder over AppleScript to place icons, which
-# needs a logged-in session that a runner does not have. A plain image with the
-# app and a symlink beside it is what those scripts produce anyway, minus the
-# background picture.
-#
-# Run it after the app is signed, and after notarization has stapled a ticket
-# to it: what is copied in here is what a user drags out, so a bundle stapled
-# afterwards is a bundle nobody gets.
+# Run it after notarization has stapled a ticket to the app: what is copied in
+# here is what a user drags out, so a bundle stapled afterwards is one nobody
+# gets.
 set -eu
 cd "$(dirname "$0")/.."
 . ./version.env
@@ -36,11 +28,9 @@ if ! codesign --verify --deep --strict "$APP" 2>/dev/null; then
 	exit 1
 fi
 
-# The image and the app inside it have to come from the same identity. Nothing
-# downstream would catch a mismatch: each signature is valid on its own, so
-# `codesign --verify` passes on both, and only comparing them shows that a
-# Developer ID build got wrapped in a self-signed image — which is exactly what
-# a run by hand does, since PLONK_SIGN_IDENTITY defaults to the development one.
+# Both signatures verify on their own, so nothing downstream catches a Developer
+# ID app wrapped in a self-signed image — only comparing them does. A run by
+# hand does exactly that, since PLONK_SIGN_IDENTITY defaults to development.
 SIGNER=$(codesign -dvv "$APP" 2>&1 | sed -n 's/^Authority=//p' | head -1)
 if [ "$SIGNER" != "$IDENTITY" ]; then
 	cat >&2 <<MSG
@@ -67,42 +57,31 @@ trap cleanup EXIT
 ditto "$APP" "$STAGING/$APP"
 ln -s /Applications "$STAGING/Applications"
 
-# HFS+ rather than the APFS default. An APFS image will not mount on anything
-# older than the Mac that made it in the way this one needs, and the app runs
-# on macOS 13 — the image should not be the part that refuses.
+# -fs stated rather than inherited, so the image does not quietly change format
+# the day the runner's macOS does.
 rm -f "$DMG"
 hdiutil create -volname "Plonk" -srcfolder "$STAGING" \
 	-fs HFS+ -format UDZO -imagekey zlib-level=9 -quiet -ov "$DMG"
 
-# Signing the image is separate from signing the app inside it. Gatekeeper
-# checks the image on download, and an unsigned one is a warning of its own
-# even when everything it carries is notarized.
+# Gatekeeper checks the image itself on download, so an unsigned one is a
+# warning of its own even when everything inside it is notarized.
 #
-# --identifier, because left to itself codesign takes one from the filename and
-# stops at the first dot: Plonk-0.2.3.dmg signs as "Plonk-0", which is both
-# wrong and different every time the minor version moves.
+# --identifier, because codesign otherwise takes one from the filename and stops
+# at the first dot: Plonk-0.2.3.dmg signs as "Plonk-0", different on every bump.
 codesign --force --identifier dev.plonk.dmg --sign "$IDENTITY" "$DMG"
 codesign --verify --strict "$DMG"
 
-# The zip gets unpacked and checked before it ships, on the grounds that an
-# archiver which mangled the signature would otherwise only be found on a user's
-# Mac. The image deserves the same: what matters is not that it mounts, but that
-# the bundle a user drags out of it is one macOS will still run. ditto is used
-# above precisely because cp -R drops the extended attributes a signature is
-# partly made of, and this is the check that would notice if it ever stopped.
+# The zip is unpacked and checked before it ships; the image gets the same. That
+# it mounts says nothing about whether the bundle inside will still run.
 MOUNT=$(mktemp -d)
 hdiutil attach "$DMG" -mountpoint "$MOUNT" -nobrowse -quiet
 codesign --verify --deep --strict "$MOUNT/$APP"
 
-# Against the requirement recorded in the repo, not the one this bundle carries.
-# Comparing a signature with itself proves nothing; what has to hold is that the
-# copy inside the image still satisfies what every installed Plonk will demand
-# of an update.
+# Against the requirement recorded in the repo, not the one this bundle carries:
+# comparing a signature with itself proves nothing.
 if [ -f scripts/release-requirement ]; then
 	codesign --verify -R="$(cat scripts/release-requirement)" "$MOUNT/$APP"
 fi
 
-# The digest is deliberately not printed here. On the release path this image is
-# stapled after it is built, which rewrites it — a hash from this moment would
-# be a hash of a file that no longer exists by the time anyone reads the log.
+# No digest here: the release path staples this image afterwards, rewriting it.
 echo "wrote $DMG"

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Packs an already-signed Plonk.app into the disk image a release ships.
+#
+# The zip stays the primary artifact — the Homebrew cask pins its sha256 and
+# every published release so far carries one. This is for the other half of
+# people, who arrive from the site rather than from brew, and for whom a zip
+# that expands into a bundle wherever the browser happened to put it is a worse
+# first minute than a window with an arrow pointing at Applications.
+#
+# Deliberately hdiutil and nothing else. The usual create-dmg wrapper wants
+# Node or Homebrew and drives Finder over AppleScript to place icons, which
+# needs a logged-in session that a runner does not have. A plain image with the
+# app and a symlink beside it is what those scripts produce anyway, minus the
+# background picture.
+#
+# Run it after the app is signed, and after notarization has stapled a ticket
+# to it: what is copied in here is what a user drags out, so a bundle stapled
+# afterwards is a bundle nobody gets.
+set -eu
+cd "$(dirname "$0")/.."
+. ./version.env
+
+APP=Plonk.app
+DMG="Plonk-$MARKETING_VERSION.dmg"
+IDENTITY=${PLONK_SIGN_IDENTITY:-Plonk Signing}
+
+if [ ! -d "$APP" ]; then
+	echo "error: $APP is not here — run ./scripts/build.sh first" >&2
+	exit 1
+fi
+
+# An unsigned bundle inside a signed image is still an unsigned bundle, and the
+# failure shows up on a user's Mac rather than here.
+if ! codesign --verify --deep --strict "$APP" 2>/dev/null; then
+	echo "error: $APP is not validly signed; nothing worth packing" >&2
+	exit 1
+fi
+
+STAGING=$(mktemp -d)
+trap 'rm -rf "$STAGING"' EXIT
+
+# ditto rather than cp: a code signature is partly extended attributes, and
+# copying without them produces a bundle that fails the check it just passed.
+ditto "$APP" "$STAGING/$APP"
+ln -s /Applications "$STAGING/Applications"
+
+# HFS+ rather than the APFS default. An APFS image will not mount on anything
+# older than the Mac that made it in the way this one needs, and the app runs
+# on macOS 13 — the image should not be the part that refuses.
+rm -f "$DMG"
+hdiutil create -volname "Plonk" -srcfolder "$STAGING" \
+	-fs HFS+ -format UDZO -imagekey zlib-level=9 -quiet -ov "$DMG"
+
+# Signing the image is separate from signing the app inside it. Gatekeeper
+# checks the image on download, and an unsigned one is a warning of its own
+# even when everything it carries is notarized.
+#
+# --identifier, because left to itself codesign takes one from the filename and
+# stops at the first dot: Plonk-0.2.3.dmg signs as "Plonk-0", which is both
+# wrong and different every time the minor version moves.
+codesign --force --identifier dev.plonk.dmg --sign "$IDENTITY" "$DMG"
+codesign --verify --strict "$DMG"
+
+echo "wrote $DMG"
+echo "sha256: $(shasum -a 256 "$DMG" | cut -d' ' -f1)"

--- a/scripts/make-dmg.sh
+++ b/scripts/make-dmg.sh
@@ -36,8 +36,31 @@ if ! codesign --verify --deep --strict "$APP" 2>/dev/null; then
 	exit 1
 fi
 
+# The image and the app inside it have to come from the same identity. Nothing
+# downstream would catch a mismatch: each signature is valid on its own, so
+# `codesign --verify` passes on both, and only comparing them shows that a
+# Developer ID build got wrapped in a self-signed image — which is exactly what
+# a run by hand does, since PLONK_SIGN_IDENTITY defaults to the development one.
+SIGNER=$(codesign -dvv "$APP" 2>&1 | sed -n 's/^Authority=//p' | head -1)
+if [ "$SIGNER" != "$IDENTITY" ]; then
+	cat >&2 <<MSG
+error: $APP is signed by "$SIGNER", but the image would be signed by "$IDENTITY".
+
+Set PLONK_SIGN_IDENTITY to the identity the app was actually built with.
+MSG
+	exit 1
+fi
+
 STAGING=$(mktemp -d)
-trap 'rm -rf "$STAGING"' EXIT
+MOUNT=
+cleanup() {
+	if [ -n "$MOUNT" ]; then
+		hdiutil detach "$MOUNT" -quiet 2>/dev/null || :
+		rmdir "$MOUNT" 2>/dev/null || :
+	fi
+	rm -rf "$STAGING"
+}
+trap cleanup EXIT
 
 # ditto rather than cp: a code signature is partly extended attributes, and
 # copying without them produces a bundle that fails the check it just passed.
@@ -61,5 +84,25 @@ hdiutil create -volname "Plonk" -srcfolder "$STAGING" \
 codesign --force --identifier dev.plonk.dmg --sign "$IDENTITY" "$DMG"
 codesign --verify --strict "$DMG"
 
+# The zip gets unpacked and checked before it ships, on the grounds that an
+# archiver which mangled the signature would otherwise only be found on a user's
+# Mac. The image deserves the same: what matters is not that it mounts, but that
+# the bundle a user drags out of it is one macOS will still run. ditto is used
+# above precisely because cp -R drops the extended attributes a signature is
+# partly made of, and this is the check that would notice if it ever stopped.
+MOUNT=$(mktemp -d)
+hdiutil attach "$DMG" -mountpoint "$MOUNT" -nobrowse -quiet
+codesign --verify --deep --strict "$MOUNT/$APP"
+
+# Against the requirement recorded in the repo, not the one this bundle carries.
+# Comparing a signature with itself proves nothing; what has to hold is that the
+# copy inside the image still satisfies what every installed Plonk will demand
+# of an update.
+if [ -f scripts/release-requirement ]; then
+	codesign --verify -R="$(cat scripts/release-requirement)" "$MOUNT/$APP"
+fi
+
+# The digest is deliberately not printed here. On the release path this image is
+# stapled after it is built, which rewrites it — a hash from this moment would
+# be a hash of a file that no longer exists by the time anyone reads the log.
 echo "wrote $DMG"
-echo "sha256: $(shasum -a 256 "$DMG" | cut -d' ' -f1)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,16 +42,52 @@ MSG
 	;;
 esac
 
-# notarytool wants credentials it can reuse. Storing them once puts an
-# app-specific password in the keychain instead of in this script's environment.
+# notarytool wants credentials, and the two ways of giving them suit different
+# places. On a laptop a keychain profile is the kind one: stored once, and an
+# app-specific password never appears in this script's environment. A runner has
+# no keychain worth persisting to and no way to answer store-credentials, so CI
+# passes an App Store Connect API key instead — three values that can be handed
+# over as secrets and revoked one key at a time, without touching the Apple ID
+# the account signs in with.
+#
+# A function rather than a variable holding the flags: this is POSIX sh with no
+# arrays, and an issuer UUID interpolated into an unquoted expansion is how
+# argument lists start splitting on surprises.
 PROFILE=${PLONK_NOTARY_PROFILE:-plonk-notary}
-if [ "$NOTARIZE" = yes ] && ! xcrun notarytool history --keychain-profile "$PROFILE" >/dev/null 2>&1; then
-	cat >&2 <<MSG
-error: no stored notarization credentials under profile "$PROFILE".
+notary() {
+	if [ -n "${PLONK_NOTARY_KEY:-}" ]; then
+		xcrun notarytool "$@" \
+			--key "$PLONK_NOTARY_KEY" \
+			--key-id "$PLONK_NOTARY_KEY_ID" \
+			--issuer "$PLONK_NOTARY_ISSUER"
+	else
+		xcrun notarytool "$@" --keychain-profile "$PROFILE"
+	fi
+}
 
-Create an app-specific password at appleid.apple.com, then run once:
+# Half a key is worse than none: it fails after the build, on the upload, with
+# whatever message Apple gives an incomplete request.
+if [ "$NOTARIZE" = yes ] && [ -n "${PLONK_NOTARY_KEY:-}" ]; then
+	if [ ! -f "$PLONK_NOTARY_KEY" ]; then
+		echo "error: PLONK_NOTARY_KEY is set to \"$PLONK_NOTARY_KEY\", which is not a file" >&2
+		exit 1
+	fi
+	if [ -z "${PLONK_NOTARY_KEY_ID:-}" ] || [ -z "${PLONK_NOTARY_ISSUER:-}" ]; then
+		echo "error: PLONK_NOTARY_KEY needs PLONK_NOTARY_KEY_ID and PLONK_NOTARY_ISSUER with it" >&2
+		exit 1
+	fi
+fi
+
+if [ "$NOTARIZE" = yes ] && ! notary history >/dev/null 2>&1; then
+	cat >&2 <<MSG
+error: notarization credentials were rejected, or there are none.
+
+On a laptop, create an app-specific password at appleid.apple.com and run once:
   xcrun notarytool store-credentials "$PROFILE" \\
     --apple-id you@example.com --team-id TEAMID --password APP-SPECIFIC-PASSWORD
+
+In CI, set PLONK_NOTARY_KEY to the .p8 App Store Connect key, with
+PLONK_NOTARY_KEY_ID and PLONK_NOTARY_ISSUER beside it.
 MSG
 	exit 1
 fi
@@ -66,7 +102,7 @@ if [ "$NOTARIZE" = yes ]; then
 	# upload copy is thrown away and the distributed zip is made again after.
 	rm -f "$ZIP"
 	ditto -c -k --keepParent "$APP" "$ZIP"
-	xcrun notarytool submit "$ZIP" --keychain-profile "$PROFILE" --wait
+	notary submit "$ZIP" --wait
 
 	# Stapling puts the ticket inside the bundle, so a first launch works
 	# offline and without a Gatekeeper round trip.
@@ -122,8 +158,34 @@ ditto -x -k "$ZIP" "$CHECK"
 codesign --verify --deep --strict "$CHECK/$APP"
 codesign --verify -R="$REQUIREMENT" "$CHECK/$APP"
 
+# The disk image exists only on the notarized path. Un-notarized it would be a
+# second artifact meeting the same "Open Anyway" wall as the zip, and one more
+# thing for the README to explain in exchange for nothing. Built here, after
+# the requirement check, so a release about to be rejected does not get packed
+# twice — and after stapling, so the bundle a user drags to Applications
+# carries its own ticket and does not need the network on first launch.
+DMG="Plonk-$MARKETING_VERSION.dmg"
+if [ "$NOTARIZE" = yes ]; then
+	PLONK_SIGN_IDENTITY="$IDENTITY" ./scripts/make-dmg.sh
+
+	# The image is notarized in its own right. Stapling the app inside it is
+	# not enough: what a browser marks with the quarantine bit is the .dmg,
+	# and that is the file Gatekeeper is asked about first.
+	notary submit "$DMG" --wait
+	xcrun stapler staple "$DMG"
+
+	# How macOS reads a downloaded image, rather than how it reads an app it
+	# has been asked to run. Both have to pass, and a stapled pair passes
+	# offline.
+	spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG"
+	xcrun stapler validate "$DMG"
+fi
+
 echo
 [ "$NOTARIZE" = yes ] && echo "notarized $APP and wrote $ZIP" || echo "wrote $ZIP (not notarized)"
 echo "requirement: $REQUIREMENT"
 echo "sha256: $(shasum -a 256 "$ZIP" | cut -d' ' -f1)"
+if [ "$NOTARIZE" = yes ]; then
+	echo "dmg sha256: $(shasum -a 256 "$DMG" | cut -d' ' -f1)"
+fi
 echo "update the cask in ostapondo/homebrew-plonk with that version and sha256."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -97,34 +97,17 @@ PLONK_SIGN_IDENTITY="$IDENTITY" ./scripts/build.sh
 APP=Plonk.app
 ZIP="Plonk-$MARKETING_VERSION.zip"
 
-if [ "$NOTARIZE" = yes ]; then
-	# notarytool takes a zip, but stapling writes into the bundle, so this
-	# upload copy is thrown away and the distributed zip is made again after.
-	rm -f "$ZIP"
-	ditto -c -k --keepParent "$APP" "$ZIP"
-	notary submit "$ZIP" --wait
-
-	# Stapling puts the ticket inside the bundle, so a first launch works
-	# offline and without a Gatekeeper round trip.
-	xcrun stapler staple "$APP"
-fi
-
-rm -f "$ZIP"
-ditto -c -k --keepParent "$APP" "$ZIP"
-
-# What a user's Mac will conclude, asked the same way it asks.
-codesign --verify --deep --strict --verbose=2 "$APP"
-if [ "$NOTARIZE" = yes ]; then
-	spctl --assess --type execute --verbose=4 "$APP"
-	xcrun stapler validate "$APP"
-fi
-
 # The requirement every published release has to satisfy, recorded in the repo
 # rather than read back from the bundle being built. Checking a build against
 # its own signature proves nothing: it is the same signature. What has to be
 # caught is the identity *changing* — a release cut on another Mac, a
 # regenerated certificate, a fallback to ad-hoc — because every user's
 # permissions and their ability to update at all hang on it staying put.
+#
+# Checked here, before notarization, because Apple is the slow and finite half
+# of this script. A build that is going to be rejected for its signature should
+# not spend a submission and ten minutes finding that out — and the first
+# Developer ID release is exactly the case that trips it, deliberately.
 EXPECTED=scripts/release-requirement
 REQUIREMENT=$(codesign -d -r- "$APP" 2>/dev/null | sed -n 's/^designated => //p')
 if [ -z "$REQUIREMENT" ]; then
@@ -148,6 +131,28 @@ the first time a Developer ID is used — update $EXPECTED in the same commit an
 say so in the release notes.
 MSG
 	exit 1
+fi
+
+if [ "$NOTARIZE" = yes ]; then
+	# notarytool takes a zip, but stapling writes into the bundle, so this
+	# upload copy is thrown away and the distributed zip is made again after.
+	rm -f "$ZIP"
+	ditto -c -k --keepParent "$APP" "$ZIP"
+	notary submit "$ZIP" --wait
+
+	# Stapling puts the ticket inside the bundle, so a first launch works
+	# offline and without a Gatekeeper round trip.
+	xcrun stapler staple "$APP"
+fi
+
+rm -f "$ZIP"
+ditto -c -k --keepParent "$APP" "$ZIP"
+
+# What a user's Mac will conclude, asked the same way it asks.
+codesign --verify --deep --strict --verbose=2 "$APP"
+if [ "$NOTARIZE" = yes ]; then
+	spctl --assess --type execute --verbose=4 "$APP"
+	xcrun stapler validate "$APP"
 fi
 
 # What ships is the zip, not the bundle it was made from: an archiver that


### PR DESCRIPTION
## Why

`scripts/release.sh` has been able to notarize since it was written. It never
could from CI: the workflow set `PLONK_SIGN_IDENTITY: Plonk Signing`, which
forces the self-signed branch every time. This wires the other branch up.

The Gatekeeper warning is the visible half. The half that costs more is
invisible: TCC keys Accessibility and Screen Recording to the bundle's
designated requirement, and ours currently pins a self-signed root by its own
SHA-1.

```
identifier "dev.plonk.app" and certificate root = H"b8efe1c8…8021"
```

If that certificate is ever regenerated, lost, or lapses, every installed copy
drops both permissions with nothing on screen to explain it, and no copy can
update to anything again. A Developer ID pins Apple's root plus a team ID —
neither of which moves when a certificate is rotated.

## Dormant until the secrets exist

Nothing changes until `APPLE_DEVELOPER_ID_P12` is set. Without it the run is the
one that happens today: self-signed, no notarization, zip only, same
attestation. With it, the workflow switches paths by itself — no flag, nothing
to remember on release day.

| Secret | What it is |
| --- | --- |
| `APPLE_DEVELOPER_ID_P12` | Developer ID Application certificate and key, base64 |
| `APPLE_DEVELOPER_ID_PASSWORD` | its export password |
| `APPLE_NOTARY_KEY` | App Store Connect `.p8`, base64 |
| `APPLE_NOTARY_KEY_ID` | the key's ten-character ID |
| `APPLE_NOTARY_ISSUER` | the issuer UUID |

An API key rather than an Apple ID and app-specific password: `notarytool
store-credentials` cannot be answered on a runner, and a key is revocable on its
own without touching the account.

## What it does

- One import step covers both identities. A self-signed root still gets
  `add-trusted-cert`; a Developer ID does not, since inventing trust for a
  certificate that already has a real chain would be a lie about its origin.
- The identity name is read back out of the keychain rather than guessed —
  a Developer ID carries an account and team that nothing here knows in advance.
- `notary()` in `release.sh` picks the API key when it is there and the keychain
  profile otherwise, so the laptop path is untouched.
- `scripts/make-dmg.sh` packs the image with `hdiutil` and nothing else. The
  usual `create-dmg` wrapper drives Finder over AppleScript for icon placement,
  which needs a logged-in session a runner does not have — and it would be the
  only build dependency in a repo that has none.
- The image is built **after** stapling, so the bundle a user drags out carries
  its own ticket, and is then notarized and stapled itself, because the
  quarantine bit lands on the `.dmg` and that is what Gatekeeper reads first.
- Both artifacts get a provenance attestation; only the zip did.
- The notary key is written to `RUNNER_TEMP`, `chmod 600`, and removed in an
  `always()` step so a failed build does not leave it behind.

## Verified locally

`make-dmg.sh` was run against the current self-signed build — the whole path
except the two Apple round trips, which need an account that does not exist yet:

- image mounts, holds `Plonk.app` and an `Applications` symlink
- `codesign --verify --deep --strict` passes on the app inside, and it still
  satisfies its designated requirement — `ditto` keeps the signature that
  `cp -R` would have stripped
- the requirement inside the image is byte-identical to `scripts/release-requirement`
- the image itself signs and verifies

`lint.sh` clean, `shellcheck -s sh` clean, workflow YAML parses, all ten `app`
steps ordered as intended.

Found and fixed on the way: left to itself `codesign` derives a disk image's
identifier from the filename and stops at the first dot, so `Plonk-0.2.3.dmg`
signed as `Plonk-0` — a different identifier on every minor bump. Set to
`dev.plonk.dmg` explicitly.

## Before this can be merged and used

This is why it is a draft.

1. **Apple Developer Program enrolment**, $99/yr. Nothing else here is blocked
   on anything.
2. **`scripts/release-requirement` has to be updated in the same commit** that
   adds the secrets. `release.sh` will refuse the build otherwise, by design and
   with a clear message. The new value is not knowable until the Team ID exists.
3. **It strands existing installs.** A Developer ID signature is a different
   designated requirement, so copies signed with `Plonk Signing` will not accept
   the update and have to be reinstalled by hand, with both permissions granted
   again — exactly what 0.0.5 did. `SECURITY.md` already makes the argument for
   doing this early: the bill scales with how many people are running it, and
   the latest release currently has 2 downloads.
4. **Docs in the same commit.** `README.md` says "signed, but **not
   notarized**", and `SECURITY.md` explains there is no paid account. Both
   become false the moment this turns on, and AGENTS.md requires they be fixed
   alongside. Not done here, because doing it now would make them false in the
   other direction.
5. **`CHANGELOG.md` deliberately untouched.** Nothing user-visible changes while
   the secrets are absent; the entry belongs to the release that flips it on.

## Unrelated, but found while reading

The bundle signs with `--options runtime` and **no entitlements at all**
(`SECURITY.md` documents this and gives a command to check). Under the hardened
runtime, microphone access normally needs
`com.apple.security.device.audio-input`. Push-to-talk may be relying on
something that will not hold on a clean machine. Left out of this PR on purpose
— it changes runtime behaviour and would make the `SECURITY.md` claim false, so
it deserves its own change with a real test behind it, not a drive-by.