### PR TITLE
fix: apply the zone gap when an agent snaps a window

### DIFF
--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -576,7 +576,7 @@ final class Router {
             return .badRequest("screen \(screen) has zones 1...\(zones.count)")
         }
         let error = windows.place(app: app, titleContains: title, screen: screen,
-                                  frac: zones[number - 1].frac)
+                                  frac: zones[number - 1].frac, gap: CGFloat(store.config.zoneGap))
         if let error { return .failed(error) }
         return .ok(["ok": true, "app": app, "screen": screen, "zone": number, "zones": zones.count])
     }

--- a/App/Sources/plonk/WindowManager.swift
+++ b/App/Sources/plonk/WindowManager.swift
@@ -212,15 +212,11 @@ final class WindowManager {
         return true
     }
 
-    private func axRect(for frac: FracRect, screenIndex: Int, in all: [ScreenInfo]) -> CGRect {
+    private func axRect(for frac: FracRect, screenIndex: Int, in all: [ScreenInfo],
+                        gap: CGFloat = 0) -> CGRect {
         guard !all.isEmpty else { return .zero }
         let v = all[min(max(screenIndex, 0), all.count - 1)].visible
-        return CGRect(
-            x: v.minX + frac.x * v.width,
-            y: v.minY + frac.y * v.height,
-            width: frac.w * v.width,
-            height: frac.h * v.height
-        )
+        return ZoneGeometry.frame(for: frac, in: v, gap: gap)
     }
 
     // MARK: - App matching
@@ -279,16 +275,23 @@ final class WindowManager {
     }
 
     /// Place one window by app name. Returns an error string, or nil on success.
-    func place(app appName: String, titleContains: String?, screen screenIdx: Int?, frac: FracRect) -> String? {
+    func place(app appName: String, titleContains: String?, screen screenIdx: Int?, frac: FracRect,
+               gap: CGFloat = 0) -> String? {
         place(app: appName, bundleID: nil, titleContains: titleContains, windowIndex: nil,
-              screen: screenIdx, frac: frac)
+              screen: screenIdx, frac: frac, gap: gap)
     }
 
     /// The workspace form: addresses a specific window of an app and can leave
     /// it minimized afterwards.
+    ///
+    /// `gap` defaults to none because most callers hand over a fraction that is
+    /// already exactly where the window goes: a workspace saved a frame that had
+    /// the gap in it, and a frame given as fractions is taken literally. Only a
+    /// caller naming a *zone* passes one, so an agent dropping a window into
+    /// zone 3 leaves the same space around it as ⌃⌥3 does.
     func place(app appName: String, bundleID: String?, titleContains: String?, windowIndex: Int?,
                screen screenIdx: Int?, frac: FracRect,
-               minimize: Bool = false, activate: Bool = true) -> String? {
+               minimize: Bool = false, activate: Bool = true, gap: CGFloat = 0) -> String? {
         guard isTrusted else { return "accessibility permission not granted" }
         let all = screens()
         if let screenIdx, !all.indices.contains(screenIdx) {
@@ -317,7 +320,7 @@ final class WindowManager {
             AXUIElementSetAttributeValue(win, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
         }
         let index = screenIdx ?? screenIndex(containing: frame(ofWindow: win) ?? .zero, in: all)
-        guard setFrame(win, axRect(for: frac, screenIndex: index, in: all)) else {
+        guard setFrame(win, axRect(for: frac, screenIndex: index, in: all, gap: gap)) else {
             return "window of \"\(appName)\" refused to move or resize"
         }
         if activate { app.activate() }
@@ -359,18 +362,7 @@ final class WindowManager {
     /// Place a specific window (used by drag snapping). `gap` is the empty
     /// space left around the zone, in points, so a snapped window can breathe.
     func apply(frac: FracRect, toWindow win: AXUIElement, screenIndex: Int, gap: CGFloat = 0) {
-        let rect = axRect(for: frac, screenIndex: screenIndex, in: screens())
-        setFrame(win, Self.inset(rect, by: gap))
-    }
-
-    /// Insets a rect by the zone gap without ever turning it inside out: a
-    /// wide gap on a narrow zone would otherwise produce a null rect, and the
-    /// window would be sent to an infinite origin.
-    static func inset(_ rect: CGRect, by gap: CGFloat) -> CGRect {
-        guard gap > 0, rect.width > 0, rect.height > 0 else { return rect }
-        let minimumSide: CGFloat = 120
-        let room = min(gap, max((rect.width - minimumSide) / 2, 0), max((rect.height - minimumSide) / 2, 0))
-        return room > 0 ? rect.insetBy(dx: room, dy: room) : rect
+        setFrame(win, axRect(for: frac, screenIndex: screenIndex, in: screens(), gap: gap))
     }
 
     /// Which screen a window sits on, by the screen its centre falls in.

--- a/App/Sources/plonk/ZoneOverlay.swift
+++ b/App/Sources/plonk/ZoneOverlay.swift
@@ -109,7 +109,7 @@ final class ZoneOverlay {
                 width: z.w * visible.width,
                 height: z.h * visible.height
             ).insetBy(dx: 5, dy: 5)
-            let gapped = WindowManager.inset(rect, by: appearance.gap)
+            let gapped = ZoneGeometry.inset(rect, by: appearance.gap)
 
             let view = NSView(frame: gapped)
             view.wantsLayer = true

--- a/App/Sources/plonk/Zones.swift
+++ b/App/Sources/plonk/Zones.swift
@@ -62,6 +62,31 @@ enum ZoneGeometry {
     static let grid = 0.05
     static let minSide = 0.1
 
+    /// The frame a window ends up with: the fraction's share of the visible
+    /// area, less the gap on every side.
+    ///
+    /// One function on purpose. A zone reached by ⌃⌥3 and the same zone reached
+    /// over MCP have to land in the same place, and they did not: the agent path
+    /// built this rect and placed the window without ever insetting it, so the
+    /// gap was a setting that only worked when a person pressed the key.
+    static func frame(for frac: FracRect, in visible: CGRect, gap: CGFloat = 0) -> CGRect {
+        inset(CGRect(x: visible.minX + frac.x * visible.width,
+                     y: visible.minY + frac.y * visible.height,
+                     width: frac.w * visible.width,
+                     height: frac.h * visible.height),
+              by: gap)
+    }
+
+    /// Insets a rect by the zone gap without ever turning it inside out: a wide
+    /// gap on a narrow zone would otherwise produce a null rect, and the window
+    /// would be sent to an infinite origin.
+    static func inset(_ rect: CGRect, by gap: CGFloat) -> CGRect {
+        guard gap > 0, rect.width > 0, rect.height > 0 else { return rect }
+        let minimumSide: CGFloat = 120
+        let room = min(gap, max((rect.width - minimumSide) / 2, 0), max((rect.height - minimumSide) / 2, 0))
+        return room > 0 ? rect.insetBy(dx: room, dy: room) : rect
+    }
+
     static func snapValue(_ v: Double) -> Double {
         (v / grid).rounded() * grid
     }

--- a/App/Tests/plonkTests/GrabMoveTests.swift
+++ b/App/Tests/plonkTests/GrabMoveTests.swift
@@ -81,20 +81,20 @@ struct GrabMoveHandleTests {
 struct ZoneGapTests {
 
     @Test func aGapShrinksTheRectOnEverySide() {
-        let inset = WindowManager.inset(CGRect(x: 0, y: 0, width: 800, height: 600), by: 10)
+        let inset = ZoneGeometry.inset(CGRect(x: 0, y: 0, width: 800, height: 600), by: 10)
         #expect(inset == CGRect(x: 10, y: 10, width: 780, height: 580))
     }
 
     @Test func noGapChangesNothing() {
         let rect = CGRect(x: 0, y: 0, width: 800, height: 600)
-        #expect(WindowManager.inset(rect, by: 0) == rect)
+        #expect(ZoneGeometry.inset(rect, by: 0) == rect)
     }
 
     /// A wide gap on a narrow zone would otherwise produce a null rect, and a
     /// window set to a null rect goes to an infinite origin.
     @Test func aGapWiderThanTheZoneIsClampedRatherThanInverting() {
         let narrow = CGRect(x: 0, y: 0, width: 130, height: 130)
-        let inset = WindowManager.inset(narrow, by: 40)
+        let inset = ZoneGeometry.inset(narrow, by: 40)
         #expect(inset.width > 0 && inset.height > 0)
         #expect(!inset.isNull && !inset.isInfinite)
         #expect(inset.width <= narrow.width && inset.height <= narrow.height)
@@ -102,6 +102,41 @@ struct ZoneGapTests {
 
     @Test func aZoneAtTheMinimumIsLeftAlone() {
         let tiny = CGRect(x: 0, y: 0, width: 100, height: 90)
-        #expect(WindowManager.inset(tiny, by: 40) == tiny)
+        #expect(ZoneGeometry.inset(tiny, by: 40) == tiny)
+    }
+
+    /// The visible area of a laptop screen with the menu bar taken off, which is
+    /// what every fraction in the app is a fraction of.
+    private let visible = CGRect(x: 0, y: 33, width: 1728, height: 1084)
+
+    @Test func aFractionBecomesItsShareOfTheVisibleArea() {
+        let left = ZoneGeometry.frame(for: FracRect(0, 0, 0.5, 1), in: visible)
+        #expect(left == CGRect(x: 0, y: 33, width: 864, height: 1084))
+    }
+
+    /// The offset is not the origin: a zone that does not start at the screen
+    /// edge has to keep the visible area's own origin under it.
+    @Test func aFractionIsMeasuredFromTheVisibleOrigin() {
+        let right = ZoneGeometry.frame(for: FracRect(0.5, 0, 0.5, 1), in: visible)
+        #expect(right == CGRect(x: 864, y: 33, width: 864, height: 1084))
+    }
+
+    /// The regression this function exists for. A window dropped into a zone by
+    /// an agent used to get the zone rect untouched, while the same zone reached
+    /// by hotkey got it inset, so the gap was a setting that only worked when a
+    /// person pressed the key. Both paths compute the frame here now, so the
+    /// number below is the one either of them lands on.
+    @Test func theGapComesOffTheZoneWhoeverAsksForIt() {
+        let leftThird = FracRect(0, 0, 1.0 / 3.0, 1)
+        #expect(ZoneGeometry.frame(for: leftThird, in: visible, gap: 8)
+                == CGRect(x: 8, y: 41, width: 560, height: 1068))
+    }
+
+    /// A frame an agent gives as fractions is taken literally: it is not a zone,
+    /// so nothing is taken off it.
+    @Test func anExplicitFractionKeepsItsFullSize() {
+        let frame = ZoneGeometry.frame(for: FracRect(0, 0, 0.6, 1), in: visible)
+        #expect(frame.width == visible.width * 0.6)
+        #expect(frame.origin == CGPoint(x: 0, y: 33))
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ one of those.
 
 ### Fixed
 
+- **The zone gap applies when an agent drops a window into a zone.** `⌃⌥3` left
+  the gap around the window and `snap_window` did not, so the same zone gave two
+  different frames depending on who asked for it, and the setting looked broken
+  to anyone driving Plonk over MCP or from the CLI. The agent path built the
+  zone's rectangle and placed the window without ever insetting it. Both paths
+  now compute the frame in one function, `ZoneGeometry.frame`, which is where
+  the gap comes off, so they cannot drift apart again.
+
 - **The main window's header sits at the top edge again.** The title bar is
   hidden so the app draws its own, but the hosting view still reserved the
   height of the one it hid: every page opened under an empty strip the width of

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -13,7 +13,7 @@
 439   App/Sources/plonk/SettingsPages.swift
 489   App/Tests/plonkTests/ConfigTests.swift
 444   App/Tests/plonkTests/RouterTests.swift
-436   App/Sources/plonk/WindowManager.swift
+428   App/Sources/plonk/WindowManager.swift
 311   App/Sources/plonk/Hotkey.swift
 351   App/Sources/plonk/DragSnapManager.swift
 349   App/Sources/plonk/GrabMove.swift


### PR DESCRIPTION
## What

`⌃⌥3` left the configured zone gap around the window. The same zone reached through `snap_window` over MCP, or through the `plonk` CLI, did not: `Router.zoneRoute` built the zone's rectangle and called `WindowManager.place`, which set the frame without ever insetting it. So the gap was a setting that only worked when a person pressed the key, and windows an agent placed sat flush against each other.

Measured on a 1728x1084 visible area with `zoneGap: 8`, zone 1 of Thirds:

| | frame |
| --- | --- |
| zone rectangle | `0 33 576 1084` |
| before, over MCP | `0 33 576 1084` |
| after, over MCP | `8 41 560 1068` |
| expected | `8 41 560 1068` |

## How

- Both paths now compute the frame in one place, `ZoneGeometry.frame(for:in:gap:)`, so the hotkey and the agent cannot drift apart again.
- `WindowManager.place` takes `gap`, defaulting to none. A workspace stores a frame that already has the gap in it, and a frame given as fractions by `apply_layout` is taken literally, so only a caller naming a *zone* passes one.
- `inset` moves from `WindowManager` to `ZoneGeometry` with the rest of the geometry. That is also what keeps `WindowManager.swift` under its line-limit baseline, which drops from 436 to 428.

## Tests

Five cases added to `ZoneGapTests`, including one pinned to this regression. The existing `inset` cases move with the function.

Ran from the repository root:

- `(cd App && swift build)`
- `./scripts/test.sh` — 362 tests in 44 suites pass
- `./scripts/lint.sh` — clean
- `node scripts/check-zone-sets.mjs` — 8 zone sets valid

Also verified against a running build: rebuilt `Plonk.app`, relaunched, and snapped a window into zone 1 over the API, which is where the "after" row above comes from.

## Not in this change

`zoneRoute` still does not record the placement in snap memory the way the hotkey path does, so a window an agent puts in a zone does not follow its number when the zone set is swapped, and does not come back after a display is unplugged. That needs the router to reach snap memory, so it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)