### PR TITLE
fix: stop over-releasing the power source type string

### DIFF
--- a/App/Sources/plonk/AwakeManager.swift
+++ b/App/Sources/plonk/AwakeManager.swift
@@ -32,8 +32,9 @@ final class AwakeManager {
     var timeoutMinutes = 0
 
     var isOnAC: Bool {
-        // IOPSGetProvidingPowerSourceType returns "AC Power", "Battery Power" or "UPS Power".
-        let type = IOPSGetProvidingPowerSourceType(nil)?.takeRetainedValue() as String?
+        // IOPSGetProvidingPowerSourceType returns "AC Power", "Battery Power" or
+        // "UPS Power". A "Get" function, so the string is not ours to release.
+        let type = IOPSGetProvidingPowerSourceType(nil)?.takeUnretainedValue() as String?
         return type == nil || type == "AC Power"
     }
 


### PR DESCRIPTION
`AwakeManager.isOnAC` read the current power source with
`IOPSGetProvidingPowerSourceType(nil)?.takeRetainedValue()`. That is a CF
"Get" function, so the string comes back unretained and the release was
never ours to hand out.

Nothing has crashed because the API only ever returns the CFSTR constants
`"AC Power"`, `"Battery Power"` and `"UPS Power"`, which survive a stray
release. The ownership was wrong regardless, so this switches to
`takeUnretainedValue()` and leaves a comment saying why.

No behaviour change. Found while checking why a Mac stayed awake with
"Automatically while charging" off: that turned out to be an unrelated
manual keep-awake session, and this was sitting next to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)