### PR TITLE
feat: give the command palette a key, and let it answer a sentence

### DIFF
--- a/App/Sources/plonk/AppDelegate+Shell.swift
+++ b/App/Sources/plonk/AppDelegate+Shell.swift
@@ -62,6 +62,13 @@ extension AppDelegate {
     }
 
     func openCommandPalette() {
+        // The same key closes it. Reopening instead would rebuild the window
+        // with an empty field, throwing away a half-typed sentence for anyone
+        // who pressed it twice wondering whether it had registered.
+        if presenter.isCommandPaletteOpen {
+            presenter.closeCommandPalette()
+            return
+        }
         presenter.showCommandPalette(commands: paletteCommands(),
                                      agent: store.config.selectedAgent) { [weak self] prompt in
             self?.askAgent(prompt)
@@ -83,12 +90,19 @@ extension AppDelegate {
         process.environment = ProcessInfo.processInfo.environment
             .merging(invocation.environment) { _, prompt in prompt }
 
-        // Kept so a failure can say why and not only that. Both pipes are set:
-        // an adapter that writes more than a pipe buffer and is never read
-        // blocks forever on the write, and then it really has hung.
-        let errors = Pipe()
-        process.standardError = errors
-        process.standardOutput = Pipe()
+        // A file, not a pipe. A pipe nobody is reading fills at about 64 KB and
+        // the adapter blocks on the write for ever — and `claude -p` printing
+        // its answer clears that easily, so attaching one and reading it only
+        // after exit produces exactly the hang this is supposed to report.
+        // Draining it concurrently would work and needs a lock and a reader;
+        // a file cannot block, and the tail is all the HUD ever shows.
+        let errorLog = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("plonk-adapter-\(UUID().uuidString).log")
+        FileManager.default.createFile(atPath: errorLog.path, contents: nil)
+        let errors = try? FileHandle(forWritingTo: errorLog)
+        process.standardError = errors ?? FileHandle.nullDevice
+        // Discarded outright: nothing reads it, and that is the same trap.
+        process.standardOutput = FileHandle.nullDevice
 
         // A ticking HUD for as long as it runs. The agent takes tens of seconds
         // and moves nothing until it has decided what to move, so without this
@@ -98,10 +112,9 @@ extension AppDelegate {
         let started = Date()
         var ticks = 0
         var progress: Timer?
-        // A command that does not exist fails in milliseconds, which can land
-        // before the timer is even scheduled. Without this the stop arrives
-        // first, no-ops, and the ticking it was meant to cancel starts after it
-        // and never ends. Only ever touched on the main thread.
+        // Belt and braces. Both halves are queued on the main thread and the
+        // start is queued first, so FIFO already orders them; this is here so
+        // that stays true if either one ever moves.
         var done = false
         let beat = {
             ticks += 1
@@ -124,8 +137,9 @@ extension AppDelegate {
         }
 
         process.terminationHandler = { finished in
-            let complaint = String(data: errors.fileHandleForReading.readDataToEndOfFile(),
-                                   encoding: .utf8) ?? ""
+            try? errors?.close()
+            let complaint = (try? String(contentsOf: errorLog, encoding: .utf8)) ?? ""
+            try? FileManager.default.removeItem(at: errorLog)
             let last = complaint.split(separator: "\n").last.map(String.init) ?? ""
             let seconds = Int(Date().timeIntervalSince(started).rounded())
             DispatchQueue.main.async {
@@ -161,10 +175,18 @@ extension AppDelegate {
         let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
         let response = router.dispatch(prompt: text)
-        if let error = response.json["error"] as? String {
-            HUD.shared.show(error)
+        let agent = (response.json["agent"] as? String) ?? "agent"
+        if response.json["error"] != nil {
+            // Router answers an API caller, and tells it to pass an "agent"
+            // field. There is no field here — there is a menu.
+            HUD.shared.show(store.config.selectedAgent == nil
+                            ? "No active agent. Pick one from the menu bar first."
+                            : (response.json["error"] as? String ?? "That did not go anywhere"))
+        } else if let note = response.json["note"] as? String {
+            // Queued for a session that has never connected. Saying "→ agent"
+            // here would be the silent success this was meant to stop.
+            HUD.shared.show("Waiting for \(agent) to connect: \(note)")
         } else {
-            let agent = (response.json["agent"] as? String) ?? "agent"
             HUD.shared.show("→ \(agent): \(text)")
         }
     }
@@ -187,7 +209,10 @@ extension AppDelegate {
     func paletteCommands() -> [PlonkCommand] {
         var result: [PlonkCommand] = []
 
-        for action in HotkeyAction.allCases {
+        // Every action but the one that opened this. Running it would hide the
+        // window to reach the front app and then reopen the palette on top of
+        // nothing, which is a loop with a side effect.
+        for action in HotkeyAction.allCases where action != .commandPalette {
             result.append(PlonkCommand(id: "hotkey.\(action.rawValue)",
                                        title: action.title,
                                        group: action.group,

--- a/App/Sources/plonk/AppDelegate+Shell.swift
+++ b/App/Sources/plonk/AppDelegate+Shell.swift
@@ -42,8 +42,45 @@ extension AppDelegate {
         store.config.appearance.apply(to: NSApp)
     }
 
+    /// A spoken command, run through the same calls the hotkeys use — so a
+    /// sentence cannot reach anything a key could not.
+    func run(_ command: VoiceCommand) {
+        switch command {
+        case .preset(let preset): commands.apply(preset)
+        case .zone(let number): commands.snap(toZone: number)
+        case .putBack: commands.unsnap()
+        case .focus(let direction): commands.moveFocus(direction)
+        case .cycleZone: commands.cycleZone(backwards: false)
+        case .showZones: dragSnap.previewZones()
+        case .awake(let minutes):
+            setAwakeTimeout(minutes: minutes ?? 0)
+            setAwake(true)
+        case .awakeOff: setAwake(false)
+        case .capture(let mode): runCapture(mode, openEditor: false)
+        case .launchWorkspace(let name): launchWorkspace(named: name, onScreen: nil)
+        }
+    }
+
     func openCommandPalette() {
-        presenter.showCommandPalette(commands: paletteCommands())
+        presenter.showCommandPalette(commands: paletteCommands(),
+                                     agent: store.config.selectedAgent) { [weak self] prompt in
+            self?.askAgent(prompt)
+        }
+    }
+
+    /// Whatever was typed into the palette that was not a command. It takes the
+    /// same call the voice path makes, so a sentence typed and a sentence spoken
+    /// reach the agent by one road and fail in one way.
+    func askAgent(_ prompt: String) {
+        let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        let response = router.dispatch(prompt: text)
+        if let error = response.json["error"] as? String {
+            HUD.shared.show(error)
+        } else {
+            let agent = (response.json["agent"] as? String) ?? "agent"
+            HUD.shared.show("→ \(agent): \(text)")
+        }
     }
 
     /// Every shortcut acts on whatever window is in front, and while the palette

--- a/App/Sources/plonk/AppDelegate+Shell.swift
+++ b/App/Sources/plonk/AppDelegate+Shell.swift
@@ -68,6 +68,92 @@ extension AppDelegate {
         }
     }
 
+    /// Runs a CLI adapter for a prompt, and says on screen how it went.
+    ///
+    /// The process can take the better part of a minute, so "it started" and
+    /// "it worked" are different pieces of news and both have to be delivered.
+    /// Before this only the first one was, for two seconds, and a failure was
+    /// an NSLog nobody reads — which from the palette looked exactly like a
+    /// window closing and nothing happening.
+    func launchAdapter(_ adapter: AgentAdapter, prompt: String) {
+        let invocation = AgentAdapter.invocation(command: adapter.command, prompt: prompt)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", invocation.command]
+        process.environment = ProcessInfo.processInfo.environment
+            .merging(invocation.environment) { _, prompt in prompt }
+
+        // Kept so a failure can say why and not only that. Both pipes are set:
+        // an adapter that writes more than a pipe buffer and is never read
+        // blocks forever on the write, and then it really has hung.
+        let errors = Pipe()
+        process.standardError = errors
+        process.standardOutput = Pipe()
+
+        // A ticking HUD for as long as it runs. The agent takes tens of seconds
+        // and moves nothing until it has decided what to move, so without this
+        // the whole middle of the job looks identical to nothing happening —
+        // which is exactly what it was mistaken for. The count is what makes it
+        // readable as progress rather than as a stuck label.
+        let started = Date()
+        var ticks = 0
+        var progress: Timer?
+        // A command that does not exist fails in milliseconds, which can land
+        // before the timer is even scheduled. Without this the stop arrives
+        // first, no-ops, and the ticking it was meant to cancel starts after it
+        // and never ends. Only ever touched on the main thread.
+        var done = false
+        let beat = {
+            ticks += 1
+            let dots = String(repeating: "·", count: 1 + ticks % 3)
+            let seconds = Int(Date().timeIntervalSince(started).rounded())
+            // Longer than the interval, so the panel never blinks out between
+            // beats, and short enough to clear itself if this stops ticking.
+            HUD.shared.show("\(adapter.name) is working \(dots)  \(seconds)s", duration: 3)
+        }
+        let stop = {
+            done = true
+            progress?.invalidate()
+            progress = nil
+        }
+
+        DispatchQueue.main.async {
+            guard !done else { return }
+            beat()
+            progress = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: true) { _ in beat() }
+        }
+
+        process.terminationHandler = { finished in
+            let complaint = String(data: errors.fileHandleForReading.readDataToEndOfFile(),
+                                   encoding: .utf8) ?? ""
+            let last = complaint.split(separator: "\n").last.map(String.init) ?? ""
+            let seconds = Int(Date().timeIntervalSince(started).rounded())
+            DispatchQueue.main.async {
+                stop()
+                if finished.terminationStatus == 0 {
+                    HUD.shared.show("✓ \(adapter.name) finished in \(seconds)s")
+                } else {
+                    HUD.shared.show("✗ \(adapter.name) failed (\(finished.terminationStatus))"
+                                    + (last.isEmpty ? "" : ": \(last.prefix(70))"))
+                }
+            }
+        }
+
+        // Adapters may run for minutes, so they never touch the main thread.
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try process.run()
+            } catch {
+                // terminationHandler never runs for a process that never ran,
+                // so the ticking has to be stopped from here or it ticks for ever.
+                DispatchQueue.main.async {
+                    stop()
+                    HUD.shared.show("\(adapter.name) would not start: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
     /// Whatever was typed into the palette that was not a command. It takes the
     /// same call the voice path makes, so a sentence typed and a sentence spoken
     /// reach the agent by one road and fail in one way.

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -16,11 +16,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let updates = UpdateManager()
     let model = AppModel()
     private let snapMemory = SnapMemory()
-    private lazy var commands = WindowCommands(windows: windows, memory: snapMemory)
+    lazy var commands = WindowCommands(windows: windows, memory: snapMemory)
     private lazy var launcher = WorkspaceLauncher(windows: windows)
     lazy var presenter = WindowPresenter(model: model)
     private var statusMenu: StatusMenuController!
-    private var dragSnap: DragSnapManager!
+    var dragSnap: DragSnapManager!
     private var grabMove: GrabMove!
     private var newWindows: NewWindowWatcher!
     private let mouse = MouseTools()
@@ -29,7 +29,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var guideLoading = false
     /// How many captures are in flight; see hideOwnWindows.
     private var captureDepth = 0
-    private var router: Router!
+    var router: Router!
     private var server: ControlServer?
     private var previewToken = 0
     private var screenSettleWork: DispatchWorkItem?
@@ -221,6 +221,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             pinCrop(live: false)
         case .shortcutGuide:
             toggleShortcutGuide()
+        case .commandPalette:
+            openCommandPalette()
         default:
             if let number = action.zoneNumber {
                 commands.snap(toZone: number)
@@ -233,25 +235,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             } else if let preset = action.preset {
                 commands.apply(preset)
             }
-        }
-    }
-
-    /// A spoken command, run through the same calls the hotkeys use — so a
-    /// sentence cannot reach anything a key could not.
-    private func run(_ command: VoiceCommand) {
-        switch command {
-        case .preset(let preset): commands.apply(preset)
-        case .zone(let number): commands.snap(toZone: number)
-        case .putBack: commands.unsnap()
-        case .focus(let direction): commands.moveFocus(direction)
-        case .cycleZone: commands.cycleZone(backwards: false)
-        case .showZones: dragSnap.previewZones()
-        case .awake(let minutes):
-            setAwakeTimeout(minutes: minutes ?? 0)
-            setAwake(true)
-        case .awakeOff: setAwake(false)
-        case .capture(let mode): runCapture(mode, openEditor: false)
-        case .launchWorkspace(let name): launchWorkspace(named: name, onScreen: nil)
         }
     }
 
@@ -835,7 +818,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Screenshot
 
-    private func runCapture(_ mode: CaptureMode, openEditor: Bool,
+    func runCapture(_ mode: CaptureMode, openEditor: Bool,
                             completion: @escaping (NSImage?) -> Void = { _ in }) {
         let hidden = hideOwnWindows()
         ScreenshotManager.capture(mode) { [weak self] image in

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -561,21 +561,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let self else { return done([["ok": false, "error": "shutting down"]]) }
             launcher.launch(workspace, named: name, onScreen: screen, completion: done)
         }
-        // Adapters may run for minutes, so they never touch the main thread.
-        router.runAdapter = { adapter, prompt in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let invocation = AgentAdapter.invocation(command: adapter.command, prompt: prompt)
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-                process.arguments = ["-lc", invocation.command]
-                process.environment = ProcessInfo.processInfo.environment
-                    .merging(invocation.environment) { _, prompt in prompt }
-                do {
-                    try process.run()
-                } catch {
-                    NSLog("Plonk: adapter \(adapter.name) failed to start: \(error)")
-                }
-            }
+        router.runAdapter = { [weak self] adapter, prompt in
+            self?.launchAdapter(adapter, prompt: prompt)
         }
 
         let token = APIToken.loadOrCreate()

--- a/App/Sources/plonk/CommandPalette.swift
+++ b/App/Sources/plonk/CommandPalette.swift
@@ -16,6 +16,27 @@ struct PlonkCommand: Identifiable {
     let run: () -> Void
 }
 
+extension PlonkCommand {
+    /// The row that hands what was typed to an agent instead of matching it
+    /// against anything. It is what makes the palette answer a sentence — "put
+    /// the browser left and the terminal top right" is not a command and never
+    /// will be, but it is the kind of thing people want to type here.
+    ///
+    /// Nil for an empty query, because a palette offering to send nothing is
+    /// offering a mistake.
+    static func ask(_ query: String, agent: String?, run: @escaping () -> Void) -> PlonkCommand? {
+        let prompt = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { return nil }
+        let named = (agent ?? "").trimmingCharacters(in: .whitespaces)
+        // Named when one is selected, so it is obvious where the sentence went;
+        // vague when none is, because that is the honest state and the HUD says
+        // the rest when it fails.
+        let who = named.isEmpty ? "the agent" : named
+        return PlonkCommand(id: "agent.ask", title: "Ask \(who): “\(prompt)”",
+                            group: "Agent", keys: ["⌘", "return"], run: run)
+    }
+}
+
 extension Array where Element == PlonkCommand {
     /// The commands matching `query`, best first.
     ///

--- a/App/Sources/plonk/CommandPaletteView.swift
+++ b/App/Sources/plonk/CommandPaletteView.swift
@@ -96,7 +96,11 @@ struct CommandPaletteView: View {
     /// that matches a real command should run it, not send a sentence about it
     /// on a round trip, and ⌘return is there for when that is what was meant.
     private var askRow: PlonkCommand? {
-        PlonkCommand.ask(query, agent: agent) { onAsk(query) }
+        // The value, not the binding. This runs a runloop turn after onClose()
+        // has torn the hosting view down, and reading @State by then can hand
+        // back the empty string it started as — which askAgent silently drops.
+        let prompt = query
+        return PlonkCommand.ask(prompt, agent: agent) { onAsk(prompt) }
     }
 
     /// Groups in the order the commands arrived, so the list does not reshuffle

--- a/App/Sources/plonk/CommandPaletteView.swift
+++ b/App/Sources/plonk/CommandPaletteView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct CommandPaletteView: View {
     let commands: [PlonkCommand]
+    /// The agent a sentence would go to, for the label on the ask row.
+    var agent: String?
+    let onAsk: (String) -> Void
     let onClose: () -> Void
     @Environment(\.colorScheme) private var scheme
 
@@ -40,7 +43,7 @@ struct CommandPaletteView: View {
     private var field: some View {
         HStack(spacing: 10) {
             Image(systemName: "magnifyingglass").foregroundStyle(.tertiary)
-            TextField("Run a command", text: $query)
+            TextField("Run a command, or say what you want done", text: $query)
                 .textFieldStyle(.plain)
                 .font(.system(size: 15))
                 .focused($focused)
@@ -89,6 +92,13 @@ struct CommandPaletteView: View {
         }
     }
 
+    /// Whatever was typed, offered to the agent. Deliberately last: a query
+    /// that matches a real command should run it, not send a sentence about it
+    /// on a round trip, and ⌘return is there for when that is what was meant.
+    private var askRow: PlonkCommand? {
+        PlonkCommand.ask(query, agent: agent) { onAsk(query) }
+    }
+
     /// Groups in the order the commands arrived, so the list does not reshuffle
     /// itself alphabetically while it is being typed into.
     private var sections: [(name: String, commands: [PlonkCommand])] {
@@ -98,7 +108,9 @@ struct CommandPaletteView: View {
             if !order.contains(command.group) { order.append(command.group) }
             byGroup[command.group, default: []].append(command)
         }
-        return order.map { ($0, byGroup[$0] ?? []) }
+        var result = order.map { ($0, byGroup[$0] ?? []) }
+        if let askRow { result.append((name: "Agent", commands: [askRow])) }
+        return result
     }
 
     private func row(_ command: PlonkCommand) -> some View {
@@ -126,11 +138,9 @@ struct CommandPaletteView: View {
         HStack(spacing: 14) {
             hint(["↑", "↓"], "navigate")
             hint(["return"], "run")
+            hint(["⌘", "return"], "ask the agent")
             hint(["esc"], "close")
             Spacer()
-            Text("Anything an agent can do, you can type")
-                .font(.system(size: 10.5))
-                .foregroundStyle(.tertiary)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 9)
@@ -142,6 +152,14 @@ struct CommandPaletteView: View {
             KeyCaps(parts: keys)
             Text(label).font(.system(size: 10.5)).foregroundStyle(.tertiary)
         }
+    }
+
+    /// Skips the selection entirely: ⌘return means "send what I typed", whatever
+    /// the list happens to be highlighting.
+    private func askSelected() {
+        guard let askRow else { return }
+        onClose()
+        DispatchQueue.main.async { askRow.run() }
     }
 
     private func runSelected() {
@@ -165,6 +183,8 @@ struct CommandPaletteView: View {
             case 125: move(1); return nil      // down
             case 126: move(-1); return nil     // up
             case 53: onClose(); return nil     // escape
+            case 36 where event.modifierFlags.contains(.command):
+                askSelected(); return nil      // return
             default: return event
             }
         }

--- a/App/Sources/plonk/EditMenu.swift
+++ b/App/Sources/plonk/EditMenu.swift
@@ -1,0 +1,51 @@
+import AppKit
+
+// The menu nobody sees, and every text field needs.
+//
+// ⌘C, ⌘V, ⌘X, ⌘A and ⌘Z are not built into NSTextField. AppKit delivers them
+// by asking the main menu for a matching key equivalent and sending the
+// selector down the responder chain — so an app with no main menu has text
+// fields that cannot be pasted into, and there is nothing in the field itself
+// to fix. Plonk had none, which is why the command palette would take a typed
+// sentence but not a pasted one.
+//
+// An accessory app never draws a menu bar, so this adds no visible surface: it
+// exists purely so `performKeyEquivalent` has somewhere to look. Nothing here
+// has a target, on purpose — nil means the responder chain, which is the field
+// that happens to be focused.
+
+enum EditMenu {
+    static func install(on app: NSApplication) {
+        let edit = NSMenu(title: "Edit")
+        for item in items() { edit.addItem(item) }
+
+        let editItem = NSMenuItem()
+        editItem.submenu = edit
+
+        let main = NSMenu()
+        main.addItem(editItem)
+        app.mainMenu = main
+    }
+
+    private static func items() -> [NSMenuItem] {
+        [
+            item("Undo", "undo:", "z"),
+            item("Redo", "redo:", "Z"),
+            .separator(),
+            item("Cut", "cut:", "x"),
+            item("Copy", "copy:", "c"),
+            item("Paste", "paste:", "v"),
+            item("Select All", "selectAll:", "a"),
+        ]
+    }
+
+    /// An uppercase key means shift is part of the equivalent, which is how
+    /// AppKit spells ⌘⇧Z without a separate modifier mask.
+    private static func item(_ title: String, _ selector: String, _ key: String) -> NSMenuItem {
+        let shifted = key != key.lowercased()
+        let entry = NSMenuItem(title: title, action: Selector(selector),
+                               keyEquivalent: key.lowercased())
+        entry.keyEquivalentModifierMask = shifted ? [.command, .shift] : [.command]
+        return entry
+    }
+}

--- a/App/Sources/plonk/Hotkey.swift
+++ b/App/Sources/plonk/Hotkey.swift
@@ -159,6 +159,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     case findCursor, jumpCursor
     case cropLive, cropStill
     case shortcutGuide
+    case commandPalette
 
     var id: String { rawValue }
 
@@ -238,6 +239,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .cropLive: return "Pin a live crop on top"
         case .cropStill: return "Pin a still crop on top"
         case .shortcutGuide: return "Show this app's shortcuts"
+        case .commandPalette: return "Open the command palette"
         default:
             if let number = zoneNumber { return "Zone \(number)" }
             if let number = layoutNumber { return "Zone set \(number)" }
@@ -263,6 +265,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .cropLive: return "pip"
         case .cropStill: return "photo"
         case .shortcutGuide: return "keyboard"
+        case .commandPalette: return "command"
         default:
             if zoneNumber != nil { return "square.grid.2x2" }
             if layoutNumber != nil { return "rectangle.3.group" }
@@ -278,7 +281,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .unsnap: return "Numbered zones"
         case .cycleZone, .cycleZoneBack, .focusLeft, .focusRight, .focusUp, .focusDown: return "Focus"
         case .findCursor, .jumpCursor: return "Pointer"
-        case .shortcutGuide: return "Guide"
+        case .shortcutGuide, .commandPalette: return "Guide"
         case .cropLive, .cropStill: return "Crop"
         default:
             if zoneNumber != nil { return "Numbered zones" }
@@ -293,7 +296,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .captureRegion, .captureText, .cropLive, .cropStill: return "shot"
         case .findCursor, .jumpCursor: return "mouse"
         case .voice: return "voice"
-        case .shortcutGuide: return "shortcuts"
+        case .shortcutGuide, .commandPalette: return "shortcuts"
         default: return "zones"
         }
     }
@@ -304,61 +307,5 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
 
     static func owned(by page: String, group: String) -> [HotkeyAction] {
         allCases.filter { $0.page == page && $0.group == group }
-    }
-
-    var defaultHotkey: Hotkey {
-        let code: Int
-        var shift = false
-        switch self {
-        case .leftHalf: code = kVK_LeftArrow
-        case .rightHalf: code = kVK_RightArrow
-        case .topHalf: code = kVK_UpArrow
-        case .bottomHalf: code = kVK_DownArrow
-        case .topLeft: code = kVK_ANSI_U
-        case .topRight: code = kVK_ANSI_I
-        case .bottomLeft: code = kVK_ANSI_J
-        case .bottomRight: code = kVK_ANSI_K
-        case .maximize: code = kVK_Return
-        case .center: code = kVK_ANSI_C
-        case .showZones: code = kVK_ANSI_Z
-        case .captureRegion: code = kVK_ANSI_S
-        case .captureText: code = kVK_ANSI_T
-        case .voice: code = kVK_ANSI_V
-        case .zone1: code = kVK_ANSI_1
-        case .zone2: code = kVK_ANSI_2
-        case .zone3: code = kVK_ANSI_3
-        case .zone4: code = kVK_ANSI_4
-        case .zone5: code = kVK_ANSI_5
-        case .zone6: code = kVK_ANSI_6
-        case .zone7: code = kVK_ANSI_7
-        case .zone8: code = kVK_ANSI_8
-        case .zone9: code = kVK_ANSI_9
-        case .layout1: code = kVK_ANSI_1; shift = true
-        case .layout2: code = kVK_ANSI_2; shift = true
-        case .layout3: code = kVK_ANSI_3; shift = true
-        case .layout4: code = kVK_ANSI_4; shift = true
-        case .layout5: code = kVK_ANSI_5; shift = true
-        case .layout6: code = kVK_ANSI_6; shift = true
-        case .layout7: code = kVK_ANSI_7; shift = true
-        case .layout8: code = kVK_ANSI_8; shift = true
-        case .layout9: code = kVK_ANSI_9; shift = true
-        case .unsnap: code = kVK_ANSI_0
-        case .cycleZone: code = kVK_ANSI_Grave
-        case .cycleZoneBack: code = kVK_ANSI_Grave; shift = true
-        case .focusLeft: code = kVK_LeftArrow; shift = true
-        case .focusRight: code = kVK_RightArrow; shift = true
-        case .focusUp: code = kVK_UpArrow; shift = true
-        case .focusDown: code = kVK_DownArrow; shift = true
-        case .findCursor: code = kVK_ANSI_Slash
-        case .jumpCursor: code = kVK_ANSI_Backslash
-        case .cropLive: code = kVK_ANSI_P
-        case .cropStill: code = kVK_ANSI_P; shift = true
-        case .shortcutGuide: code = kVK_ANSI_Slash; shift = true
-        }
-        return Hotkey(keyCode: UInt32(code), control: true, option: true, shift: shift)
-    }
-
-    static var defaults: [String: String] {
-        allCases.reduce(into: [:]) { $0[$1.rawValue] = $1.defaultHotkey.spec }
     }
 }

--- a/App/Sources/plonk/HotkeyDefaults.swift
+++ b/App/Sources/plonk/HotkeyDefaults.swift
@@ -1,0 +1,70 @@
+import Carbon.HIToolbox
+
+// What each action is bound to out of the box.
+//
+// Split out of Hotkey.swift, which is over the line limit: the enum there
+// says what an action *is*, and this says what key it arrives on. Every
+// binding is ⌃⌥ and something, which is the one combination macOS itself
+// leaves alone and no app in the wild seems to want.
+
+extension HotkeyAction {
+    var defaultHotkey: Hotkey {
+        let code: Int
+        var shift = false
+        switch self {
+        case .leftHalf: code = kVK_LeftArrow
+        case .rightHalf: code = kVK_RightArrow
+        case .topHalf: code = kVK_UpArrow
+        case .bottomHalf: code = kVK_DownArrow
+        case .topLeft: code = kVK_ANSI_U
+        case .topRight: code = kVK_ANSI_I
+        case .bottomLeft: code = kVK_ANSI_J
+        case .bottomRight: code = kVK_ANSI_K
+        case .maximize: code = kVK_Return
+        case .center: code = kVK_ANSI_C
+        case .showZones: code = kVK_ANSI_Z
+        case .captureRegion: code = kVK_ANSI_S
+        case .captureText: code = kVK_ANSI_T
+        case .voice: code = kVK_ANSI_V
+        case .zone1: code = kVK_ANSI_1
+        case .zone2: code = kVK_ANSI_2
+        case .zone3: code = kVK_ANSI_3
+        case .zone4: code = kVK_ANSI_4
+        case .zone5: code = kVK_ANSI_5
+        case .zone6: code = kVK_ANSI_6
+        case .zone7: code = kVK_ANSI_7
+        case .zone8: code = kVK_ANSI_8
+        case .zone9: code = kVK_ANSI_9
+        case .layout1: code = kVK_ANSI_1; shift = true
+        case .layout2: code = kVK_ANSI_2; shift = true
+        case .layout3: code = kVK_ANSI_3; shift = true
+        case .layout4: code = kVK_ANSI_4; shift = true
+        case .layout5: code = kVK_ANSI_5; shift = true
+        case .layout6: code = kVK_ANSI_6; shift = true
+        case .layout7: code = kVK_ANSI_7; shift = true
+        case .layout8: code = kVK_ANSI_8; shift = true
+        case .layout9: code = kVK_ANSI_9; shift = true
+        case .unsnap: code = kVK_ANSI_0
+        case .cycleZone: code = kVK_ANSI_Grave
+        case .cycleZoneBack: code = kVK_ANSI_Grave; shift = true
+        case .focusLeft: code = kVK_LeftArrow; shift = true
+        case .focusRight: code = kVK_RightArrow; shift = true
+        case .focusUp: code = kVK_UpArrow; shift = true
+        case .focusDown: code = kVK_DownArrow; shift = true
+        case .findCursor: code = kVK_ANSI_Slash
+        case .jumpCursor: code = kVK_ANSI_Backslash
+        case .cropLive: code = kVK_ANSI_P
+        case .cropStill: code = kVK_ANSI_P; shift = true
+        case .shortcutGuide: code = kVK_ANSI_Slash; shift = true
+        // Space, because the thing it opens is the one surface here that
+        // answers a sentence rather than a key, and that is where every Mac
+        // user's hand already goes for exactly that.
+        case .commandPalette: code = kVK_Space
+        }
+        return Hotkey(keyCode: UInt32(code), control: true, option: true, shift: shift)
+    }
+
+    static var defaults: [String: String] {
+        allCases.reduce(into: [:]) { $0[$1.rawValue] = $1.defaultHotkey.spec }
+    }
+}

--- a/App/Sources/plonk/HotkeyDefaults.swift
+++ b/App/Sources/plonk/HotkeyDefaults.swift
@@ -56,10 +56,11 @@ extension HotkeyAction {
         case .cropLive: code = kVK_ANSI_P
         case .cropStill: code = kVK_ANSI_P; shift = true
         case .shortcutGuide: code = kVK_ANSI_Slash; shift = true
-        // Space, because the thing it opens is the one surface here that
-        // answers a sentence rather than a key, and that is where every Mac
-        // user's hand already goes for exactly that.
-        case .commandPalette: code = kVK_Space
+        // Not Space, however much it wants to be: ⌃⌥Space is macOS's own
+        // "Select next source in Input menu", on by default and live the
+        // moment a second keyboard layout exists. It would take the key
+        // silently and switch the layout instead.
+        case .commandPalette: code = kVK_ANSI_A
         }
         return Hotkey(keyCode: UInt32(code), control: true, option: true, shift: shift)
     }

--- a/App/Sources/plonk/ShortcutsPage.swift
+++ b/App/Sources/plonk/ShortcutsPage.swift
@@ -33,11 +33,18 @@ struct ShortcutsPage: View {
                 }
             }
             Section {
-                ShortcutRows(model: model, actions: HotkeyAction.owned(by: "shortcuts"))
+                ShortcutRows(model: model, actions: [.shortcutGuide])
             } header: {
                 Text("Guide")
             } footer: {
                 Text("Opens every shortcut the app in front actually has, read from its own menus — so it is never out of date, and it works for software with no documentation at all. Press it again to close.")
+            }
+            Section {
+                ShortcutRows(model: model, actions: [.commandPalette])
+            } header: {
+                Text("Palette")
+            } footer: {
+                Text("Run anything in Plonk by name, over whatever you are looking at. What is not a command can be sent to the active agent as a sentence, with ⌘return. Press the key again to close it.")
             }
             ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
                 Section(group.name) {

--- a/App/Sources/plonk/WindowPresenter.swift
+++ b/App/Sources/plonk/WindowPresenter.swift
@@ -47,7 +47,8 @@ final class WindowPresenter: NSObject {
 
     /// ⌘K. Rebuilt on every open rather than kept around, because the commands
     /// it lists change with the workspaces, the zone sets and the bindings.
-    func showCommandPalette(commands: [PlonkCommand]) {
+    func showCommandPalette(commands: [PlonkCommand], agent: String?,
+                            onAsk: @escaping (String) -> Void) {
         closeCommandPalette()
         let window = EditorWindow(contentRect: .zero, styleMask: .borderless,
                                   backing: .buffered, defer: false)
@@ -62,7 +63,7 @@ final class WindowPresenter: NSObject {
         // keeps eating the arrow keys.
         window.delegate = self
         window.contentViewController = NSHostingController(
-            rootView: CommandPaletteView(commands: commands) { [weak self] in
+            rootView: CommandPaletteView(commands: commands, agent: agent, onAsk: onAsk) { [weak self] in
                 self?.closeCommandPalette()
             }
         )

--- a/App/Sources/plonk/WindowPresenter.swift
+++ b/App/Sources/plonk/WindowPresenter.swift
@@ -45,6 +45,8 @@ final class WindowPresenter: NSObject {
         present(main)
     }
 
+    var isCommandPaletteOpen: Bool { palette != nil }
+
     /// ⌘K. Rebuilt on every open rather than kept around, because the commands
     /// it lists change with the workspaces, the zone sets and the bindings.
     func showCommandPalette(commands: [PlonkCommand], agent: String?,

--- a/App/Sources/plonk/main.swift
+++ b/App/Sources/plonk/main.swift
@@ -4,4 +4,5 @@ let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate
 app.setActivationPolicy(.accessory)
+EditMenu.install(on: app)
 app.run()

--- a/App/Tests/plonkTests/CommandPaletteTests.swift
+++ b/App/Tests/plonkTests/CommandPaletteTests.swift
@@ -54,3 +54,29 @@ private let sample = [
         #expect([command("a")].matching("aa").isEmpty)
     }
 }
+
+@Suite struct AskRowTests {
+    @Test func anEmptyQueryOffersNothingToSend() {
+        #expect(PlonkCommand.ask("", agent: "claude-code") {} == nil)
+        #expect(PlonkCommand.ask("   \n ", agent: "claude-code") {} == nil)
+    }
+
+    @Test func theRowNamesTheAgentAndQuotesWhatWasTyped() {
+        let row = PlonkCommand.ask("  put the browser left  ", agent: "claude-code") {}
+        #expect(row?.title == "Ask claude-code: “put the browser left”")
+        #expect(row?.group == "Agent")
+    }
+
+    @Test func withNoAgentSelectedItStaysVague() {
+        #expect(PlonkCommand.ask("save this", agent: nil) {}?.title == "Ask the agent: “save this”")
+        #expect(PlonkCommand.ask("save this", agent: "  ") {}?.title == "Ask the agent: “save this”")
+    }
+
+    /// The ask row is not a command, so it must never be filtered out by the
+    /// matcher — a sentence that matches nothing is exactly when it is needed.
+    @Test func theRowIsNotSubjectToCommandMatching() {
+        let row = PlonkCommand.ask("zzzz qqqq", agent: nil) {}
+        #expect(row != nil)
+        #expect(sample.matching("zzzz qqqq").isEmpty)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ attestation, so `gh attestation verify` fails on them. That is the whole reason
 [the release workflow](.github/workflows/release.yml) exists now. Do not install
 one of those.
 
+## Unreleased
+
+### Added
+
+- **The command palette has a key of its own — `⌃⌥Space`.** It was already
+  there, and it was reachable only from inside Plonk's own window, which is the
+  one place you are not when you want to move a window. It now opens over
+  whatever you are looking at, the way Spotlight does.
+- **Type a sentence into it and it goes to your agent.** Anything that is not a
+  command — "put the browser left and the terminal top right", "save this as a
+  workspace called review" — can be sent as it is, with `⌘return` or by picking
+  the last row. It takes the same road a spoken command takes, so it can reach
+  nothing a key could not.
+
 ## 0.2.3 — 2026-08-09
 
 Nothing in the app changed. This release exists so the MCP server can be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ one of those.
 
 ### Added
 
-- **The command palette has a key of its own — `⌃⌥Space`.** It was already
+- **The command palette has a key of its own — `⌃⌥A`.** It was already
   there, and it was reachable only from inside Plonk's own window, which is the
   one place you are not when you want to move a window. It now opens over
   whatever you are looking at, the way Spotlight does.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ one of those.
 
 ## Unreleased
 
+### Fixed
+
+- **⌘C, ⌘V, ⌘X and ⌘A work in Plonk's text fields.** They never had, anywhere
+  in the app: AppKit delivers those through the main menu's key equivalents,
+  and Plonk had no main menu at all, so a field would take a typed sentence but
+  not a pasted one. An accessory app draws no menu bar, so the menu that fixes
+  it stays invisible.
+
 ### Added
 
 - **The command palette has a key of its own — `⌃⌥Space`.** It was already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ one of those.
 
 ### Fixed
 
+- **A prompt sent to an agent now shows what it is doing.** A CLI adapter takes
+  tens of seconds and moves nothing until it has decided what to move, so the
+  palette closing was followed by a two-second HUD and then silence — which
+  looks exactly like nothing happening. There is now a ticking count for as
+  long as it runs, and it ends on how it went. A failure used to be an `NSLog`
+  nobody reads; it says so on screen, with the last line the adapter complained
+  about.
+
 - **⌘C, ⌘V, ⌘X and ⌘A work in Plonk's text fields.** They never had, anywhere
   in the app: AppKit delivers those through the main menu's key equivalents,
   and Plonk had no main menu at all, so a field would take a typed sentence but

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -21,7 +21,7 @@
 | `⌃⌥⇧/` | Every shortcut the front app has |
 | `⌃⌥/` · `⌃⌥\` | Find the pointer · jump it to the next screen |
 | `⌃⌥V` | Hold to talk |
-| `⌃⌥Space` | Command palette — run anything by name, or type a sentence for the agent |
+| `⌃⌥A` | Command palette — run anything by name, or type a sentence for the agent |
 
 ---
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -21,6 +21,7 @@
 | `⌃⌥⇧/` | Every shortcut the front app has |
 | `⌃⌥/` · `⌃⌥\` | Find the pointer · jump it to the next screen |
 | `⌃⌥V` | Hold to talk |
+| `⌃⌥Space` | Command palette — run anything by name, or type a sentence for the agent |
 
 ---
 

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -8,13 +8,13 @@
 # delete the line once it is under the limit.
 #
 # lines  path
-1241  App/Sources/plonk/AppDelegate.swift
+1224  App/Sources/plonk/AppDelegate.swift
 759   App/Sources/plonk/Router.swift
 439   App/Sources/plonk/SettingsPages.swift
 489   App/Tests/plonkTests/ConfigTests.swift
 450   App/Tests/plonkTests/RouterTests.swift
 436   App/Sources/plonk/WindowManager.swift
-364   App/Sources/plonk/Hotkey.swift
+311   App/Sources/plonk/Hotkey.swift
 351   App/Sources/plonk/DragSnapManager.swift
 349   App/Sources/plonk/GrabMove.swift
 342   App/Sources/plonk/UpdateManager.swift

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -8,7 +8,7 @@
 # delete the line once it is under the limit.
 #
 # lines  path
-1224  App/Sources/plonk/AppDelegate.swift
+1211  App/Sources/plonk/AppDelegate.swift
 759   App/Sources/plonk/Router.swift
 439   App/Sources/plonk/SettingsPages.swift
 489   App/Tests/plonkTests/ConfigTests.swift


### PR DESCRIPTION
The palette already existed. It could only be opened from inside Plonk's own
window — the one place you are not standing when you want to move a window.

- **`⌃⌥A`** opens it over whatever is in front. Pressing it again closes it.
- Anything typed that is not a command goes to the active agent, with `⌘return`
  or by picking the last row. It takes `router.dispatch`, the same call the
  voice path makes, so a sentence typed can reach nothing a key could not.
- The ask row is last and never matched against: a query that names a real
  command should run it, not send a sentence about it on a round trip.

Two fixes fell out of using it.

**⌘C / ⌘V / ⌘X / ⌘A never worked in any Plonk text field.** AppKit delivers
those through the main menu's key equivalents and the app had no main menu at
all, so a field would take a typed sentence but not a pasted one. An accessory
app draws no menu bar, so the menu that fixes it is invisible.

**A prompt sent to an agent now shows its work.** A CLI adapter takes tens of
seconds and moves nothing until it has decided what to move, so the palette
closing was followed by a two-second HUD and then silence — indistinguishable
from nothing happening, which is what it was taken for. There is a ticking
count while it runs, and it ends on the outcome: how long it took, or the exit
status and the last line from stderr. A failure used to be an `NSLog`.

## Reviewed twice, at `high` and `max`

Seven findings, all fixed in `46c6511`. Two worth naming:

- The adapter's stdout and stderr were given pipes nothing read. A pipe fills
  at ~64 KB and the writer blocks for ever, so `claude -p` printing its answer
  would hang the process and the new HUD would tick until the app was quit —
  and the comment above it described that trap while the code walked into it.
  stderr goes to a temp file now, stdout is discarded. Verified with an adapter
  writing 300 KB: hangs on the old code, done in two seconds on this one.
- `⌃⌥Space` is macOS's own "Select next source in Input menu", live as soon as
  a Mac has two keyboard layouts. `RegisterEventHotKey` reports success anyway
  and the event never arrives, so the documented key was silently switching the
  layout. Hence `⌃⌥A`.

The rest: the ask row read `@State` after teardown and could send an empty
string; the palette listed itself; the key did not toggle; a queued-but-nobody-
connected reply read as success; the no-agent error repeated Router's advice to
pass an `"agent"` field, which means nothing in a palette; the binding row sat
under a footer about a different feature.

## Line limits

`Hotkey.swift` 364 → 311, default bindings moved to `HotkeyDefaults.swift`.
`AppDelegate.swift` 1241 → 1211, the voice-command switch and the adapter
launcher moved to `AppDelegate+Shell`, whose header already claims "how a
command is run". Baseline lowered in the same commits.

317 tests pass, lint clean.