### PR TITLE
docs: shorten the README and lead CONTRIBUTING with the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ one of those.
 
 ## Unreleased
 
+### Changed
+
+- **README and CONTRIBUTING are shorter.** Roughly a fifth off each. Install
+  moved above the feature tour, and CONTRIBUTING leads with what there is to do
+  rather than with how review works. The version badge said 0.2.2, and so did
+  the `gh attestation verify` example next to it.
+
 ### Fixed
 
 - **The zone gap applies when an agent drops a window into a zone.** `⌃⌥3` left

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,23 @@
 # Contributing
 
-Bug reports, zone sets, client one-pagers and code are all welcome.
+Bug reports, zone sets, client one-pagers and code are all welcome. You do not
+need a signing certificate, an Apple account, or the app running.
 
-Two things worth saying before anything else, because both are usually left to
-be guessed at:
+What you can expect:
 
-**A pull request gets a real answer within 48 hours**, even when the answer is
-that it needs another week of thought. There is one maintainer, so that is a
-promise about attention rather than about speed. If something sits longer, it is
-an oversight rather than a verdict — say so on the thread. A change that is
-declined is declined with the reason, and "What this project will not take"
-below exists so that happens as rarely as possible.
+- **A real answer within 48 hours**, even if the answer is that it needs another
+  week of thought. There is one maintainer, so that is a promise about attention,
+  not speed. If something sits longer, it is an oversight. Say so on the thread.
+- **A change that is declined is declined with the reason.** "What this project
+  will not take" below exists so that happens as rarely as possible.
+- **Your branch is yours.** Review asks for changes rather than pushing them. If
+  a pull request is nearly there and you would rather it were finished for you,
+  say so and it will be.
+- Anyone whose change lands is listed in the release notes it ships in.
 
-Anyone whose change lands is listed in the release notes it ships in.
+Everyone taking part follows the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-**Your branch is yours.** Review comments will ask for changes rather than push
-them. If a pull request is nearly there and you would rather it were finished
-for you than iterated on, say so and it will be; otherwise nothing is pushed to
-your branch.
-
-Everyone taking part is expected to follow the
-[Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Your first change, in about fifteen minutes
-
-You do not need a signing certificate, an Apple account, or the app running.
+## Get it building
 
 ```sh
 git clone https://github.com/ostapondo/plonk && cd plonk
@@ -36,62 +29,53 @@ node scripts/check-zone-sets.mjs           # the layouts in zone-sets/
 ```
 
 Each line is a subshell, so the block runs as written from the repository root.
-That is exactly what CI runs, and if it passes, the mechanical half of review is
+That is exactly what CI runs. If it passes, the mechanical half of review is
 already done.
 
-Now pick something. [Issue #21][21] is a good one to read first: `plonk state`
-tells a person to "ask the user to launch Plonk.app" — which, in a shell, means
-asking themselves. The fix is a message in `mcp/src/api.ts`, a test in
-`mcp/test/`, and `npm test`. Nothing else.
+## Pick something
 
-That is the shape of most of the work here: one file, one seam, one test.
+If you want one handed to you: [issue #21][21]. `plonk state` tells a person to
+"ask the user to launch Plonk.app", which, in a shell, means asking themselves.
+The fix is a message in `mcp/src/api.ts`, a test in `mcp/test/`, and `npm test`.
+Nothing else. That is the shape of most of the work here: one file, one seam, one
+test.
 
-[21]: https://github.com/ostapondo/plonk/issues/21
+The rest, roughly in order of how much of the repo you have to hold in your head.
+The first two need no Swift at all. The third needs no Swift on your machine.
 
-## Where the work is
-
-Roughly in order of how much of the repo you have to hold in your head. The
-first two need no Swift at all, and the third needs no Swift on your machine.
-
-- **A zone set.** One JSON file in [`zone-sets/`](zone-sets/), which is a
-  gallery of layouts people keep going back to. Draw it in the app, read the
-  numbers back out of `plonk state --json`, drop them in a file. CI for that
-  folder is its own job and answers in about twenty seconds. Good ones end up
-  shipping as built-ins. [`zone-sets/README.md`](zone-sets/README.md) has the
-  format and the rules.
-- **[needs-hardware][hw]** — see below. The single most useful thing you can
-  send, and it needs neither Swift nor a certificate.
+- **A zone set.** One JSON file in [`zone-sets/`](zone-sets/), a gallery of
+  layouts people keep going back to. Draw it in the app, read the numbers out of
+  `plonk state --json`, drop them in a file. That folder has its own CI job and
+  answers in about twenty seconds. Good ones ship as built-ins.
+  [`zone-sets/README.md`](zone-sets/README.md) has the format.
+- **[needs-hardware][hw].** See below. The single most useful thing you can send.
 - **Something in `mcp/`.** The MCP server and the `plonk` CLI are TypeScript, a
-  thin proxy over the app's HTTP API, and they build and test on any machine —
-  Linux included, without a Mac in sight. `npm ci && npm test` in `mcp/` is the
-  whole loop.
+  thin proxy over the app's HTTP API. They build and test anywhere, Linux
+  included, with no Mac in sight. `npm ci && npm test` in `mcp/` is the whole
+  loop.
 - **A one-pager for an MCP client.** `docs/clients/` has Cursor, Zed and Cline.
-  Any client that can run a stdio server works; the page is the missing part.
-  If you use a client that is not there, you already know the one thing this
-  repo does not.
+  Any client that runs a stdio server works; the page is the missing part.
 - **A voice command.** `VoiceCommands.swift` maps spoken phrases to actions that
-  run in the app, with no agent and no network. Adding a phrase is a small
-  change with a unit test next to it in `VoiceCommandTests.swift`, and the
-  parser is pure — the tests run with no desktop session.
-- **A file off `scripts/line-limit-baseline`.** Every line in that file is a
-  type waiting to be lifted out of something too big. [Issue #17][17] is the
-  first one, and it comes with tests that cannot be written until it moves.
-- **A new module.** The seam is described under "Adding a module" in
-  [AGENTS.md](AGENTS.md). Open an issue first so two people do not build the
-  same thing.
+  run in the app, with no agent and no network. Adding a phrase is a small change
+  with a unit test next to it in `VoiceCommandTests.swift`. The parser is pure,
+  so the tests need no desktop session.
+- **A file off `scripts/line-limit-baseline`.** Every line in that file is a type
+  waiting to be lifted out of something too big. [Issue #17][17] is the first,
+  and it comes with tests that cannot be written until it moves.
+- **A new module.** The seam is under "Adding a module" in [AGENTS.md](AGENTS.md).
+  Open an issue first so two people do not build the same thing.
 
-The issues tagged **[good first issue][gfi]** are the same idea, written out:
-each one names the file to open, what done looks like, and the command that
-proves it. Comment on one to claim it, so nobody writes it twice.
+Issues tagged **[good first issue][gfi]** name the file to open, what done looks
+like, and the command that proves it. Comment on one to claim it.
 
-The ones tagged **[reserved][res]** are deliberately left alone: the maintainer
-is not working on them and will not start, so they are yours if you say so on
-the thread. Nothing here moves fast enough to be worth racing.
+Issues tagged **[reserved][res]** are deliberately left alone: the maintainer is
+not working on them and will not start. Say so on the thread and it is yours.
 
 [gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [res]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Areserved-for-contributors
 [hw]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-hardware
 [17]: https://github.com/ostapondo/plonk/issues/17
+[21]: https://github.com/ostapondo/plonk/issues/21
 
 ## Hardware nobody here has
 
@@ -100,12 +84,12 @@ This is the honest weak point of the project, and the easiest place to help.
 A window manager breaks on arrangements the author cannot see: three monitors,
 an ultrawide, a Retina screen beside a 1x one, a display that comes and goes,
 Sidecar, a vertical panel. Placement needs a real desktop session, so none of it
-is reachable from the unit suite — the whole of `App/Tests/plonkTests/` runs
-without one on purpose.
+is reachable from the unit suite. `App/Tests/plonkTests/` runs without one on
+purpose.
 
-So a report from a desk that is not this one is worth more than a patch. The
-[needs-hardware][hw] label is exactly that list, and answering one means running
-a few shortcuts and pasting what happened.
+A report from a desk that is not this one is worth more than a patch. The
+[needs-hardware][hw] label is that list, and answering one means running a few
+shortcuts and pasting what happened.
 
 `scripts/testbench.sh` opens throwaway TextEdit windows so you never have to
 move your real ones:
@@ -117,9 +101,8 @@ move your real ones:
 ```
 
 Fractions rather than pixels, because those travel between machines. The pull
-request template has the six arrangements worth running through, and you are not
-expected to own all six — tick what you ran and write "no hardware" against the
-rest.
+request template lists six arrangements worth running through. You are not
+expected to own all six: tick what you ran, write "no hardware" against the rest.
 
 ## Running the app
 
@@ -131,50 +114,48 @@ Only needed to change something you can see. Make your own certificate once:
 open Plonk.app
 ```
 
-That certificate is yours, not the one releases are signed with, so a local
-build will not auto-update and macOS asks for Accessibility and Screen Recording
-again the first time it runs. Both are expected.
+That certificate is yours, not the one releases are signed with, so a local build
+will not auto-update and macOS asks for Accessibility and Screen Recording again
+the first time it runs. Both are expected.
 
-Do not work around `build.sh` by ad-hoc signing. macOS pins those two
-permissions to the code signature, an ad-hoc signature is a different one every
-build, and the result is a bundle that looks built and then silently cannot move
-a window.
+Do not work around `build.sh` with ad-hoc signing. macOS pins those two
+permissions to the code signature, an ad-hoc signature is different every build,
+and the result is a bundle that looks built and then silently cannot move a
+window.
 
 ## Sending a change
 
 - Branch off `main`. Nothing is pushed to `main` directly, including by the
   maintainer.
-- **The pull request title is a sentence, and it does not have to be clever.**
-  `fix: nil display UUID after unplug` is a good title. So is `Add a setup page
-  for Windsurf`. The essayistic subjects in `git log` on `main` are one person's
-  habit, not a standard anyone is held to.
+- **The title is a sentence, and it does not have to be clever.** `fix: nil
+  display UUID after unplug` is a good title. So is `Add a setup page for
+  Windsurf`. The essayistic subjects in `git log` are one person's habit, not a
+  standard anyone is held to.
 - Conventional commits on your branch: `feat:`, `fix:`, `docs:`, `chore:`,
   `refactor:`. Imperative subject under 72 characters, body only when the why is
   not obvious. A pull request with more than one commit is squashed under its
-  title, which is why `main` has subjects with no prefix.
-- One logical change per commit, and `swift build` passes on every one of them.
+  title.
+- One logical change per commit, and `swift build` passes on every one.
 - Put new logic somewhere testable. `ZoneGeometry`, `Config`, `ImageFit`,
   `Router` and `ControlServer.parseIfComplete` exist to be reachable without a
-  desktop session; cover what you add in `App/Tests/plonkTests/` or `mcp/test/`.
-- A pull request says what changed, why, and which commands you ran.
-  Screenshots for anything visual.
-- Match the surrounding code. Swift API design guidelines, comments only for
-  constraints that are not obvious from the code, no emoji anywhere including
-  user-facing strings, and user-facing text in English. `./scripts/lint.sh`
-  checks the part of that a script can check, so style is not something to find
-  out about at review time.
+  desktop session. Cover what you add in `App/Tests/plonkTests/` or `mcp/test/`.
+- Say what changed, why, and which commands you ran. Screenshots for anything
+  visual.
+- Match the surrounding code: Swift API design guidelines, comments only for
+  constraints the code does not show, no emoji anywhere including user-facing
+  strings, user-facing text in English. `./scripts/lint.sh` checks the part a
+  script can check.
 
-If a change touches the network, the permissions, the entitlements or the update
-path, it makes a claim in `README.md` or `SECURITY.md` false. Fix the document in
-the same commit. Those claims are meant to be checkable from a terminal, and that
-is the only reason they are worth anything.
+A change that touches the network, the permissions, the entitlements or the
+update path makes a claim in `README.md` or `SECURITY.md` false. Fix the document
+in the same commit. Those claims are meant to be checkable from a terminal, and
+that is the only reason they are worth anything.
 
-[AGENTS.md](AGENTS.md) is the long version of all of this: the repo layout, the
-five places a new module touches, which coordinate space each number is in, and
-the mistakes that have already cost someone an hour. It is phrased as
-instructions to an agent because that is what most often reads it, but it is the
-engineering guide either way. Read it before a second change, not before a
-first.
+[AGENTS.md](AGENTS.md) is the long version: the repo layout, the five places a
+new module touches, which coordinate space each number is in, and the mistakes
+that have already cost someone an hour. It is phrased as instructions to an agent
+because that is what most often reads it, but it is the engineering guide either
+way. Read it before a second change, not a first.
 
 ## Reporting a bug
 
@@ -182,27 +163,26 @@ Use the bug template. The three things that decide whether a window bug is
 reproducible are the macOS version, the monitor arrangement, and which app owned
 the window, so the template asks for all three.
 
-The fastest way to show what your desk looked like is the state route. It is
-gated on the API token like everything else, so pass it:
+The fastest way to show what your desk looked like is `plonk state`, which finds
+the API token for you. The raw route, if you would rather not install the CLI:
 
 ```sh
 curl -s -H "X-Plonk-Token: $(cat ~/Library/'Application Support'/Plonk/token)" \
   127.0.0.1:43917/state
 ```
 
-It lists the title of every open window, so read it before you paste it. `plonk
-state` prints the same thing and finds the token for you.
+It lists the title of every open window, so read it before you paste it.
 
 ## Security
 
 Do not open a normal issue for something exploitable. `SECURITY.md` has the
-reporting route, and the same page describes the boundaries the app is supposed
-to hold, which is the useful thing to check a finding against.
+reporting route, and describes the boundaries the app is supposed to hold, which
+is the useful thing to check a finding against.
 
 ## What this project will not take
 
 Some directions are settled, and a pull request in them will be declined however
-good it is. This list exists so nobody spends a weekend on one:
+good it is. This list exists so nobody spends a weekend on one.
 
 - Accounts, cloud sync, telemetry, analytics or crash reporting.
 - Third-party Swift dependencies in `App/`.
@@ -210,9 +190,9 @@ good it is. This list exists so nobody spends a weekend on one:
 - CORS headers on the local API, or binding it to anything but loopback.
 
 Everything outside that list is open, including things already built. If you
-think a decision here is wrong, the place to say so is a
-[discussion](https://github.com/ostapondo/plonk/discussions), and it will get a
+think a decision here is wrong, say so in a
+[discussion](https://github.com/ostapondo/plonk/discussions) and it will get a
 real answer rather than a link back to this page.
 
-`ROADMAP.md` has the rest, including the features that were considered and
+`ROADMAP.md` has the rest, including features that were considered and
 deliberately left out.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 <h1 align="center">Plonk</h1>
 
-<p align="center"><strong>A window manager with zones you draw yourself, and nine
-more menu bar utilities behind the same icon.</strong><br>
-<sub>Workspaces that put the desk back, text lifted off the screen, keep-awake,
-screenshots you can draw on, pointer tools, a shortcut guide, voice. On a Mac
-each of those is its own download. To plonk is to set a thing down exactly where
-it belongs: you drag it there, you press a key, or you say where.</sub></p>
+<p align="center"><strong>A Mac window manager with zones you draw yourself, plus
+nine more menu bar utilities behind the same icon.</strong><br>
+<sub>To plonk is to set a thing down exactly where it belongs. You drag it
+there, you press a key, or you say where.</sub></p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.2.2-8b7cf6?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.2.4-8b7cf6?style=flat-square">
   <img alt="macOS 13+" src="https://img.shields.io/badge/macOS-13%2B-111?style=flat-square">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?style=flat-square">
   <img alt="No dependencies" src="https://img.shields.io/badge/dependencies-0-2ea043?style=flat-square">
@@ -18,176 +16,167 @@ it belongs: you drag it there, you press a key, or you say where.</sub></p>
 
 <p align="center">
   <a href="https://ostapondo.github.io/Plonk/"><strong>ostapondo.github.io/Plonk</strong></a>
-  <br><sub>The same thing on one page, if you would rather look than read.</sub>
 </p>
 
 <p align="center">
-  <img src="docs/demo.gif" alt="A pile of overlapping windows is cleared four ways in turn: one window is dragged into a zone as the zones light up, the next is sent to zone two with ⌃⌥2, the third by holding ⌃⌥V and saying “zone three”, and the last two are placed together from a sentence typed to an agent" width="720">
+  <img src="docs/demo.gif" width="720"
+       alt="A pile of overlapping windows is cleared four ways in turn: one window is dragged into a zone as the zones light up, the next is sent to zone two with ⌃⌥2, the third by holding ⌃⌥V and saying “zone three”, and the last two are placed together from a sentence typed to an agent">
 </p>
-
-## Three ways to put a window somewhere
-
-**Drag it.** Zones light up as you move a window, and it drops into one. Hold
-`⌘` as well and it takes two of them at once. Turn on grab-and-move and you can
-pull a window from anywhere inside it, instead of aiming for the title bar.
-
-**Press a key.** `⌃⌥←` for the left half, `⌃⌥1`–`⌃⌥9` for the numbered zones on
-that screen, `⌃⌥0` to put a window back exactly where it was before Plonk ever
-touched it.
-
-**Say it.** Hold `⌃⌥V` and name where it goes — "snap this left", "zone three".
-That runs inside the app, offline, with on-device recognition. Plonk also speaks
-MCP, so a whole desk at once can go to an agent you already have open:
-
-> browser on the left 60%, terminal top right, notes bottom right
->
-> save that as a workspace called "review"
->
-> keep the Mac awake until this build finishes
->
-> read the error out of that dialog and tell me what it says
-
-Five zone sets ship with it, and past those you cut your own: click a zone to
-split it, `⇧`-click to split it the other way, one set per monitor. Swap the
-set on a screen and the windows already sitting in a numbered zone go to
-wherever that number is now.
-
-<p align="center">
-  <img src="docs/zones.gif" alt="Five clicks in the zone editor cut one screen into six zones, six windows fill them, and ⌃⌥⇧2 then swaps the whole set for another while the windows already in it follow their numbers across" width="720">
-</p>
-
-<p align="center">
-  <img src="docs/app-zones.png" alt="Plonk's Zones page: a row of zone sets across the top with Thirds selected and its three numbered zones drawn below, controls for drag-to-snap and the modifier that shows the zones, and the list of halves, quarters, maximize and centre with the shortcut bound to each" width="820">
-</p>
-
-Everything runs on your Mac. No account, no cloud, no telemetry — and
-[none of that is a promise you have to take](docs/verify.md), it is all
-checkable from a terminal.
 
 ## Install
 
-macOS 13+.
+macOS 13 or newer.
 
 ```sh
 brew install --cask ostapondo/plonk/plonk
 ```
 
 Grant Accessibility when it asks, then relaunch. Screen Recording is asked for
-separately, the first time you capture. Nothing else — no Full Disk Access, no
+separately, the first time you capture. Nothing else: no Full Disk Access, no
 Automation, no Keychain.
 
-Optional, and only if you want the `plonk` CLI or an agent driving it (Node 18+):
+<details>
+<summary>Installing by hand, and why macOS holds a downloaded copy</summary>
+
+<br>
+
+Plonk is signed but **not notarized**. The certificate is self-signed rather
+than an Apple Developer ID, because notarizing needs a paid Apple account and
+this project does not have one. So macOS cannot vouch for who built it, and says
+so: a hand-downloaded copy is held on first launch. The cask skips that by
+clearing the quarantine flag for you.
+
+That is a check being skipped on your behalf, so here is a stronger one to run
+instead, before you open anything:
+
+```sh
+gh attestation verify $(brew --cache)/downloads/*--Plonk-0.2.4.zip \
+  -R ostapondo/plonk
+```
+
+It prints the commit and the GitHub Actions run that built this exact archive.
+Apple's stamp would tell you a build passed a malware scan; this tells you the
+binary came from the source in this repository, with no laptop in between.
+
+Without Homebrew: download [the latest release][rel], unzip, drop Plonk.app into
+Applications, then clear the flag yourself, which is all the cask does:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Plonk.app
+```
+
+Or do the Gatekeeper detour once: open Plonk, dismiss the warning, then System
+Settings, Privacy & Security, scroll to Security, **Open Anyway**.
+
+If you later move or rename Plonk.app, macOS ties the old grant to the old path
+and windows of newly launched apps stop being seen. Remove Plonk from Privacy &
+Security, Accessibility, and grant it again.
+
+</details>
+
+## Three ways to move a window
+
+**Drag it.** Zones light up as you move a window, and it drops into one. Hold
+`⌘` too and it takes two of them at once. Turn on grab-and-move to pull a window
+from anywhere inside it instead of aiming for the title bar.
+
+**Press a key.** `⌃⌥←` for the left half. `⌃⌥1` to `⌃⌥9` for the numbered zones
+on that screen. `⌃⌥0` puts a window back where it was before Plonk touched it.
+
+**Say it.** Hold `⌃⌥V` and name the place: "snap this left", "zone three". That
+runs in the app, offline, on-device.
+
+Five zone sets ship with it. Past those you cut your own: click a zone to split
+it, `⇧`-click to split the other way, one set per monitor. Swap the set on a
+screen and windows already in a numbered zone move to wherever that number is
+now.
+
+<p align="center">
+  <img src="docs/zones.gif" width="720"
+       alt="Five clicks in the zone editor cut one screen into six zones, six windows fill them, and ⌃⌥⇧2 then swaps the whole set for another while the windows already in it follow their numbers across">
+</p>
+
+<p align="center">
+  <img src="docs/app-zones.png" width="820"
+       alt="Plonk's Zones page: zone sets across the top with Thirds selected and its three numbered zones drawn below, controls for drag-to-snap and the modifier that shows the zones, and the list of halves, quarters, maximize and centre with the shortcut bound to each">
+</p>
+
+## What you get
+
+Ten things. The first three are the window manager. The rest are what would
+otherwise each be another menu bar icon.
+
+| | |
+| --- | --- |
+| **[Zones](docs/zones.md)** | Any layout you like, per monitor. Snap by dragging, by number, or by asking. Windows return to their zone after a display is unplugged and plugged back in |
+| **[Workspaces](docs/workspaces.md)** | A desk you can put away: the apps, every window's frame, the monitor each belongs on, what each app opens on the way up. Launch it onto an empty desktop and it rebuilds itself |
+| **Focus that follows the layout** | `⌃⌥⇧←` goes to the window actually on the left, not the one you used last. `` ⌃⌥` `` cycles the windows stacked in one zone |
+| **Text off the screen** | `⌃⌥T` selects an area and copies the words in it: a screenshot, a paused video, a dialog that will not let you select. On-device |
+| **Pin part of the screen** | Float a live crop above everything else. A build log, a chart, a call, visible in a corner while you work over it |
+| **Keep awake** | Real power assertions, not a jiggler. Sessions end by themselves: after N minutes, at a wall-clock time, or when a process exits |
+| **Screenshots** | Region, window or screen, then pen, arrow, rectangle, ellipse, highlighter. Saved at native resolution |
+| **A shortcut guide** | Every shortcut the front app actually has, read from its own menus, so it is never out of date |
+| **Pointer tools** | Find the cursor, ring every click for a recording, crosshairs, jump to the next display |
+| **Voice** | Hold `⌃⌥V` and say it. Common commands run in the app, offline. Anything bigger goes to your agent. Recognition is on-device |
+
+Longer versions: [Zones](docs/zones.md) · [Workspaces](docs/workspaces.md) ·
+[Hotkeys](docs/hotkeys.md) · [Everything else](docs/features.md)
+
+## For agents
+
+Plonk exposes its whole surface over MCP, so an agent can read the desk,
+rearrange it, save the result, and read the screen back without a screenshot
+round trip for anything that is really just words.
+
+```
+browser on the left 60%, terminal top right, notes bottom right
+save that as a workspace called "review"
+keep the Mac awake until this build finishes
+read the error out of that dialog and tell me what it says
+```
+
+Nineteen tools across state, layouts, workspaces, zones, keep-awake, screenshots
+and on-device OCR. Frames are fractions of a monitor's visible area, origin
+top-left, so "left 60%" is `{x: 0, y: 0, w: 0.6, h: 1}`. Several agents can
+connect at once, each registering itself, with an optional mode that locks
+changes to the active one.
+
+<p align="center">
+  <img src="docs/agents.gif" width="720"
+       alt="Four sentences typed to an agent: a layout is applied across the desk, the result is saved as a workspace called review and the Mac held awake until a build finishes, everything is then closed to an empty desktop and rebuilt from that workspace, and finally a line of error text is read off the screen">
+</p>
+
+Setup, if you want the `plonk` CLI or an agent driving it (Node 18+):
 
 ```sh
 claude mcp add plonk -- npx -y plonk-mcp   # Claude Code
 codex mcp add plonk -- npx -y plonk-mcp    # Codex CLI
 ```
 
-In Claude Code it can also come as a plugin — the same server, pinned to the
-release it shipped with rather than to whatever npm serves as latest:
+In Claude Code it can also be a plugin: same server, pinned to the release it
+shipped with rather than to whatever npm serves as latest.
 
 ```
 /plugin marketplace add ostapondo/plonk
 /plugin install plonk@plonk
 ```
 
-Any MCP client works the same way, over stdio or HTTP.
-[For agents](docs/agents.md) has the rest, plus one-pagers for
+For Claude Desktop there is nothing to type. Download `plonk-<version>.mcpb`
+from the [latest release][rel] and open it. The bundle carries the server and
+its dependencies, so no config file is edited and nothing is fetched at launch.
+
+Any MCP client works, over stdio or HTTP. One-pagers for
 [Cursor](docs/clients/cursor.md), [Zed](docs/clients/zed.md) and
 [Cline](docs/clients/cline.md).
 
-For Claude Desktop there is nothing to type: download `plonk-<version>.mcpb`
-from the [latest release](https://github.com/ostapondo/plonk/releases/latest)
-and open it. The bundle carries the server and its dependencies, so no config
-file gets edited and nothing is fetched at launch.
-
-<details>
-<summary><strong>Installing it by hand, and why macOS holds a downloaded copy</strong></summary>
-
-<br>
-
-Plonk is signed, but **not notarized**. The certificate is self-signed rather
-than an Apple Developer ID, because notarizing one requires a paid Apple
-account and this project does not have one. So macOS cannot vouch for who built
-this, and says so: a hand-downloaded copy is held on first launch, and the cask
-above skips that by clearing the quarantine flag for you.
-
-Worth stating plainly, since it is a check being skipped on your behalf. Here is
-the one that replaces it, and it is stronger — run it before you open anything:
-
-```sh
-gh attestation verify $(brew --cache)/downloads/*--Plonk-0.2.2.zip \
-  -R ostapondo/plonk
-```
-
-That prints the commit and the GitHub Actions run this exact archive was built
-by. Apple's stamp would tell you a build passed a malware scan; this tells you
-the binary on your Mac came from the source in this repository, and nothing
-went through a laptop on the way. It is the first of
-[several such checks](docs/verify.md) — none of what this README claims about
-privacy has to be taken on trust.
-
-Without Homebrew: download [the latest release](https://github.com/ostapondo/plonk/releases/latest),
-unzip, and drop Plonk.app into Applications. Then either do the Gatekeeper
-detour once — open Plonk, dismiss the warning, then System Settings → Privacy &
-Security, scroll to Security, **Open Anyway** — or clear the flag yourself,
-which is all the cask does:
-
-```sh
-xattr -dr com.apple.quarantine /Applications/Plonk.app
-```
-
-If you later move or rename Plonk.app (or its folder), macOS quietly ties the
-old grant to the old path: windows of newly launched apps stop being seen.
-Remove Plonk from Privacy & Security → Accessibility and grant it again.
-
-</details>
-
-## What you get
-
-Ten of them. The first three are the window manager, and the rest are the ones
-that would otherwise each be another icon in the menu bar.
-
-| | |
-| --- | --- |
-| **[Zones](docs/zones.md)** | Draw any layout you like, per monitor. Snap by dragging, by number, or by asking. Windows come back to their zone when a display is unplugged and plugged in again |
-| **[Workspaces](docs/workspaces.md)** | A desk you can put away: the apps, every window's frame, the monitor each belongs on, and what each app opens on the way up. Launch it onto an empty desktop and it rebuilds itself |
-| **Focus that follows the layout** | `⌃⌥⇧←` goes to the window that is actually on the left, not the one you used last. `` ⌃⌥` `` cycles the windows stacked in one zone |
-| **Text off the screen** | `⌃⌥T` selects an area and copies the words in it — from a screenshot, a paused video, a dialog that will not let you select. On-device, nothing uploaded |
-| **Pin part of the screen** | Float a live crop of anything above everything else: a build log, a chart, a call, visible in a corner while you work over it |
-| **Keep awake** | Real power assertions, not a jiggler — and a session that ends by itself: after N minutes, at a wall-clock time, or the moment a process exits |
-| **Screenshots** | Region, window or screen, then pen, arrow, rectangle, ellipse and highlighter. Saved at native resolution |
-| **A shortcut guide** | Every shortcut the app in front actually has, read from its own menus, so it is never out of date |
-| **Pointer tools** | Find the cursor, ring every click for a screen recording, crosshairs, jump to the next display |
-| **Voice** | Hold `⌃⌥V` and say it. The common ones — "snap this left", "zone three", "keep awake for an hour", "launch my review workspace" — run in the app itself, offline and instantly; anything bigger goes to your agent. Recognition is on-device |
-
-The long version: [Zones](docs/zones.md) · [Workspaces](docs/workspaces.md) ·
-[Hotkeys](docs/hotkeys.md) · [Everything else](docs/features.md)
-
-## For agents
-
-This is the part no other Mac window manager has. Plonk exposes its whole
-surface over MCP, so an agent can read the desk, rearrange it, save the result
-and read the screen back — without a screenshot round trip for anything that is
-really just words. Frames are fractions of a monitor's visible area, origin
-top-left, which is why "left 60%" is just `{x: 0, y: 0, w: 0.6, h: 1}`.
-
-<p align="center">
-  <img src="docs/agents.gif" alt="Four sentences typed to an agent: a layout is applied across the desk, the result is saved as a workspace called review and the Mac held awake until a build finishes, everything is then closed to an empty desktop and rebuilt from that workspace, and finally a line of error text is read off the screen" width="720">
-</p>
-
-Nineteen tools, across state, layouts, workspaces, zones, keep-awake,
-screenshots and on-device OCR. Several agents can be connected at once, each
-registering itself, with an optional mode that locks changes to the active one.
-
 The same package carries a `plonk` command, for the things that are neither an
-agent nor a settings window — a Makefile, a Raycast script, a shell alias:
+agent nor a settings window:
 
 ```sh
 plonk state                      # screens, zone sets, workspaces, windows
 plonk launch review              # a saved workspace
 plonk awake while npm run build  # awake for exactly as long as the build
-plonk text | pbcopy              # OCR a region straight into the clipboard
+plonk text | pbcopy              # OCR a region into the clipboard
 ```
 
 **[For agents](docs/agents.md)** has every tool, the multi-agent rules, the HTTP
@@ -195,35 +184,37 @@ transport and the rest of the CLI.
 
 ## Privacy
 
-Everything runs on your Mac, and none of it is a promise you have to take. The
-API binds to `127.0.0.1`, refuses anything carrying headers a browser cannot
-suppress, and is gated on a token only you can read. The one outbound connection
-is the update check, which carries no identifier and can be switched off.
-Releases are built and signed on GitHub's runners and ship with an attestation,
-so the binary on your Mac can be tied to the commit it came from:
+No account, no cloud, no telemetry. The API binds to `127.0.0.1`, refuses
+anything carrying headers a browser cannot suppress, and is gated on a token
+only you can read. The one outbound connection is the update check, which
+carries no identifier and can be switched off.
+
+None of that is a claim you have to take on trust. Releases are built and signed
+on GitHub's runners and ship with an attestation, so the binary on your Mac ties
+back to the commit it came from:
 
 ```sh
 gh attestation verify Plonk-<version>.zip -R ostapondo/plonk
 ```
 
-**[Check it yourself](docs/verify.md)** is every one of those claims with the
-command that tests it, and [SECURITY.md](SECURITY.md) is where each of them
-stops.
+**[Check it yourself](docs/verify.md)** is every claim above with the command
+that tests it. [SECURITY.md](SECURITY.md) is where each one stops.
 
 ## Under the hood
 
 <p align="center">
-  <img src="docs/architecture.svg" alt="Claude talks to the MCP server over stdio, which calls the app's loopback HTTP API" width="760">
+  <img src="docs/architecture.svg" width="760"
+       alt="Claude talks to the MCP server over stdio, which calls the app's loopback HTTP API">
 </p>
 
-- The app is the single source of truth; the MCP server is a stateless bridge.
+- The app is the single source of truth. The MCP server is a stateless bridge.
 - `App/` is the Swift menu bar app, `mcp/` the TypeScript MCP server.
 - Config is plain JSON at `~/Library/Application Support/Plonk/config.json`.
 
 ## Build
 
-Five commands, and they are exactly what CI runs on every pull request. Each
-line is a subshell, so paste the block from the repository root and it works:
+Five commands, and they are what CI runs on every pull request. Each line is a
+subshell, so paste the block from the repository root.
 
 ```sh
 (cd App && swift build)                    # the app compiles
@@ -234,46 +225,42 @@ node scripts/check-zone-sets.mjs           # the layouts in zone-sets/
 ```
 
 None of that needs a signing certificate. Zone geometry, config decoding, HTTP
-routing, MCP tools, voice command parsing, the CLI and every document here are
-reachable from that loop, and most changes never need more.
+routing, MCP tools, voice parsing, the CLI and every document here are reachable
+from that loop, and most changes need nothing more.
 
-Producing a launchable `Plonk.app` is the one step that does need one. Make your
-own once with `./scripts/make-signing-cert.sh`, then `./scripts/build.sh`. macOS
-ties Accessibility and Screen Recording to the code signature, and an ad-hoc one
+Producing a launchable `Plonk.app` does need one. Make your own once with
+`./scripts/make-signing-cert.sh`, then run `./scripts/build.sh`. macOS ties
+Accessibility and Screen Recording to the code signature, and an ad-hoc one
 changes every build, so a stable certificate is what stops rebuilds from
-resetting permissions. [CONTRIBUTING.md](CONTRIBUTING.md) has the details;
-[AGENTS.md](AGENTS.md) has the release process, which runs on GitHub's runners
-and never from a laptop.
+resetting permissions.
 
 ## Contributing
 
-Bug reports, zone sets, client one-pagers and code are all welcome, and none of
-them need a signing certificate — the loop above is the whole requirement.
-[CONTRIBUTING.md](CONTRIBUTING.md) opens with a first change you can send in
-about fifteen minutes, and says how long a review takes.
+Bug reports, zone sets, client one-pagers and code are all welcome. None of them
+need a signing certificate.
 
-The smallest useful change here is one JSON file. [`zone-sets/`](zone-sets/) is
-a gallery of layouts worth copying — an ultrawide split, a rotated monitor, the
-one built around a recurring meeting. Draw it in the app, read the numbers out
-of `plonk state --json`, open a pull request; that folder has its own CI job and
-answers in about twenty seconds. Nothing to build, nothing to sign, no Swift.
+- **The smallest useful change is one JSON file.** [`zone-sets/`](zone-sets/) is
+  a gallery of layouts worth copying: an ultrawide split, a rotated monitor, the
+  one built around a recurring meeting. Draw it in the app, read the numbers out
+  of `plonk state --json`, open a pull request. That folder has its own CI job
+  and answers in about twenty seconds. No build, no signing, no Swift.
+- **[good first issue][gfi]** issues are written to be picked up cold. Each says
+  where the code is and how to tell it worked, and carries a prompt you can hand
+  to an agent, since [AGENTS.md](AGENTS.md) already explains the repo to one.
+- **[needs-hardware][hw]** issues need neither Swift nor a certificate, and are
+  the most useful thing anyone can send. A window manager breaks on arrangements
+  the author cannot see, so a report from three monitors or an ultrawide is
+  worth more than a patch.
 
-The issues tagged [good first issue][gfi] are written to be picked up cold —
-each one says where the code is and how to tell it worked, and carries a prompt
-you can hand straight to an agent, since [AGENTS.md](AGENTS.md) already tells
-one how this repo is put together. The ones tagged [needs-hardware][hw] need
-neither Swift nor a certificate, and are the most useful thing anyone can send:
-a window manager breaks on arrangements the author cannot see, and a report
-from three monitors or an ultrawide is worth more than a patch.
-
-Questions, half-formed ideas and layouts worth showing off go to
-[Discussions](https://github.com/ostapondo/plonk/discussions); a security
-problem goes through [SECURITY.md](SECURITY.md) instead of a public issue.
-Everyone taking part is expected to follow the
-[Code of Conduct](CODE_OF_CONDUCT.md).
+[CONTRIBUTING.md](CONTRIBUTING.md) has the rest, including how long a review
+takes. Questions and half-formed ideas go to
+[Discussions](https://github.com/ostapondo/plonk/discussions). A security
+problem goes through [SECURITY.md](SECURITY.md), not a public issue. Everyone
+taking part follows the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 [gfi]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [hw]: https://github.com/ostapondo/plonk/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-hardware
+[rel]: https://github.com/ostapondo/plonk/releases/latest
 
 ## License
 


### PR DESCRIPTION
## Why

Both pages read as one long essay. Every paragraph has the same shape, an assertion followed by a clause qualifying it, and there is nothing to scan. The README spent 2228 words and 17 em dashes before a reader reached anything to type. CONTRIBUTING opened on how review works rather than on anything a contributor could pick up and do.

## What changed

**README**, 2228 → 1909 words:

- Install moved above the feature tour. It is what a reader wants first.
- The contributing section is three bullets instead of four paragraphs: the one-JSON-file change, `good first issue`, `needs-hardware`.
- Sentences cut down throughout; every em dash replaced with a colon or a full stop.

**CONTRIBUTING**, 1702 → 1517 words:

- Opens with the work. Issue #21 named up front with the file to change and the command that proves it, then the list of places to start, then the rules.
- The 48-hour promise, "your branch is yours" and the release-notes credit are still there, compressed into four bullets at the top instead of five paragraphs.

**Two stale facts**, both in the README: the version badge said 0.2.2, and so did the hardcoded filename in the `gh attestation verify` example under it. Both now say 0.2.4, which matches `version.env`.

## Not in this change

No image, script or page under `docs/` is touched. The GIFs, the landing page and `scripts/make-demo.sh` are exactly as they are on `main`.

## Checks

`./scripts/lint.sh` is clean. Nothing else in the CI loop reads these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)