### PR TITLE
fix: check for updates again when the network comes back

### DIFF
--- a/App/Sources/plonk/UpdateManager.swift
+++ b/App/Sources/plonk/UpdateManager.swift
@@ -32,18 +32,16 @@ final class UpdateManager {
     /// times and every onChange bumps the change bus, which does not coalesce:
     /// one update would bury every listener on /events under its own progress.
     var onProgress: (() -> Void)?
-    /// Whether launch and the daily timer check on their own. The user's
+    /// Whether launch and the schedule check on their own. The user's
     /// setting; a check they ask for explicitly always runs.
     var automatic = true {
-        didSet { scheduleAutomaticCheck() }
+        didSet { schedule.automatic = automatic }
     }
 
     private let session: URLSession
-    private var timer: Timer?
+    private let schedule = UpdateSchedule()
     private var observation: NSKeyValueObservation?
     private var inFlight = false
-
-    private static let checkInterval: TimeInterval = 24 * 60 * 60
 
     init() {
         let config = URLSessionConfiguration.ephemeral
@@ -54,10 +52,10 @@ final class UpdateManager {
             "User-Agent": "Plonk/\(UpdateManager.currentVersionText)",
         ]
         session = URLSession(configuration: config)
+        schedule.onDue = { [weak self] in self?.check() }
     }
 
     deinit {
-        timer?.invalidate()
         observation?.invalidate()
     }
 
@@ -79,21 +77,9 @@ final class UpdateManager {
     // MARK: - Checking
 
     func start() {
-        scheduleAutomaticCheck()
+        schedule.automatic = automatic
         guard automatic else { return }
         check()
-    }
-
-    private func scheduleAutomaticCheck() {
-        timer?.invalidate()
-        timer = nil
-        guard automatic else { return }
-        let timer = Timer(timeInterval: Self.checkInterval, repeats: true) { [weak self] _ in
-            self?.check()
-        }
-        timer.tolerance = 60 * 60
-        RunLoop.main.add(timer, forMode: .common)
-        self.timer = timer
     }
 
     func check() {
@@ -325,13 +311,19 @@ final class UpdateManager {
     /// again — a check that gave up still leaves the app usable.
     private func finish(_ error: Error) {
         let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-        set(phase: .failed, status: message)
+        var offline = false
+        if case UpdateError.network = error { offline = true }
+        set(phase: .failed, status: message, offline: offline)
     }
 
-    private func set(phase: Phase, status: String) {
+    /// `offline` marks the one failure the schedule can undo on its own, and
+    /// every other call clears it: whatever a check ends up saying, it is the
+    /// current answer, and the network coming back does not change it.
+    private func set(phase: Phase, status: String, offline: Bool = false) {
         let apply = { [weak self] in
             guard let self else { return }
             if phase == .failed { inFlight = false }
+            schedule.awaitingNetwork = offline
             self.phase = phase
             self.status = status
             onChange?()

--- a/App/Sources/plonk/UpdatePage.swift
+++ b/App/Sources/plonk/UpdatePage.swift
@@ -57,7 +57,7 @@ struct UpdatePage: View {
                 Toggle(isOn: model.binding(\.updateCheckAutomatically,
                                            set: { $0.setUpdateCheckAutomatically($1) })) {
                     Text("Check for updates automatically")
-                    Text("On launch and once a day")
+                    Text("On launch, once a day, and when the network comes back")
                 }
             } footer: {
                 Text("""

--- a/App/Sources/plonk/UpdateSchedule.swift
+++ b/App/Sources/plonk/UpdateSchedule.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Network
+
+// When a check runs without the user asking for one. UpdateManager does the
+// asking; this decides when, and it is the only thing in the app that watches
+// the network path.
+//
+// Both halves are off together: with automatic checks turned off there is no
+// timer and no monitor, so the buttons on the update page stay the only way a
+// connection is opened.
+
+/// A path change, weighed against what the updater is waiting for. The monitor
+/// reports every change — a Wi-Fi hop, a VPN coming up, a cable pulled — and
+/// almost none of them are worth another check.
+struct ConnectivityChange: Equatable {
+    /// Whether a request could go out now.
+    let isSatisfied: Bool
+    /// Whether the last check gave up for want of a network. A feed that
+    /// answered badly is a different problem, and changing Wi-Fi does not fix
+    /// it: only this failure is worth retrying on the network coming back.
+    let awaitingNetwork: Bool
+    /// The user's setting.
+    let automatic: Bool
+
+    var warrantsCheck: Bool { isSatisfied && awaitingNetwork && automatic }
+}
+
+final class UpdateSchedule {
+
+    /// Fires on the main queue when a check is due.
+    var onDue: (() -> Void)?
+
+    var automatic = false {
+        didSet { automatic ? start() : stop() }
+    }
+
+    /// Set when a check gives up with a network error, cleared by the next
+    /// check whatever becomes of it. Without it the daily timer is the whole
+    /// recovery: a copy that launched with the Wi-Fi off would sit on "the
+    /// Internet connection appears to be offline" for a day after it came back.
+    var awaitingNetwork = false
+
+    private var timer: Timer?
+    private var monitor: NWPathMonitor?
+
+    private static let interval: TimeInterval = 24 * 60 * 60
+
+    deinit { stop() }
+
+    private func start() {
+        stop()
+        let timer = Timer(timeInterval: Self.interval, repeats: true) { [weak self] _ in
+            self?.onDue?()
+        }
+        timer.tolerance = 60 * 60
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+
+        // A cancelled monitor cannot be restarted, so turning the setting back
+        // on gets one of its own rather than reusing the old one.
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            let satisfied = path.status == .satisfied
+            DispatchQueue.main.async { self?.networkChanged(satisfied: satisfied) }
+        }
+        monitor.start(queue: DispatchQueue.global(qos: .utility))
+        self.monitor = monitor
+    }
+
+    private func stop() {
+        timer?.invalidate()
+        timer = nil
+        monitor?.cancel()
+        monitor = nil
+    }
+
+    private func networkChanged(satisfied: Bool) {
+        let change = ConnectivityChange(isSatisfied: satisfied,
+                                        awaitingNetwork: awaitingNetwork,
+                                        automatic: automatic)
+        guard change.warrantsCheck else { return }
+        // The check clears this too, on the way to reporting what it found.
+        // Clearing it here as well is what keeps the next path change — the
+        // rest of a reconnection arriving as several — from queueing more.
+        awaitingNetwork = false
+        onDue?()
+    }
+}

--- a/App/Tests/plonkTests/UpdateManagerTests.swift
+++ b/App/Tests/plonkTests/UpdateManagerTests.swift
@@ -180,3 +180,30 @@ struct UpdateVerdictTests {
             == .refuse(.wrongPayload("its bundle identifier is not ours")))
     }
 }
+
+struct UpdateRetryTests {
+
+    @Test func theNetworkComingBackRetriesACheckThatGaveUpWithoutOne() {
+        #expect(ConnectivityChange(isSatisfied: true, awaitingNetwork: true, automatic: true)
+            .warrantsCheck)
+    }
+
+    @Test func aPathChangeOnItsOwnIsNotWorthACheck() {
+        // Wi-Fi hops, VPNs, a cable pulled and put back: none of them is a
+        // reason to ask GitHub anything when the last check got an answer.
+        #expect(!ConnectivityChange(isSatisfied: true, awaitingNetwork: false, automatic: true)
+            .warrantsCheck)
+    }
+
+    @Test func theNetworkGoingAwayIsNotACheck() {
+        #expect(!ConnectivityChange(isSatisfied: false, awaitingNetwork: true, automatic: true)
+            .warrantsCheck)
+    }
+
+    @Test func nothingIsRetriedWhenTheUserTurnedCheckingOff() {
+        // The settings page promises the buttons are the only way a connection
+        // is opened, and a check that failed does not get to be an exception.
+        #expect(!ConnectivityChange(isSatisfied: true, awaitingNetwork: true, automatic: false)
+            .warrantsCheck)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ one of those.
   of the tokens. `interactive: true` hands the ruler to the user and waits for
   what they measure. Needs Screen Recording, like every other capture.
 
+### Fixed
+
+- **An update check that failed offline runs again when the network is back.**
+  It stopped at "The update check failed: The Internet connection appears to be
+  offline", and that is where it stayed: nothing watched for the network
+  returning, so the next attempt was the daily timer or the Check Now button. A
+  copy launched away from a network sat on a day-old error next to a version it
+  had never managed to check. Only that failure is retried, and only while
+  automatic checks are on — a Wi-Fi hop does not re-ask GitHub about a feed that
+  answered badly, and with checks turned off the buttons are still the only way
+  a connection is opened.
+
 ## 0.2.5 — 2026-08-15
 
 Two fixes, one of them a setting that only worked when a person asked for it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,9 +129,11 @@ This is the part of the app with the most reach, so here is every step it takes:
 
 1. On launch and once a day it asks `api.github.com` for the latest release, and
    sends nothing but a `User-Agent` naming the app and its version. No
-   identifier, no account, no analytics. Turn the check off under Updates and
-   this stops happening, agents included — they get a 409 rather than a
-   connection opened on your behalf.
+   identifier, no account, no analytics. A check that failed because there was
+   no network is retried once the network is back, and nothing else about the
+   path is acted on. Turn the check off under Updates and all of this stops
+   happening, agents included — they get a 409 rather than a connection opened
+   on your behalf.
 2. Nothing downloads until you press Install.
 3. The archive's SHA-256 is checked against the digest GitHub published for that
    asset, before it is unpacked. This catches a download that arrived damaged or

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -36,7 +36,9 @@ plonk  …  TCP 127.0.0.1:43917 (LISTEN)
 One listener on loopback. The only outbound connection Plonk makes is the
 update check: on launch and once a day it asks `api.github.com` for the latest
 release, and sends nothing but a User-Agent naming the app and its version — no
-identifier, no account, no analytics, no crash reporter. Turn it off under
+identifier, no account, no analytics, no crash reporter. A check that failed
+for want of a network runs again when one comes back, which is the only thing
+the app watches the network path for. Turn it off under
 Updates and it stops happening — including for agents, which get a 409 rather
 than a connection made on your behalf, so the buttons on that page are the only
 thing that can trigger one. `nettop` or Little Snitch will then show a process

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -16,6 +16,6 @@
 428   App/Sources/plonk/WindowManager.swift
 351   App/Sources/plonk/DragSnapManager.swift
 349   App/Sources/plonk/GrabMove.swift
-341   App/Sources/plonk/UpdateManager.swift
+333   App/Sources/plonk/UpdateManager.swift
 312   App/Sources/plonk/WorkspaceLauncher.swift
 306   mcp/src/api.ts


### PR DESCRIPTION
A check that ran without a network stopped at "The update check failed: The
Internet connection appears to be offline" and stayed there. Nothing watched for
the network returning, so the next attempt was the daily timer or the Check Now
button: a copy launched away from a network showed a day-old error beside a
version it had never managed to check.

The timer and an `NWPathMonitor` now live together in `UpdateSchedule`, which is
the only thing in the app that watches the network path. Both are off together
when automatic checks are, so the promise the settings page makes — the buttons
are the only way a connection is opened — holds in one place.

Only a network failure is retried, and only once the path can carry a request: a
Wi-Fi hop does not re-ask GitHub about a feed that answered badly. The decision
is `ConnectivityChange`, plain enough to test without a network or a desktop
session, and covered by four tests.

`UpdateManager` was at its line budget, so the schedule left with the timer
rather than being added on top of it: the file is 333 lines and the baseline
comes down with it. `SECURITY.md`, `docs/verify.md` and the toggle's own
subtitle say what the app now does, since all three describe when it connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)