### PR TITLE
refactor: decide an update from plain values, not from the IO

### DIFF
--- a/App/Sources/plonk/CodeSignature.swift
+++ b/App/Sources/plonk/CodeSignature.swift
@@ -38,14 +38,14 @@ enum CodeSignature {
         return (certificates?.isEmpty ?? true)
     }
 
-    /// Throws unless the bundle at `url` is intact and signed the same way this
-    /// copy is. Nested code is checked too, so a tampered helper inside an
-    /// otherwise valid bundle is caught.
-    static func verify(bundleAt url: URL, satisfies requirement: SecRequirement) throws {
+    /// Whether the bundle at `url` is intact and signed the same way this copy
+    /// is, and what to say when it is not. Nested code is checked too, so a
+    /// tampered helper inside an otherwise valid bundle is caught.
+    static func check(bundleAt url: URL, satisfies requirement: SecRequirement) -> SignatureCheck {
         var candidate: SecStaticCode?
         let created = SecStaticCodeCreateWithPath(url as CFURL, [], &candidate)
         guard created == errSecSuccess, let candidate else {
-            throw UpdateError.signatureRejected("the download is not signed code (OSStatus \(created))")
+            return .rejected("the download is not signed code (OSStatus \(created))")
         }
         let flags = SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSCheckNestedCode)
         var failure: Unmanaged<CFError>?
@@ -53,8 +53,9 @@ enum CodeSignature {
         guard status == errSecSuccess else {
             let detail = (failure?.takeRetainedValue() as Error?)?.localizedDescription
                 ?? "it is not signed by the certificate this copy was signed with (OSStatus \(status))"
-            throw UpdateError.signatureRejected(detail)
+            return .rejected(detail)
         }
+        return .satisfied
     }
 
     private static func selfStaticCode() throws -> SecStaticCode {

--- a/App/Sources/plonk/Release.swift
+++ b/App/Sources/plonk/Release.swift
@@ -39,7 +39,7 @@ struct ReleaseVersion: Comparable, CustomStringConvertible {
     }
 }
 
-struct Release {
+struct Release: Equatable {
     let version: ReleaseVersion
     /// The .zip asset holding Plonk.app.
     let downloadURL: URL
@@ -154,7 +154,7 @@ struct Release {
     """
 }
 
-enum UpdateError: LocalizedError {
+enum UpdateError: LocalizedError, Equatable {
     case malformedFeed(String)
     case network(String)
     case unpackFailed(String)

--- a/App/Sources/plonk/UpdateDecision.swift
+++ b/App/Sources/plonk/UpdateDecision.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+// What the updater decides, kept apart from how it finds any of it out.
+//
+// Every value here is plain: a version, a flag, a string read off a bundle.
+// UpdateManager does the network and the filesystem work and hands the results
+// over, so the decision that ends in a swapped-in app — the one that costs the
+// user their permissions when it goes wrong — can be called with made-up
+// values and pinned by tests.
+
+enum UpdateDecision: Equatable {
+    /// Nothing newer than the running copy.
+    case upToDate
+    /// A newer release, worth putting in front of the user.
+    case offer(Release)
+    /// Everything checked so far passed, and something is still unchecked.
+    case proceed
+    /// Every check passed. Swap it in.
+    case install
+    /// Stop, and say why.
+    case refuse(UpdateError)
+}
+
+/// The copy that is running, as far as installing over it is concerned. All of
+/// it is known before anything is downloaded.
+struct InstalledCopy: Equatable {
+    /// Whether the running copy is a .app at all, rather than a bare binary.
+    let isApplicationBundle: Bool
+    /// Whether both the bundle and the directory holding it can be written.
+    let isWritable: Bool
+    /// The directory holding the bundle, named in the refusal when it cannot.
+    let parentPath: String
+    /// Ad-hoc signing means no certificate, so no download could ever satisfy
+    /// this copy's requirement.
+    let isAdHoc: Bool
+}
+
+/// What was found inside the archive, before any of it is judged.
+struct StagedPayload: Equatable {
+    /// The bundle name looked for, e.g. "Plonk.app".
+    let name: String
+    /// False when the archive holds nothing by that name.
+    let exists: Bool
+    /// The staged bundle's identifier, nil when it has none to read.
+    let identifier: String?
+    /// CFBundleShortVersionString exactly as read, so a refusal can quote it.
+    let shortVersion: String
+}
+
+enum SignatureCheck: Equatable {
+    case satisfied
+    case rejected(String)
+}
+
+/// The verification steps, in the order they run, each nil until its step has.
+/// A filled-in field means that work is already done — which is why the digest
+/// is a field of its own rather than folded in with the rest: it is checked
+/// before `ditto` is handed the archive, and nothing below it has happened yet.
+struct VerificationResult: Equatable {
+    /// nil when the release carries no digest, which is how releases cut before
+    /// GitHub published one still install: they fall through to the signature.
+    var digestMatched: Bool?
+    /// nil until the archive has been unpacked.
+    var payload: StagedPayload?
+    /// nil until the staged bundle has been checked against the requirement.
+    var signature: SignatureCheck?
+
+    init(digestMatched: Bool? = nil, payload: StagedPayload? = nil, signature: SignatureCheck? = nil) {
+        self.digestMatched = digestMatched
+        self.payload = payload
+        self.signature = signature
+    }
+}
+
+extension UpdateDecision {
+
+    /// Whether the release that came back is newer than what is running.
+    static func offering(running: ReleaseVersion?, latest: Release?) -> UpdateDecision {
+        guard let latest, let running, running < latest.version else { return .upToDate }
+        return .offer(latest)
+    }
+
+    /// Whether this copy can install an update at all. Settled before the
+    /// download starts, so a copy that could never install one never fetches
+    /// the bytes.
+    static func preflight(_ copy: InstalledCopy) -> UpdateDecision {
+        guard copy.isApplicationBundle else { return .refuse(.notInstalled) }
+        guard copy.isWritable else { return .refuse(.notWritable(copy.parentPath)) }
+        guard !copy.isAdHoc else { return .refuse(.adHocCopy) }
+        return .proceed
+    }
+
+    /// The verdict on what has been checked so far. Asked after each step, and
+    /// the first failure is the answer: the caller stops there, so a download
+    /// that failed the digest is never unpacked, and one that is not the app we
+    /// were offered is never handed to the signature check.
+    static func verdict(on verification: VerificationResult, expecting release: Release,
+                        identifier expected: String?) -> UpdateDecision {
+        if verification.digestMatched == false { return .refuse(.digestMismatch) }
+        guard let payload = verification.payload else { return .proceed }
+        if let refusal = payload.refusal(expecting: release, identifier: expected) {
+            return .refuse(refusal)
+        }
+        guard let signature = verification.signature else { return .proceed }
+        if case .rejected(let why) = signature { return .refuse(.signatureRejected(why)) }
+        return .install
+    }
+}
+
+extension UpdateDecision {
+    /// The release to put in front of the user, when the decision is one.
+    var offered: Release? {
+        guard case .offer(let release) = self else { return nil }
+        return release
+    }
+
+    /// The refusal to throw, when the decision is one.
+    var refusal: UpdateError? {
+        guard case .refuse(let error) = self else { return nil }
+        return error
+    }
+}
+
+extension VerificationResult {
+    /// Puts what has been checked so far to the decision and stops on the first
+    /// refusal, which is how the caller runs its steps in order.
+    @discardableResult
+    func checked(against release: Release, identifier: String?) throws -> UpdateDecision {
+        let decision = UpdateDecision.verdict(on: self, expecting: release, identifier: identifier)
+        if let refusal = decision.refusal { throw refusal }
+        return decision
+    }
+}
+
+extension StagedPayload {
+
+    /// The archive has to hold the app we were offered, at the version we were
+    /// offered. Without this a stale or mismatched asset would pass the
+    /// signature check on its way to being installed as an "update".
+    func refusal(expecting release: Release, identifier expected: String?) -> UpdateError? {
+        guard exists else { return .wrongPayload("it holds no \(name)") }
+        guard let identifier, identifier == expected else {
+            return .wrongPayload("its bundle identifier is not \(expected ?? "ours")")
+        }
+        guard let version = ReleaseVersion(shortVersion), version == release.version else {
+            return .wrongPayload("it contains \(shortVersion), not \(release.version)")
+        }
+        return nil
+    }
+}

--- a/App/Sources/plonk/UpdateManager.swift
+++ b/App/Sources/plonk/UpdateManager.swift
@@ -73,8 +73,7 @@ final class UpdateManager {
 
     /// The newer release, when there is one to offer.
     var available: Release? {
-        guard let latest, let current = Self.currentVersion, current < latest.version else { return nil }
-        return latest
+        UpdateDecision.offering(running: Self.currentVersion, latest: latest).offered
     }
 
     // MARK: - Checking
@@ -126,7 +125,7 @@ final class UpdateManager {
     private func offer(_ release: Release) {
         latest = release
         inFlight = false
-        guard let current = Self.currentVersion, current < release.version else {
+        guard case .offer = UpdateDecision.offering(running: Self.currentVersion, latest: release) else {
             set(phase: .idle, status: "Plonk \(Self.currentVersionText) is the latest release.")
             return
         }
@@ -150,8 +149,8 @@ final class UpdateManager {
             return
         }
         do {
-            let installed = try installedBundleURL()
-            guard !CodeSignature.selfIsAdHoc() else { throw UpdateError.adHocCopy }
+            let installed = Bundle.main.bundleURL
+            if let refusal = UpdateDecision.preflight(installedCopy(at: installed)).refusal { throw refusal }
             let requirement = try CodeSignature.selfRequirement()
             inFlight = true
             progress = 0
@@ -211,14 +210,20 @@ final class UpdateManager {
             let directory = FileManager.default.temporaryDirectory
                 .appendingPathComponent("plonk-update-\(UUID().uuidString)", isDirectory: true)
             defer { try? FileManager.default.removeItem(at: archive) }
+            let ours = Bundle.main.bundleIdentifier
             do {
-                try checkDigest(of: archive, matches: release)
+                // Each step fills in one more field and asks again, so the first
+                // refusal stops the step below it from ever running.
+                var verification = VerificationResult()
+                verification.digestMatched = try digestMatches(archive, of: release)
+                try verification.checked(against: release, identifier: ours)
                 try unpack(archive, into: directory)
                 let staged = directory.appendingPathComponent(installed.lastPathComponent)
-                try checkPayload(at: staged, matches: release)
-                try CodeSignature.verify(bundleAt: staged, satisfies: requirement)
-                DispatchQueue.main.async { [weak self] in
-                    self?.swap(staged, into: installed)
+                verification.payload = readPayload(at: staged)
+                try verification.checked(against: release, identifier: ours)
+                verification.signature = CodeSignature.check(bundleAt: staged, satisfies: requirement)
+                if case .install = try verification.checked(against: release, identifier: ours) {
+                    DispatchQueue.main.async { [weak self] in self?.swap(staged, into: installed) }
                 }
             } catch {
                 try? FileManager.default.removeItem(at: directory)
@@ -228,12 +233,12 @@ final class UpdateManager {
     }
 
     /// The cheapest check there is, and the first one: the bytes on disk have
-    /// to be the bytes the feed described. It runs before `ditto` is handed
-    /// the archive, so a download that went wrong on the way is never unpacked
-    /// at all. Releases cut before GitHub published a digest carry none, and
-    /// those fall through to the signature check exactly as they used to.
-    private func checkDigest(of archive: URL, matches release: Release) throws {
-        guard let expected = release.digest else { return }
+    /// to be the bytes the feed described. It runs before `ditto` is handed the
+    /// archive, so a download that went wrong on the way is never unpacked at
+    /// all. Releases cut before GitHub published a digest carry none and answer
+    /// nil, falling through to the signature check exactly as they used to.
+    private func digestMatches(_ archive: URL, of release: Release) throws -> Bool? {
+        guard let expected = release.digest else { return nil }
         let handle: FileHandle
         do {
             handle = try FileHandle(forReadingFrom: archive)
@@ -248,7 +253,7 @@ final class UpdateManager {
             hasher.update(data: chunk)
         }
         let actual = hasher.finalize().map { String(format: "%02x", $0) }.joined()
-        guard actual == expected else { throw UpdateError.digestMismatch }
+        return actual == expected
     }
 
     private func unpack(_ archive: URL, into directory: URL) throws {
@@ -265,22 +270,15 @@ final class UpdateManager {
         }
     }
 
-    /// The archive has to hold the app we were offered, at the version we were
-    /// offered. Without this a stale or mismatched asset would pass the
-    /// signature check on its way to being installed as an "update".
-    private func checkPayload(at staged: URL, matches release: Release) throws {
-        guard FileManager.default.fileExists(atPath: staged.path) else {
-            throw UpdateError.wrongPayload("it holds no \(staged.lastPathComponent)")
-        }
-        guard let bundle = Bundle(url: staged),
-              let identifier = bundle.bundleIdentifier,
-              identifier == Bundle.main.bundleIdentifier else {
-            throw UpdateError.wrongPayload("its bundle identifier is not \(Bundle.main.bundleIdentifier ?? "ours")")
-        }
-        let shipped = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-        guard let version = ReleaseVersion(shipped), version == release.version else {
-            throw UpdateError.wrongPayload("it contains \(shipped), not \(release.version)")
-        }
+    /// What the unpacked archive holds. Whether that is the app we were offered
+    /// is `StagedPayload.refusal` to say.
+    private func readPayload(at staged: URL) -> StagedPayload {
+        let bundle = Bundle(url: staged)
+        return StagedPayload(
+            name: staged.lastPathComponent,
+            exists: FileManager.default.fileExists(atPath: staged.path),
+            identifier: bundle?.bundleIdentifier,
+            shortVersion: bundle?.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
     }
 
     private func swap(_ staged: URL, into installed: URL) {
@@ -309,15 +307,16 @@ final class UpdateManager {
         NSApp.terminate(nil)
     }
 
-    private func installedBundleURL() throws -> URL {
-        let url = Bundle.main.bundleURL
-        guard url.pathExtension == "app" else { throw UpdateError.notInstalled }
+    /// Everything the preflight needs about the copy being installed over.
+    /// Reading it is this manager's job; deciding on it is not.
+    private func installedCopy(at url: URL) -> InstalledCopy {
         let parent = url.deletingLastPathComponent()
-        guard FileManager.default.isWritableFile(atPath: url.path),
-              FileManager.default.isWritableFile(atPath: parent.path) else {
-            throw UpdateError.notWritable(parent.path)
-        }
-        return url
+        let files = FileManager.default
+        return InstalledCopy(
+            isApplicationBundle: url.pathExtension == "app",
+            isWritable: files.isWritableFile(atPath: url.path) && files.isWritableFile(atPath: parent.path),
+            parentPath: parent.path,
+            isAdHoc: CodeSignature.selfIsAdHoc())
     }
 
     // MARK: - State

--- a/App/Tests/plonkTests/UpdateManagerTests.swift
+++ b/App/Tests/plonkTests/UpdateManagerTests.swift
@@ -1,0 +1,182 @@
+import Testing
+import Foundation
+@testable import plonk
+
+// The decision that ends in a swapped-in app. Every case here is a refusal the
+// user's permissions depend on: TCC pins Accessibility and Screen Recording to
+// the running copy's signature, so a build that gets past these checks without
+// satisfying it costs them both. None of this touches the network or a real
+// bundle — that is the point of the split.
+
+private let ours = "dev.plonk.app"
+
+private func release(_ version: String = "0.2.5", digest: String? = nil) -> Release {
+    Release(
+        version: ReleaseVersion(version)!,
+        downloadURL: URL(string: "https://example.invalid/Plonk-\(version).zip")!,
+        pageURL: URL(string: "https://example.invalid/releases/v\(version)")!,
+        notes: "",
+        size: 0,
+        digest: digest
+    )
+}
+
+private func payload(name: String = "Plonk.app", exists: Bool = true,
+                     identifier: String? = ours, shortVersion: String = "0.2.5") -> StagedPayload {
+    StagedPayload(name: name, exists: exists, identifier: identifier, shortVersion: shortVersion)
+}
+
+private func verdict(_ verification: VerificationResult,
+                     expecting offered: Release = release(),
+                     identifier: String? = ours) -> UpdateDecision {
+    UpdateDecision.verdict(on: verification, expecting: offered, identifier: identifier)
+}
+
+struct UpdateOfferTests {
+
+    @Test func aNewerReleaseIsOffered() {
+        #expect(UpdateDecision.offering(running: ReleaseVersion("0.2.4"), latest: release("0.2.5"))
+            == .offer(release("0.2.5")))
+    }
+
+    @Test func theVersionAlreadyRunningIsNotOffered() {
+        #expect(UpdateDecision.offering(running: ReleaseVersion("0.2.5"), latest: release("0.2.5"))
+            == .upToDate)
+    }
+
+    @Test func aCopyAheadOfTheFeedIsLeftAlone() {
+        // A build made from a branch, or a release pulled after it went out.
+        #expect(UpdateDecision.offering(running: ReleaseVersion("0.3.0"), latest: release("0.2.5"))
+            == .upToDate)
+    }
+
+    @Test func nothingIsOfferedUntilTheFeedHasBeenRead() {
+        #expect(UpdateDecision.offering(running: ReleaseVersion("0.2.4"), latest: nil) == .upToDate)
+    }
+
+    @Test func aCopyWithNoReadableVersionIsOfferedNothing() {
+        // Nothing to compare against, so there is no case for replacing it.
+        #expect(UpdateDecision.offering(running: nil, latest: release("0.2.5")) == .upToDate)
+    }
+}
+
+struct UpdatePreflightTests {
+
+    private func copy(bundle: Bool = true, writable: Bool = true,
+                      parent: String = "/Applications", adHoc: Bool = false) -> InstalledCopy {
+        InstalledCopy(isApplicationBundle: bundle, isWritable: writable,
+                      parentPath: parent, isAdHoc: adHoc)
+    }
+
+    @Test func anOrdinaryInstalledCopyGetsToDownload() {
+        #expect(UpdateDecision.preflight(copy()) == .proceed)
+    }
+
+    @Test func anAdHocCopyIsRefusedBeforeAnythingIsFetched() {
+        // Its requirement names a hash that changes with every build, so no
+        // download could ever satisfy it. Better said plainly than at the end.
+        #expect(UpdateDecision.preflight(copy(adHoc: true)) == .refuse(.adHocCopy))
+    }
+
+    @Test func aCopyRunningUnbundledHasNothingToInstallOver() {
+        #expect(UpdateDecision.preflight(copy(bundle: false)) == .refuse(.notInstalled))
+    }
+
+    @Test func aCopySomewhereUnwritableNamesTheDirectoryItCannotWrite() {
+        #expect(UpdateDecision.preflight(copy(writable: false, parent: "/Volumes/Plonk"))
+            == .refuse(.notWritable("/Volumes/Plonk")))
+    }
+
+    @Test func beingUnbundledIsSaidFirst() {
+        // A binary run out of .build is both unbundled and ad-hoc signed;
+        // telling the user to install by hand is the useful half.
+        #expect(UpdateDecision.preflight(copy(bundle: false, writable: false, adHoc: true))
+            == .refuse(.notInstalled))
+    }
+}
+
+struct UpdateVerdictTests {
+
+    @Test func aDownloadThatMatchesEveryCheckIsInstalled() {
+        #expect(verdict(VerificationResult(digestMatched: true, payload: payload(),
+                                           signature: .satisfied)) == .install)
+    }
+
+    @Test func aDigestThatDoesNotMatchIsRefused() {
+        #expect(verdict(VerificationResult(digestMatched: false)) == .refuse(.digestMismatch))
+    }
+
+    @Test func aReleaseWithNoPublishedDigestStillInstalls() {
+        // Releases cut before GitHub published digests carry none. They fall
+        // through to the signature check, which is the one that matters, and
+        // that has not moved. nil here means "none published", not "matched".
+        let none = VerificationResult(digestMatched: nil, payload: payload(), signature: .satisfied)
+        #expect(verdict(none, expecting: release("0.2.5", digest: nil)) == .install)
+    }
+
+    @Test func theDigestIsAnsweredBeforeTheArchiveIsOpened() {
+        // Nothing below the digest has run yet, so a mangled download is
+        // refused without ditto ever being handed it.
+        #expect(verdict(VerificationResult(digestMatched: true)) == .proceed)
+        #expect(verdict(VerificationResult()) == .proceed)
+    }
+
+    @Test func aBadDigestOutranksWhateverTheArchiveHolds() {
+        let both = VerificationResult(digestMatched: false, payload: payload(exists: false),
+                                      signature: .rejected("wrong certificate"))
+        #expect(verdict(both) == .refuse(.digestMismatch))
+    }
+
+    @Test func anArchiveWithoutTheAppInsideIsRefused() {
+        #expect(verdict(VerificationResult(digestMatched: true, payload: payload(exists: false)))
+            == .refuse(.wrongPayload("it holds no Plonk.app")))
+    }
+
+    @Test func anArchiveHoldingSomeoneElsesAppIsRefused() {
+        #expect(verdict(VerificationResult(digestMatched: true,
+                                           payload: payload(identifier: "com.example.other")))
+            == .refuse(.wrongPayload("its bundle identifier is not dev.plonk.app")))
+        // A bundle we cannot read an identifier out of is the same refusal.
+        #expect(verdict(VerificationResult(digestMatched: true, payload: payload(identifier: nil)))
+            == .refuse(.wrongPayload("its bundle identifier is not dev.plonk.app")))
+    }
+
+    @Test func anArchiveHoldingAnotherVersionIsRefused() {
+        // Not the build that was offered: a stale asset would otherwise pass
+        // the signature check on its way in as an "update".
+        #expect(verdict(VerificationResult(digestMatched: true,
+                                           payload: payload(shortVersion: "0.2.1")))
+            == .refuse(.wrongPayload("it contains 0.2.1, not 0.2.5")))
+        #expect(verdict(VerificationResult(digestMatched: true, payload: payload(shortVersion: "")))
+            == .refuse(.wrongPayload("it contains , not 0.2.5")))
+    }
+
+    @Test func aBundleSignedWithAnotherCertificateIsRefused() {
+        // The check the whole update path exists to make. Installing this would
+        // take Accessibility and Screen Recording from everyone who has them.
+        let detail = "it is not signed by the certificate this copy was signed with"
+        let rejected = VerificationResult(digestMatched: true, payload: payload(),
+                                          signature: .rejected(detail))
+        #expect(verdict(rejected) == .refuse(.signatureRejected(detail)))
+    }
+
+    @Test func theRightAppIsStillNotInstalledUntilItsSignatureIsChecked() {
+        #expect(verdict(VerificationResult(digestMatched: true, payload: payload())) == .proceed)
+    }
+
+    @Test func theWrongAppIsRefusedWithoutBlamingItsSignature() {
+        // Order again: the payload is answered first, so the message names what
+        // actually went wrong.
+        let both = VerificationResult(digestMatched: true, payload: payload(shortVersion: "0.2.1"),
+                                      signature: .rejected("wrong certificate"))
+        #expect(both.payload != nil)
+        #expect(verdict(both) == .refuse(.wrongPayload("it contains 0.2.1, not 0.2.5")))
+    }
+
+    @Test func aCopyWithNoIdentifierOfItsOwnCanMatchNothing() {
+        // Bundle.main has no identifier when the tests run unbundled, and that
+        // has to read as a refusal rather than as anything matching.
+        #expect(verdict(VerificationResult(digestMatched: true, payload: payload()), identifier: nil)
+            == .refuse(.wrongPayload("its bundle identifier is not ours")))
+    }
+}

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -17,6 +17,6 @@
 311   App/Sources/plonk/Hotkey.swift
 351   App/Sources/plonk/DragSnapManager.swift
 349   App/Sources/plonk/GrabMove.swift
-342   App/Sources/plonk/UpdateManager.swift
+341   App/Sources/plonk/UpdateManager.swift
 312   App/Sources/plonk/WorkspaceLauncher.swift
 306   mcp/src/api.ts


### PR DESCRIPTION
## What changed, and why

`UpdateManager.installUpdate` decided whether to install while it was still doing the IO — the digest, the unpack, the payload read and the signature check each threw from the middle of the download queue. That made the one decision that matters most, whether a downloaded bundle may replace this copy, untestable: nothing in the unit suite can reach it without a network and a real bundle.

This moves the decision into `UpdateDecision`, a set of plain values (`InstalledCopy`, `StagedPayload`, `SignatureCheck`, `VerificationResult`). `UpdateManager` still does all the IO and now only reports what it found; the answer comes back as `.install` or a refusal. Behavior is unchanged, including the order refusals come out in — a bad digest is still reported ahead of whatever the archive turned out to hold, and an unbundled ad-hoc copy is still told it is not installed rather than that it is ad-hoc.

The tests then cover the cases that matter: the version already running, an older one, a mismatched digest, a release GitHub published no digest for, an archive holding the wrong app, and a bundle signed with a different certificate. That last one is the point of the rest — installing a build that does not satisfy this copy's designated requirement takes Accessibility and Screen Recording away from everyone who granted them. Nothing in the suite touches the network or a real bundle.

Closes #20.

## What you ran

```
(cd App && swift build)
./scripts/test.sh     # 358 tests in 44 suites, passed
./scripts/lint.sh     # clean
```

`mcp/` is untouched.

## Checks

- [x] `swift build` passes on every commit in the branch, not just the last one
- [x] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be
- [x] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [x] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — fixed in this PR if not
- [x] Screenshots below for anything visual — nothing visual changed

The update path is refactored, not changed: the same checks run in the same order against the same designated requirement, so `README.md`, `docs/verify.md` and `SECURITY.md` still describe it accurately.
