### PR TITLE
fix: draw the window header at the top edge

### DIFF
--- a/App/Sources/plonk/MainWindowView.swift
+++ b/App/Sources/plonk/MainWindowView.swift
@@ -52,6 +52,10 @@ struct MainWindowView: View {
                 }
             }
         }
+        // The window hides its title bar so our own header is the only one, but
+        // the hosting view still insets the content by its height. Without this
+        // the top bar hangs below an empty strip the width of the window.
+        .ignoresSafeArea(.container, edges: .top)
         .frame(minWidth: 620, minHeight: 520)
         // Both, and deliberately: `tint` is what system controls read, and the
         // deprecated `accentColor` is the only one that moves `Color.accentColor`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ attestation, so `gh attestation verify` fails on them. That is the whole reason
 [the release workflow](.github/workflows/release.yml) exists now. Do not install
 one of those.
 
+## Unreleased
+
+### Fixed
+
+- **The main window's header sits at the top edge again.** The title bar is
+  hidden so the app draws its own, but the hosting view still reserved the
+  height of the one it hid: every page opened under an empty strip the width of
+  the window, and the sidebar started lower than it was told to.
+
 ## 0.2.4 — 2026-08-10
 
 The command palette got a key of its own, an agent can photograph a window it


### PR DESCRIPTION
The main window hides its title bar so Plonk's own header is the only one, but
`NSHostingController` still inset the content by the height of the bar it hid.
The result: every page opened under an empty strip the width of the window, the
top bar hung below it, and the sidebar's 30pt of room for the traffic lights was
stacked on top of that inset.

`.ignoresSafeArea(.container, edges: .top)` on the window's root puts the header
back on the top edge. The sidebar keeps its own padding, which is what clears the
traffic lights now that nothing else does.

Verified by eye against the built bundle: header flush with the top edge, traffic
lights clear of the brand row, nothing else moved.

Commands run:

    (cd App && swift build)
    ./scripts/test.sh    # 358 tests, passed
    ./scripts/lint.sh    # clean
    ./scripts/build.sh && open Plonk.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)