### PR TITLE
ci: keep the Smithery listing current from the release, not by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ name: Release
 #
 #   PLONK_SIGN_CERT_P12       the "Plonk Signing" certificate and its key, base64
 #   PLONK_SIGN_CERT_PASSWORD  the password used when exporting it
+#   SMITHERY_API_KEY          smithery.ai > Account > API keys
+#
+# Only the first two are required. Without SMITHERY_API_KEY the release still
+# goes out in full and the Smithery listing keeps whatever version it last had.
 #
 # npm needs no secret at all: plonk-mcp names this repository and this workflow
 # file as a trusted publisher (npmjs.com > the package > Settings > Trusted
@@ -290,6 +294,12 @@ jobs:
     runs-on: ubuntu-latest
     # The draft release this uploads to is created by the app job.
     needs: app
+    env:
+      # Here rather than on the two steps that use it because `if:` cannot read
+      # the secrets context, and a step's own env is not in scope for its `if`
+      # either. A job env var is, so the Smithery steps test this and skip
+      # cleanly on a fork or a dispatch where the secret is not set.
+      SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
     permissions:
       contents: write # upload the bundle to the release
       id-token: write # sign the attestation
@@ -324,3 +334,32 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: gh release upload "v$VERSION" "mcp/plonk-$VERSION.mcpb" --clobber
+
+      # Smithery listed 0.2.2 for six days after 0.2.5 shipped, because the
+      # first publish was run by hand and nothing ran the second. These two
+      # steps are that hand, moved into the release.
+      #
+      # Neither blocks a release. By the time they run the zip, the npm tarball
+      # and the bundle are already out; a directory that is down should leave a
+      # yellow mark on the run, not withhold a build from everyone else.
+      - name: Publish the bundle to Smithery
+        continue-on-error: true
+        if: env.SMITHERY_API_KEY != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -eu
+          # The off-spec build: Smithery validates manifest.tools against the
+          # MCP tool schema, where inputSchema is required. See build-mcpb.sh.
+          ./scripts/build-mcpb.sh --smithery
+          npx --yes @smithery/cli@4 mcp publish \
+            "mcp/plonk-$VERSION-smithery.mcpb" -n ostapondo/plonk
+
+      # Separate step because the publish above carries none of this: `mcp
+      # publish` takes only --name, --resume and --config-schema, and the
+      # bundle path drops the manifest's listing fields (smithery-ai/cli#787),
+      # so a card published without this shows a bare qualified name.
+      - name: Fill in the Smithery listing
+        continue-on-error: true
+        if: env.SMITHERY_API_KEY != ''
+        run: ./scripts/publish-smithery.sh

--- a/scripts/publish-smithery.sh
+++ b/scripts/publish-smithery.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Fills in the Smithery listing for ostapondo/plonk.
+#
+# `smithery mcp publish` uploads the bundle and nothing else: its only flags
+# are --name, --resume and --config-schema, and the bundle path drops the
+# manifest's listing fields on the way in (smithery-ai/cli#787). So the card
+# shows the qualified name, no description and no icon, however complete
+# manifest.json is. The metadata has to be set over the management API
+# afterwards, which is what this does.
+#
+# Everything here comes from a file that already exists, so the card cannot
+# say something the package does not. Run it after `smithery mcp publish`,
+# with a key from https://smithery.ai/account/api-keys:
+#
+#   SMITHERY_API_KEY=... ./scripts/publish-smithery.sh
+set -eu
+cd "$(dirname "$0")/.."
+
+if [ -z "${SMITHERY_API_KEY:-}" ]; then
+	printf 'SMITHERY_API_KEY is not set\n' >&2
+	exit 1
+fi
+
+SERVER=ostapondo/plonk
+SITE=https://ostapondo.github.io/Plonk
+
+# node builds the body rather than a heredoc, so the description is escaped as
+# JSON by something that knows how, not by hand.
+BODY=$(SITE="$SITE" node -e '
+	const pkg = require("./mcp/package.json");
+	process.stdout.write(JSON.stringify({
+		displayName: "Plonk",
+		description: pkg.description,
+		homepage: process.env.SITE + "/",
+		repositoryUrl: "https://github.com/ostapondo/plonk",
+		license: pkg.license,
+		// A URL, not the multipart upload endpoint: the icon is already
+		// served from the project site, and one copy cannot go stale.
+		iconUrl: process.env.SITE + "/logo-400.png",
+	}));
+')
+
+# The qualified name has a slash in it and goes in the path.
+ENCODED=$(printf '%s' "$SERVER" | sed 's|/|%2F|')
+
+STATUS=$(curl -sS -X PATCH \
+	"https://api.smithery.ai/servers/$ENCODED" \
+	-H "Authorization: Bearer $SMITHERY_API_KEY" \
+	-H "Content-Type: application/json" \
+	-d "$BODY" \
+	-o /tmp/smithery-patch.json -w '%{http_code}')
+
+if [ "$STATUS" != "200" ]; then
+	printf 'PATCH %s failed with %s:\n' "$SERVER" "$STATUS" >&2
+	cat /tmp/smithery-patch.json >&2
+	printf '\n' >&2
+	rm -f /tmp/smithery-patch.json
+	exit 1
+fi
+
+rm -f /tmp/smithery-patch.json
+printf 'updated https://smithery.ai/server/%s\n' "$SERVER"
+
+# Read it back, because a 200 from the write path is not the same as the card
+# having changed.
+#
+# From the management API, not registry.smithery.ai: the public endpoint sits
+# behind a CDN that serves the pre-write copy for a while, so reading it here
+# reports a failure that did not happen.
+curl -sS "https://api.smithery.ai/servers/$ENCODED" \
+	-H "Authorization: Bearer $SMITHERY_API_KEY" | node -e '
+	let raw = "";
+	process.stdin.on("data", (c) => (raw += c));
+	process.stdin.on("end", () => {
+		const server = JSON.parse(raw);
+		for (const field of ["displayName", "description", "iconUrl"]) {
+			console.log(`  ${field}: ${server[field] || "(empty)"}`);
+		}
+	});
+'


### PR DESCRIPTION
Smithery listed 0.2.2 for six days after 0.2.5 shipped: the first publish was run from a laptop and nothing ran the second. The card was also blank — qualified name only, no description, no icon.

**Why one call is not enough**

`smithery mcp publish` uploads the bundle and carries none of its metadata. Its only flags are `--name`, `--resume` and `--config-schema`, and the bundle path drops the manifest's listing fields ([smithery-ai/cli#787](https://github.com/smithery-ai/cli/issues/787), open since June, confirmed by two others on 4.11.1). So `manifest.json` can be complete and the card still shows nothing. The metadata lives behind `PATCH https://api.smithery.ai/servers/{qualifiedName}`.

**What is here**

- `scripts/publish-smithery.sh` — the PATCH, with every field taken from `mcp/package.json` so the card cannot drift from the package. The icon goes as a URL to the copy already served from the project site rather than through the upload endpoint, so there is one file rather than two.
- `release.yml` — the `--smithery` build and `mcp publish`, then that script, in the `bundle` job.

**Two things worth reviewing**

The script reads the card back after writing, from the management API rather than `registry.smithery.ai`. The public endpoint sits behind a CDN that served the pre-write copy for minutes; reading it there reported `(empty)` for a write that had already landed.

Both steps are `continue-on-error`. By the time they run, the zip, the npm tarball and the bundle are already out, so a directory being down should mark the run yellow rather than withhold a build from everyone else. The key comes in as a job env var because `if:` cannot read the `secrets` context and a step's own `env` is not in scope for its `if`, so a fork or a dispatch without `SMITHERY_API_KEY` skips both steps instead of failing on an empty key.

**Checks**

- `./scripts/lint.sh` adds no finding for either file.
- The workflow parses; both steps carry the guard and `continue-on-error`.
- `build-mcpb.sh --smithery` writes exactly the path the publish step passes.
- The PATCH was run against the live card, which now shows `Plonk`, the package description and the icon. Verified on the rendered page, not only in the API.

`SMITHERY_API_KEY` is already set in Actions secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)