### PR TITLE
feat: the zone sets as a list on screen

### DIFF
--- a/App/Sources/plonk/AppDelegate+Shell.swift
+++ b/App/Sources/plonk/AppDelegate+Shell.swift
@@ -239,6 +239,11 @@ extension AppDelegate {
             })
         }
 
+        result.append(PlonkCommand(id: "app.zoneSetPalette",
+                                   title: "Pick a zone set for this screen…",
+                                   group: "Zone sets") { [weak self] in
+            self?.openZoneSetPalette()
+        })
         result.append(PlonkCommand(id: "app.editZones", title: "Edit zone sets…",
                                    group: "Zone sets") { [weak self] in
             self?.openZonePicker()

--- a/App/Sources/plonk/AppDelegate+Zones.swift
+++ b/App/Sources/plonk/AppDelegate+Zones.swift
@@ -1,0 +1,74 @@
+import AppKit
+
+// Everything the app does to a zone set: which screen wears it, what is in it,
+// and the two windows that edit it. Split out of AppDelegate, which is over
+// the line limit and may only shrink.
+
+extension AppDelegate {
+    func assignZoneSet(_ name: String?, toScreen index: Int) {
+        store.update { $0.assignZoneSet(name, forKeys: ScreenIdentity.keys(forIndex: index)) }
+        refreshZoneModel()
+        commands.relayout(screenIndex: index)
+    }
+
+    func updateZoneSet(_ name: String, zones: [ZoneRect]) {
+        store.update { $0.zoneSets[name] = zones }
+        refreshZoneModel()
+        for index in NSScreen.screens.indices
+        where store.config.zoneAssignment(forKeys: ScreenIdentity.keys(forIndex: index)) == name {
+            commands.relayout(screenIndex: index)
+        }
+        if !presenter.isFullscreenEditorVisible {
+            dragSnap.previewZones()
+        }
+    }
+
+    func renameZoneSet(_ old: String, to new: String) -> Bool {
+        guard old != new else { return true }
+        guard store.config.zoneSets[old] != nil, store.config.zoneSets[new] == nil else { return false }
+        store.update {
+            guard let zones = $0.zoneSets.removeValue(forKey: old) else { return }
+            $0.zoneSets[new] = zones
+            $0.screenZoneSets = $0.screenZoneSets.mapValues { $0 == old ? new : $0 }
+        }
+        refreshZoneModel()
+        return true
+    }
+
+    func deleteZoneSet(_ name: String) {
+        store.update { $0.forgetZoneSet(named: name) }
+        refreshZoneModel()
+    }
+
+    func togglePreview(zoneSet name: String, onScreen index: Int) {
+        previewToken += 1
+        guard model.previewedZoneSet != name else {
+            clearPreview()
+            return
+        }
+        guard let zones = store.config.zoneSets[name] ?? BuiltinZoneSets.all[name] else { return }
+        dragSnap.showPreview(zones: zones, screenIndex: index)
+        model.previewedZoneSet = name
+
+        let token = previewToken
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            guard let self, previewToken == token else { return }
+            clearPreview()
+        }
+    }
+
+    func openZonePicker() {
+        presenter.showZonePicker()
+    }
+
+    /// The list on top of whatever is on screen, for the screen the cursor is
+    /// on: the same screen the ⌃⌥⇧-digit swaps act on, so the two agree about
+    /// which monitor "this one" means.
+    func openZoneSetPalette() {
+        presenter.showZoneSetPalette(screenIndex: ScreenIdentity.indexUnderCursor)
+    }
+
+    func editZoneSet(_ name: String, seed: [ZoneRect]?, onScreen index: Int) {
+        presenter.showFullscreenEditor(set: name, seed: seed, screenIndex: index)
+    }
+}

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -31,7 +31,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var captureDepth = 0
     var router: Router!
     private var server: ControlServer?
-    private var previewToken = 0
+    var previewToken = 0
     private var screenSettleWork: DispatchWorkItem?
     /// Display UUIDs seen at the last screen-parameter change, so a Dock
     /// resize can be told apart from a monitor being plugged in.
@@ -226,6 +226,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             toggleShortcutGuide()
         case .commandPalette:
             openCommandPalette()
+        case .zoneSetPalette:
+            openZoneSetPalette()
         default:
             if let number = action.zoneNumber {
                 commands.snap(toZone: number)
@@ -673,7 +675,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         statusMenu.workspaceNames = model.workspaceNames
     }
 
-    private func refreshZoneModel() {
+    func refreshZoneModel() {
         let custom = store.config.zoneSets.keys.sorted()
         model.customZoneSetNames = custom
         model.zoneSetNames = custom + BuiltinZoneSets.all.keys.sorted().filter { !custom.contains($0) }
@@ -695,7 +697,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
     }
 
-    private func clearPreview() {
+    func clearPreview() {
         dragSnap.hidePreviews()
         model.previewedZoneSet = nil
     }
@@ -1027,66 +1029,6 @@ extension AppDelegate: AppActions {
     func reportBug() {
         guard let url = URL(string: Self.issuesURL) else { return }
         NSWorkspace.shared.open(url)
-    }
-
-    func assignZoneSet(_ name: String?, toScreen index: Int) {
-        store.update { $0.assignZoneSet(name, forKeys: ScreenIdentity.keys(forIndex: index)) }
-        refreshZoneModel()
-        commands.relayout(screenIndex: index)
-    }
-
-    func updateZoneSet(_ name: String, zones: [ZoneRect]) {
-        store.update { $0.zoneSets[name] = zones }
-        refreshZoneModel()
-        for index in NSScreen.screens.indices
-        where store.config.zoneAssignment(forKeys: ScreenIdentity.keys(forIndex: index)) == name {
-            commands.relayout(screenIndex: index)
-        }
-        if !presenter.isFullscreenEditorVisible {
-            dragSnap.previewZones()
-        }
-    }
-
-    func renameZoneSet(_ old: String, to new: String) -> Bool {
-        guard old != new else { return true }
-        guard store.config.zoneSets[old] != nil, store.config.zoneSets[new] == nil else { return false }
-        store.update {
-            guard let zones = $0.zoneSets.removeValue(forKey: old) else { return }
-            $0.zoneSets[new] = zones
-            $0.screenZoneSets = $0.screenZoneSets.mapValues { $0 == old ? new : $0 }
-        }
-        refreshZoneModel()
-        return true
-    }
-
-    func deleteZoneSet(_ name: String) {
-        store.update { $0.forgetZoneSet(named: name) }
-        refreshZoneModel()
-    }
-
-    func togglePreview(zoneSet name: String, onScreen index: Int) {
-        previewToken += 1
-        guard model.previewedZoneSet != name else {
-            clearPreview()
-            return
-        }
-        guard let zones = store.config.zoneSets[name] ?? BuiltinZoneSets.all[name] else { return }
-        dragSnap.showPreview(zones: zones, screenIndex: index)
-        model.previewedZoneSet = name
-
-        let token = previewToken
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
-            guard let self, previewToken == token else { return }
-            clearPreview()
-        }
-    }
-
-    func openZonePicker() {
-        presenter.showZonePicker()
-    }
-
-    func editZoneSet(_ name: String, seed: [ZoneRect]?, onScreen index: Int) {
-        presenter.showFullscreenEditor(set: name, seed: seed, screenIndex: index)
     }
 
     func launchWorkspace(named name: String, onScreen screen: Int?) {

--- a/App/Sources/plonk/AppModel.swift
+++ b/App/Sources/plonk/AppModel.swift
@@ -63,6 +63,9 @@ protocol AppActions: AnyObject {
     func deleteZoneSet(_ name: String)
     func togglePreview(zoneSet name: String, onScreen index: Int)
     func openZonePicker()
+    /// The zone sets, listed over whatever is on screen, for the monitor the
+    /// pointer is on.
+    func openZoneSetPalette()
     /// `seed` opens the editor on a set that does not exist yet; it is only
     /// written if the user saves, so cancelling leaves nothing behind.
     func editZoneSet(_ name: String, seed: [ZoneRect]?, onScreen index: Int)
@@ -198,6 +201,26 @@ struct SettingsGroup: Identifiable {
 extension AppModel {
     /// The colour the app draws itself with, ready to hand to SwiftUI.
     var accent: Color { Color(nsColor: appearance.accent) }
+
+    /// A zone set name nobody has taken, which is `base` itself when it is free.
+    func freeZoneSetName(base: String) -> String {
+        if zoneSets[base] == nil { return base }
+        var index = 2
+        while zoneSets["\(base) \(index)"] != nil { index += 1 }
+        return "\(base) \(index)"
+    }
+
+    /// Opens the editor on a set. A built-in template is duplicated first, so
+    /// editing one never changes what the app ships with.
+    func editZoneSet(named name: String, onScreen index: Int) {
+        guard let actions else { return }
+        guard !customZoneSetNames.contains(name) else {
+            actions.editZoneSet(name, seed: nil, onScreen: index)
+            return
+        }
+        actions.editZoneSet(freeZoneSetName(base: name + " copy"),
+                            seed: zoneSets[name] ?? [], onScreen: index)
+    }
 
     /// Reads published state, writes through AppActions.
     func binding<Value>(_ keyPath: KeyPath<AppModel, Value>,

--- a/App/Sources/plonk/HotkeyAction.swift
+++ b/App/Sources/plonk/HotkeyAction.swift
@@ -16,6 +16,8 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
     /// Swap the whole zone set on the screen under the cursor, by its place in
     /// the list the Zones page shows.
     case layout1, layout2, layout3, layout4, layout5, layout6, layout7, layout8, layout9
+    /// The same swap, but with the sets on screen to choose from.
+    case zoneSetPalette
     case unsnap
     case cycleZone, cycleZoneBack
     case focusLeft, focusRight, focusUp, focusDown
@@ -105,6 +107,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .ruler: return "Measure the screen"
         case .shortcutGuide: return "Show this app's shortcuts"
         case .commandPalette: return "Open the command palette"
+        case .zoneSetPalette: return "Pick a zone set for this screen"
         default:
             if let number = zoneNumber { return "Zone \(number)" }
             if let number = layoutNumber { return "Zone set \(number)" }
@@ -132,6 +135,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .ruler: return "ruler"
         case .shortcutGuide: return "keyboard"
         case .commandPalette: return "command"
+        case .zoneSetPalette: return "rectangle.3.group"
         default:
             if zoneNumber != nil { return "square.grid.2x2" }
             if layoutNumber != nil { return "rectangle.3.group" }
@@ -150,6 +154,7 @@ enum HotkeyAction: String, CaseIterable, Identifiable {
         case .shortcutGuide, .commandPalette: return "Guide"
         case .cropLive, .cropStill: return "Crop"
         case .ruler: return "Ruler"
+        case .zoneSetPalette: return "Zone sets"
         default:
             if zoneNumber != nil { return "Numbered zones" }
             if layoutNumber != nil { return "Zone sets" }

--- a/App/Sources/plonk/HotkeyDefaults.swift
+++ b/App/Sources/plonk/HotkeyDefaults.swift
@@ -44,6 +44,7 @@ extension HotkeyAction {
         case .layout7: code = kVK_ANSI_7; shift = true
         case .layout8: code = kVK_ANSI_8; shift = true
         case .layout9: code = kVK_ANSI_9; shift = true
+        case .zoneSetPalette: code = kVK_ANSI_L
         case .unsnap: code = kVK_ANSI_0
         case .cycleZone: code = kVK_ANSI_Grave
         case .cycleZoneBack: code = kVK_ANSI_Grave; shift = true

--- a/App/Sources/plonk/ScreenIdentity.swift
+++ b/App/Sources/plonk/ScreenIdentity.swift
@@ -21,6 +21,13 @@ enum ScreenIdentity {
         return [uuid, String(index)]
     }
 
+    /// The screen the pointer is on, falling back to the first one: a shortcut
+    /// with no window to read a screen from acts on the one being looked at.
+    static var indexUnderCursor: Int {
+        let point = NSEvent.mouseLocation
+        return NSScreen.screens.firstIndex { $0.frame.contains(point) } ?? 0
+    }
+
     /// Where that display sits now, or nil when it is not attached.
     static func index(forUUID uuid: String) -> Int? {
         NSScreen.screens.indices.first { self.uuid(forIndex: $0) == uuid }

--- a/App/Sources/plonk/WindowCommands.swift
+++ b/App/Sources/plonk/WindowCommands.swift
@@ -153,9 +153,7 @@ final class WindowCommands {
             announce?(names.isEmpty ? "No zone sets to switch to" : "There are \(names.count) zone sets")
             return
         }
-        let point = NSEvent.mouseLocation
-        let screen = NSScreen.screens.firstIndex { $0.frame.contains(point) } ?? 0
-        assign(names[number - 1], screen)
+        assign(names[number - 1], ScreenIdentity.indexUnderCursor)
         announce?(names[number - 1])
     }
 

--- a/App/Sources/plonk/WindowPresenter.swift
+++ b/App/Sources/plonk/WindowPresenter.swift
@@ -14,6 +14,7 @@ final class WindowPresenter: NSObject {
     private var shotEditor: NSWindow?
     private var workspaceLaunch: NSPanel?
     private var palette: EditorWindow?
+    private var zoneSetPalette: EditorWindow?
 
     var shotFolder: () -> String = { "~/Desktop" }
     var onCancelWorkspaceLaunch: (() -> Void)?
@@ -52,35 +53,12 @@ final class WindowPresenter: NSObject {
     func showCommandPalette(commands: [PlonkCommand], agent: String?,
                             onAsk: @escaping (String) -> Void) {
         closeCommandPalette()
-        let window = EditorWindow(contentRect: .zero, styleMask: .borderless,
-                                  backing: .buffered, defer: false)
-        window.onEscape = { [weak self] in self?.closeCommandPalette() }
-        window.isOpaque = false
-        window.backgroundColor = .clear
-        window.level = .floating
-        window.isReleasedWhenClosed = false
-        window.hasShadow = true
-        // Clicking anywhere else dismisses it, the way Spotlight does. Without
-        // this it stays on top of whatever you switched to, and its key monitor
-        // keeps eating the arrow keys.
-        window.delegate = self
-        window.contentViewController = NSHostingController(
-            rootView: CommandPaletteView(commands: commands, agent: agent, onAsk: onAsk) { [weak self] in
-                self?.closeCommandPalette()
-            }
-        )
-        window.setContentSize(window.contentViewController?.view.fittingSize
-                              ?? NSSize(width: 560, height: 420))
+        let window = overlay(content: CommandPaletteView(commands: commands, agent: agent,
+                                                        onAsk: onAsk) { [weak self] in
+            self?.closeCommandPalette()
+        }, onEscape: { [weak self] in self?.closeCommandPalette() })
         palette = window
-        // A third of the way down rather than centred: a list that grows
-        // downwards should not start in the middle of the screen.
-        if let screen = NSScreen.main {
-            let frame = window.frame
-            window.setFrameOrigin(NSPoint(x: screen.frame.midX - frame.width / 2,
-                                          y: screen.visibleFrame.maxY - frame.height - 140))
-        }
-        NSApp.activate(ignoringOtherApps: true)
-        window.makeKeyAndOrderFront(nil)
+        show(window, near: NSScreen.main)
     }
 
     /// Closed rather than ordered out: the hosting view has to be torn down so
@@ -91,6 +69,58 @@ final class WindowPresenter: NSObject {
         palette = nil
         window.delegate = nil
         window.close()
+    }
+
+    /// The zone sets for one screen, opened on that screen: the list is about
+    /// that monitor, so it has to be visible on it.
+    func showZoneSetPalette(screenIndex: Int) {
+        closeZoneSetPalette()
+        let window = overlay(content: ZoneSetPaletteView(model: model, screenIndex: screenIndex) {
+            [weak self] in self?.closeZoneSetPalette()
+        }, onEscape: { [weak self] in self?.closeZoneSetPalette() })
+        zoneSetPalette = window
+        let screens = NSScreen.screens
+        show(window, near: screens.indices.contains(screenIndex) ? screens[screenIndex] : .main)
+    }
+
+    func closeZoneSetPalette() {
+        guard let window = zoneSetPalette else { return }
+        zoneSetPalette = nil
+        window.delegate = nil
+        window.close()
+    }
+
+    /// A borderless panel over everything, sized to what SwiftUI asks for.
+    /// Clicking anywhere else dismisses it, the way Spotlight does: without
+    /// that it stays on top of whatever you switched to, and its key monitor
+    /// keeps eating the arrow keys.
+    private func overlay<Content: View>(content: Content,
+                                        onEscape: @escaping () -> Void) -> EditorWindow {
+        let window = EditorWindow(contentRect: .zero, styleMask: .borderless,
+                                  backing: .buffered, defer: false)
+        window.onEscape = onEscape
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = .floating
+        window.isReleasedWhenClosed = false
+        window.hasShadow = true
+        window.delegate = self
+        window.contentViewController = NSHostingController(rootView: content)
+        window.setContentSize(window.contentViewController?.view.fittingSize
+                              ?? NSSize(width: 560, height: 420))
+        return window
+    }
+
+    /// A third of the way down rather than centred: a list that grows
+    /// downwards should not start in the middle of the screen.
+    private func show(_ window: NSWindow, near screen: NSScreen?) {
+        if let screen {
+            let frame = window.frame
+            window.setFrameOrigin(NSPoint(x: screen.frame.midX - frame.width / 2,
+                                          y: screen.visibleFrame.maxY - frame.height - 140))
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
     }
 
     func showZonePicker() {
@@ -239,8 +269,9 @@ extension WindowPresenter: NSWindowDelegate {
     }
 
     func windowDidResignKey(_ notification: Notification) {
-        guard (notification.object as? NSWindow) === palette else { return }
-        closeCommandPalette()
+        let window = notification.object as? NSWindow
+        if window === palette { closeCommandPalette() }
+        if window === zoneSetPalette { closeZoneSetPalette() }
     }
 }
 

--- a/App/Sources/plonk/ZonePickerView.swift
+++ b/App/Sources/plonk/ZonePickerView.swift
@@ -112,7 +112,7 @@ struct ZonePickerView: View {
                     isPreviewing: model.previewedZoneSet == name,
                     onSelect: { model.actions?.assignZoneSet(name, toScreen: selectedScreen) },
                     onPreview: { model.actions?.togglePreview(zoneSet: name, onScreen: selectedScreen) },
-                    onEdit: { edit(name, isCustom: isCustom) },
+                    onEdit: { model.editZoneSet(named: name, onScreen: selectedScreen) },
                     onDelete: isCustom ? { model.actions?.deleteZoneSet(name) } : nil,
                     onRename: isCustom ? { _ = model.actions?.renameZoneSet(name, to: $0) } : nil
                 )
@@ -120,26 +120,9 @@ struct ZonePickerView: View {
         }
     }
 
-    private func edit(_ name: String, isCustom: Bool) {
-        guard let actions = model.actions else { return }
-        guard !isCustom else {
-            actions.editZoneSet(name, seed: nil, onScreen: selectedScreen)
-            return
-        }
-        actions.editZoneSet(uniqueName(base: name + " copy"),
-                            seed: model.zoneSets[name] ?? [], onScreen: selectedScreen)
-    }
-
     private func createNewLayout() {
-        model.actions?.editZoneSet(uniqueName(base: "Custom"),
+        model.actions?.editZoneSet(model.freeZoneSetName(base: "Custom"),
                                    seed: [ZoneRect(0, 0, 1, 1)], onScreen: selectedScreen)
-    }
-
-    private func uniqueName(base: String) -> String {
-        if model.zoneSets[base] == nil { return base }
-        var i = 2
-        while model.zoneSets["\(base) \(i)"] != nil { i += 1 }
-        return "\(base) \(i)"
     }
 }
 

--- a/App/Sources/plonk/ZoneSetPaletteView.swift
+++ b/App/Sources/plonk/ZoneSetPaletteView.swift
@@ -1,0 +1,238 @@
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+// Every zone set that could go on one screen, drawn small. Arrows or a digit
+// to pick one, return to put it on the screen, E to open it in the editor.
+//
+// The digits match the ⌃⌥⇧1-9 bindings deliberately: those do the same swap
+// blind, and this is where the order they use becomes something you can see.
+// Edge snapping sits at the top with no digit, because it is a mode rather
+// than a set and has no editor to open.
+//
+// Arrow keys come from a local event monitor for the same reason the command
+// palette's do: nothing here is a text field, so SwiftUI's move commands never
+// fire on their own.
+
+struct ZoneSetPaletteView: View {
+    @ObservedObject var model: AppModel
+    let screenIndex: Int
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var scheme
+    @State private var selection = 0
+    @State private var monitor: Any?
+
+    /// One line of the list. An empty name is edge snapping.
+    private struct Row: Identifiable {
+        let name: String
+        let zones: [ZoneRect]
+        let custom: Bool
+        var id: String { name }
+        var title: String { name.isEmpty ? "Edge snapping" : name }
+    }
+
+    private var rows: [Row] {
+        [Row(name: "", zones: [], custom: false)] + model.zoneSetNames.map {
+            Row(name: $0, zones: model.zoneSets[$0] ?? [],
+                custom: model.customZoneSetNames.contains($0))
+        }
+    }
+
+    /// What the screen is on now. No assignment means the default set.
+    private var assigned: String {
+        model.screenAssignments[screenIndex] ?? BuiltinZoneSets.defaultName
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            list
+            footer
+        }
+        .frame(width: 460)
+        .background(VisualEffect(material: .popover))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Ink.capStroke))
+        .onAppear {
+            selection = rows.firstIndex { $0.name == assigned } ?? 0
+            startMonitor()
+        }
+        .onDisappear(perform: stopMonitor)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "rectangle.3.group").foregroundStyle(.tertiary)
+            Text("Zone sets").font(.system(size: 13, weight: .semibold))
+            Spacer()
+            Text(screenLabel).font(.system(size: 11)).foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+    }
+
+    private var screenLabel: String {
+        let size = model.screenDescriptions.indices.contains(screenIndex)
+            ? model.screenDescriptions[screenIndex] : ""
+        guard model.screenCount > 1 else { return size }
+        return size.isEmpty ? "Screen \(screenIndex + 1)" : "Screen \(screenIndex + 1) — \(size)"
+    }
+
+    private var list: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                        line(row, index: index)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 340)
+            .onChange(of: selection) { index in
+                guard rows.indices.contains(index) else { return }
+                proxy.scrollTo(rows[index].id, anchor: .center)
+            }
+        }
+    }
+
+    private func line(_ row: Row, index: Int) -> some View {
+        let selected = index == selection
+        return HStack(spacing: 11) {
+            thumbnail(row)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.title).font(.system(size: 12.5, weight: selected ? .semibold : .regular))
+                if row.name == assigned {
+                    Text("On this screen now").font(.system(size: 10.5)).foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            if index < 10 { KeyCaps(parts: ["\(index)"]) }
+            if !row.name.isEmpty {
+                Button { edit(row) } label: { Image(systemName: "pencil") }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .help(row.custom ? "Edit this set" : "Edit a copy of this template")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(selected ? Ink.raised(scheme) : .clear)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(selected ? Color.accentColor : .clear).frame(width: 2.5)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { selection = index; apply(row) }
+        .id(row.id)
+    }
+
+    private func thumbnail(_ row: Row) -> some View {
+        Group {
+            if row.zones.isEmpty {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.gray.opacity(0.12))
+                    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Color.gray.opacity(0.35)))
+                    .overlay(Image(systemName: "arrow.down.left.and.arrow.up.right")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary))
+            } else {
+                ZoneCanvas(zones: row.zones)
+            }
+        }
+        .frame(width: 62, height: 39)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 14) {
+            hint(["↑", "↓"], "pick")
+            hint(["return"], "use it")
+            hint(["E"], "edit")
+            hint(["N"], "new")
+            hint(["esc"], "close")
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .overlay(alignment: .top) { Rectangle().fill(Ink.hairline).frame(height: 1) }
+    }
+
+    private func hint(_ keys: [String], _ label: String) -> some View {
+        HStack(spacing: 5) {
+            KeyCaps(parts: keys)
+            Text(label).font(.system(size: 10.5)).foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: - Doing something about it
+
+    /// Closes first, and does the work a runloop turn later: a relayout moves
+    /// real windows, and the editor opens a window of its own. Neither should
+    /// race the teardown of this one.
+    private func apply(_ row: Row) {
+        onClose()
+        let name = row.name
+        let screen = screenIndex
+        DispatchQueue.main.async { [model] in
+            model.actions?.assignZoneSet(name, toScreen: screen)
+            HUD.shared.show(name.isEmpty ? "Edge snapping" : name)
+        }
+    }
+
+    private func edit(_ row: Row) {
+        guard !row.name.isEmpty else { return }
+        onClose()
+        let name = row.name
+        let screen = screenIndex
+        DispatchQueue.main.async { [model] in
+            model.editZoneSet(named: name, onScreen: screen)
+        }
+    }
+
+    private func createNew() {
+        onClose()
+        let screen = screenIndex
+        DispatchQueue.main.async { [model] in
+            model.actions?.editZoneSet(model.freeZoneSetName(base: "Custom"),
+                                       seed: [ZoneRect(0, 0, 1, 1)], onScreen: screen)
+        }
+    }
+
+    private func move(_ delta: Int) {
+        let count = rows.count
+        guard count > 0 else { return }
+        selection = min(max(selection + delta, 0), count - 1)
+    }
+
+    private func startMonitor() {
+        stopMonitor()
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let entries = rows
+            switch Int(event.keyCode) {
+            case kVK_DownArrow: move(1); return nil
+            case kVK_UpArrow: move(-1); return nil
+            case kVK_Escape: onClose(); return nil
+            case kVK_Return, kVK_ANSI_KeypadEnter:
+                if entries.indices.contains(selection) { apply(entries[selection]) }
+                return nil
+            case kVK_ANSI_E:
+                if entries.indices.contains(selection) { edit(entries[selection]) }
+                return nil
+            case kVK_ANSI_N:
+                createNew()
+                return nil
+            default:
+                guard let digit = Int(event.charactersIgnoringModifiers ?? ""),
+                      entries.indices.contains(digit) else { return event }
+                apply(entries[digit])
+                return nil
+            }
+        }
+    }
+
+    private func stopMonitor() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+    }
+}

--- a/App/Sources/plonk/ZonesPage.swift
+++ b/App/Sources/plonk/ZonesPage.swift
@@ -80,7 +80,8 @@ struct ZonesPage: View {
         SettingsCard(title: "Switch zone sets",
                      note: "Applies the set at that place in the list of zone sets, to whichever "
                          + "screen the cursor is on. Windows already sitting in a numbered zone "
-                         + "move to where that number is in the new set.") {
+                         + "move to where that number is in the new set. The last shortcut puts "
+                         + "the same list on screen to pick from, or to open one in the editor.") {
             SettingBlock {
                 ShortcutRows(model: model, actions: HotkeyAction.owned(by: "zones", group: "Zone sets"))
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ one of those.
 
 ### Added
 
+- **The zone sets, as a list you can see.** `⌃⌥L` draws every set available for
+  the screen the cursor is on, each one as a small picture of itself, with the
+  one that screen is wearing marked. Arrows or the digit picks, `return` puts it
+  on the screen, `E` opens it in the fullscreen editor, `N` starts a new one,
+  Escape leaves everything as it was.
+
+  `⌃⌥⇧1`–`⌃⌥⇧9` already swapped a set, but only for someone who remembers which
+  set is number four. The digits in the list are those same numbers, so the list
+  is also the thing that teaches them. Editing from here duplicates a built-in
+  template first, exactly as the Zones window does, so the shipped sets stay
+  intact.
+
 - **A ruler for the screen.** `⌃⌥R`, then hover: Plonk photographs the screen
   once, walks out from the pointer in all four directions until one pixel is
   unlike the one beside it, and draws each run as a dimension line with its own

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -13,6 +13,7 @@
 | `⌃⌥` arrows, `U I J K`, `↩`, `C` | Halves, quarters, maximize, centre |
 | `⌃⌥1`–`⌃⌥9`, `⌃⌥0` | Into a numbered zone, or back where it was |
 | `⌃⌥⇧1`–`⌃⌥⇧9` | Swap the whole zone set on this screen |
+| `⌃⌥L` | The zone sets as a list on screen — pick one, or press `E` to edit it |
 | `⌃⌥⇧` arrows | Focus the window that is actually in that direction |
 | `` ⌃⌥` `` | Next window in this zone |
 | `⌃⌥Z` | Flash the zones |

--- a/docs/zones.md
+++ b/docs/zones.md
@@ -24,6 +24,7 @@ it.
 | **Or none** | Edge snapping instead: middles are halves, top is maximize, corners are quarters |
 | **Or hover the line** | Bring the cursor near the border between two zones and both light up, no modifier at all |
 | **Whole sets** | `⌃⌥⇧1`–`⌃⌥⇧9` swap the set on the screen the cursor is on. Windows already sitting in a numbered zone move to where that number is now |
+| **Picking one** | `⌃⌥L` draws the sets for that screen as a list: arrows or the digit to pick, `return` to use it, `E` to open it in the editor, `N` for a new one |
 | **Looks** | Gap, colour, opacity, numbers on or off, every monitor's zones shown while dragging. The gap is real — a window keeps that much space around it |
 | **Exceptions** | A list of apps Plonk keeps its hands off — games, remote desktops, anything that manages its own geometry. Asking an agent to place one still works; that names the window on purpose |
 | **New windows** | Optionally, a window that opens goes where that app's last one went |

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -8,7 +8,7 @@
 # delete the line once it is under the limit.
 #
 # lines  path
-1184  App/Sources/plonk/AppDelegate.swift
+1126  App/Sources/plonk/AppDelegate.swift
 595   App/Sources/plonk/Router.swift
 439   App/Sources/plonk/SettingsPages.swift
 489   App/Tests/plonkTests/ConfigTests.swift


### PR DESCRIPTION
## What changed, and why

`⌃⌥⇧1`–`⌃⌥⇧9` already swap a whole zone set, but only for someone who remembers which set is number four. `⌃⌥L` now draws the sets available for the screen the cursor is on: each one as a small picture of itself, the one that screen is wearing marked, arrows or the digit to pick, `return` to use it. The digits in the list are the same numbers those shortcuts use, so the list is what teaches them.

`E` opens the highlighted set in the fullscreen editor and `N` starts a new one, which is the part that was missing entirely: editing a set meant opening the Zones window first. A built-in template is duplicated before it opens, exactly as the Zones window does, so the shipped sets stay intact.

AppDelegate is at its line limit and may only shrink, so the zone-set methods moved to `AppDelegate+Zones.swift` on the way past. They are unchanged; `refreshZoneModel`, `clearPreview` and `previewToken` lost their `private` so the extension can see them. `ScreenIdentity.indexUnderCursor` is the cursor-to-screen lookup `WindowCommands.applyZoneSet` already had, now shared with the new shortcut so the two agree about which monitor "this one" means, and `AppModel.freeZoneSetName` / `editZoneSet(named:onScreen:)` are `ZonePickerView`'s naming and duplicate-a-template rules, moved where both callers can reach them.

## What you ran

```
(cd App && swift build)
./scripts/test.sh      # 380 tests
./scripts/lint.sh      # clean; baseline for AppDelegate.swift lowered 1184 -> 1126
./scripts/build.sh && open Plonk.app && curl -s 127.0.0.1:43917/ping
```

## Checks

- [x] `swift build` passes on every commit in the branch, not just the last one
- [x] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be — it is a view and a window; the pure parts it uses (`Config`, `ZoneGeometry`) are already covered
- [x] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [ ] If this touches the network, the permissions, the entitlements or the update path — it touches none of them
- [ ] Screenshots below for anything visual — not attached; the panel is a list of the sets the machine it runs on happens to have

## If this moves windows

**Setup:** macOS 15 (Darwin 25.5), 1 display

Nothing about placement changed. The palette calls the same `assignZoneSet` the Zones window and the `⌃⌥⇧`-digit shortcuts already call, and that method moved between files verbatim.

- [x] **One screen.** App launched from the signed bundle, `/ping` answers, the shortcut opens the panel and assigning a set relayouts the screen.
- [ ] **A second monitor.** No hardware. The screen index comes from `ScreenIdentity.indexUnderCursor`, the same lookup the digit shortcuts use.
- [ ] **Mixed scale factors.** No hardware.
- [ ] **Unplug and plug back in.** No hardware. Assignment is still keyed by display UUID through `ScreenIdentity.keys(forIndex:)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)