### PR TITLE
One apply per config write, and the managers behind it

### DIFF
--- a/App/Sources/plonk/AppDelegate+DragSnap.swift
+++ b/App/Sources/plonk/AppDelegate+DragSnap.swift
@@ -16,7 +16,6 @@ extension AppDelegate {
             guard let self else { return [] }
             return store.config.zones(forKeys: ScreenIdentity.keys(forIndex: index))
         }
-        dragSnap.appearance = { [weak self] in self?.zoneAppearance ?? ZoneAppearance() }
         dragSnap.isExcluded = { [weak self] app in self?.isExcluded(app) ?? false }
         dragSnap.onSnap = { [weak self] window, before, frac, screenIndex in
             guard let self else { return }
@@ -28,7 +27,6 @@ extension AppDelegate {
         dragSnap.apply(store.config)
         dragSnap.start()
     }
-
 
     var zoneAppearance: ZoneAppearance { ZoneAppearance(store.config) }
 
@@ -63,7 +61,6 @@ extension AppDelegate {
         grabMove.apply(store.config)
     }
 
-
     /// Which numbered zone a dropped fraction corresponds to, so editing the
     /// set later can move the window with its number. Nil for a span or an
     /// edge snap, which match no single zone.
@@ -77,7 +74,7 @@ extension AppDelegate {
 
     func setupNewWindows() {
         newWindows = NewWindowWatcher(windows: windows)
-        newWindows.enabled = store.config.placeNewWindows
+        newWindows.apply(store.config)
         newWindows.isExcluded = { [weak self] app in self?.isExcluded(app) ?? false }
         newWindows.zoneGap = { [weak self] in CGFloat(self?.store.config.zoneGap ?? 0) }
         newWindows.placement = { [weak self] app in

--- a/App/Sources/plonk/AppDelegate+Login.swift
+++ b/App/Sources/plonk/AppDelegate+Login.swift
@@ -9,6 +9,16 @@ extension AppDelegate {
         SMAppService.mainApp.status == .enabled
     }
 
+    /// Make the login item match `config.launchAtLogin`. Asking macOS is an
+    /// XPC round trip and this runs after every write, so it only asks when
+    /// the setting itself moved (or at launch, when nothing has been applied
+    /// yet). A refusal shows on the toggle; turning it off and on asks again.
+    func applyLoginItem(_ config: Config, previous: Config?) {
+        guard previous?.launchAtLogin != config.launchAtLogin else { return }
+        applyLaunchAtLogin(config.launchAtLogin)
+        model.loginItemRegistered = isLaunchAtLoginEnabled
+    }
+
     /// Registers the app bundle as a login item. Fails silently when the app
     /// runs unbundled (swift run), where there is nothing to register.
     func applyLaunchAtLogin(_ enabled: Bool) {
@@ -21,13 +31,5 @@ extension AppDelegate {
         } catch {
             NSLog("Plonk: login item update failed: \(error)")
         }
-    }
-
-    func setLaunchAtLogin(_ on: Bool) {
-        applyLaunchAtLogin(on)
-        update(\.launchAtLogin, to: on)
-        // macOS can refuse, so the toggle shows what it settled on rather than
-        // what it was asked for.
-        model.loginItemRegistered = isLaunchAtLoginEnabled
     }
 }

--- a/App/Sources/plonk/AppDelegate+Model.swift
+++ b/App/Sources/plonk/AppDelegate+Model.swift
@@ -12,9 +12,9 @@ extension AppDelegate {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     }
 
-    /// The whole model, for a window about to open. Everything config decides
-    /// goes through applyConfig; what is left is fixed for the run or comes
-    /// from macOS.
+    /// The whole model, once, at launch. Everything config decides goes
+    /// through applyConfig; what is left is fixed for the run or comes from
+    /// macOS.
     func refreshModel() {
         model.appVersion = appVersion
         model.configWarning = store.loadFailure
@@ -22,7 +22,19 @@ extension AppDelegate {
         model.settingsGroups = SettingsPages.groups
         model.settingsPages = SettingsPages.all
         refreshPermissions()
+        refreshScreenModel()
         applyConfig()
+    }
+
+    /// Hang applyConfig off the store. Its own step in the launch order, after
+    /// every manager it reaches exists and independent of the HTTP server, so
+    /// nothing about which writes get applied rides on where setupServer sits.
+    func watchConfig() {
+        store.didMutate = { [weak self] in
+            guard let self else { return }
+            applyConfig()
+            router.changes.bump("config")
+        }
     }
 
     /// Everything a config change has to reach, in one place, run after every
@@ -33,8 +45,27 @@ extension AppDelegate {
     /// so none of them has to be told which setting it cares about. That costs
     /// a few assignments per change and buys the guarantee that a saved
     /// setting is an applied one.
+    ///
+    /// A manager's apply can write config itself (keep-awake persisting a
+    /// session it just ended), which lands back here mid-run. That inner call
+    /// is deferred until this one has finished, so every manager sees the
+    /// newest config in order rather than a stale snapshot after a newer one.
     func applyConfig() {
+        guard !applyingConfig else {
+            configApplyPending = true
+            return
+        }
+        applyingConfig = true
+        defer {
+            applyingConfig = false
+            if configApplyPending {
+                configApplyPending = false
+                applyConfig()
+            }
+        }
+
         let config = store.config
+        let previous = appliedConfig
         model.config = config
 
         applyAppearance()
@@ -46,13 +77,20 @@ extension AppDelegate {
         active.apply(config)
         newWindows.apply(config)
         updates.apply(config)
+        applyLoginItem(config, previous: previous)
+        applyRectangleURLs(config, previous: previous)
+        appliedConfig = config
 
-        // What the config implies rather than states: the names in it, sorted
-        // for the lists, and what each manager makes of its new settings.
+        // What the config implies rather than states, and what each manager
+        // makes of its new settings. The zone and workspace lists are computed
+        // off model.config; only what also depends on the screens is refreshed
+        // here, and only when the part of config it reads has moved.
+        statusMenu.workspaceNames = model.workspaceNames
+        if previous?.screenZoneSets != config.screenZoneSets {
+            refreshScreenAssignments()
+        }
         refreshAwakeModel()
         refreshActiveModel()
-        refreshWorkspaceModel()
-        refreshZoneModel()
         refreshHotkeyModel()
         refreshAgentModel()
         refreshUpdateModel()
@@ -66,7 +104,9 @@ extension AppDelegate {
 
     func refreshAgentModel() {
         model.connectedAgents = agents.onlineNames()
-        if !model.connectedAgents.isEmpty {
+        // Checked here first: markGettingStarted copies the whole config to
+        // find out, and this runs on every write.
+        if !model.connectedAgents.isEmpty, !store.config.sawFirstAgent {
             markGettingStarted { $0.sawFirstAgent = true }
         }
     }
@@ -85,18 +125,17 @@ extension AppDelegate {
         }
     }
 
-    func refreshWorkspaceModel() {
-        model.workspaceNames = store.config.workspaces.keys.sorted()
-        statusMenu.workspaceNames = model.workspaceNames
-    }
-
-    func refreshZoneModel() {
-        let custom = store.config.zoneSets.keys.sorted()
-        model.customZoneSetNames = custom
-        model.zoneSetNames = custom + BuiltinZoneSets.all.keys.sorted().filter { !custom.contains($0) }
-        model.zoneSets = BuiltinZoneSets.all.merging(store.config.zoneSets) { _, user in user }
+    /// What the displays are, which config has no say in: at launch and when
+    /// a screen comes or goes.
+    func refreshScreenModel() {
         model.screenCount = NSScreen.screens.count
         model.screenDescriptions = NSScreen.screens.map { "\(Int($0.frame.width)) × \(Int($0.frame.height))" }
+        refreshScreenAssignments()
+    }
+
+    /// Which set each screen wears: config keyed by display UUID, resolved
+    /// against the screens attached now.
+    func refreshScreenAssignments() {
         model.screenAssignments = NSScreen.screens.indices.reduce(into: [:]) { result, index in
             result[index] = store.config.zoneAssignment(forKeys: ScreenIdentity.keys(forIndex: index))
         }

--- a/App/Sources/plonk/AppDelegate+Rectangle.swift
+++ b/App/Sources/plonk/AppDelegate+Rectangle.swift
@@ -115,13 +115,20 @@ extension AppDelegate {
 
     // MARK: - URLs
 
-    /// Ask macOS to send `rectangle://` here too, or hand it back.
-    func setRectangleURLs(_ on: Bool) {
-        store.update { $0.handleRectangleURLs = on }
-        // Asking who holds a scheme is a round trip to lsd, and this runs from
-        // a SwiftUI setter. The answer comes back on the main queue.
+    /// Make what macOS does about `rectangle://` match `config.handleRectangleURLs`.
+    ///
+    /// Asked when the setting moves and once at launch, not on every write:
+    /// asking costs a round trip to `lsd`, and nothing on the launch path may
+    /// wait on another process, so it goes off the main queue and the answer
+    /// comes back on it. Launch matters because it can drift either way while
+    /// the app is not running: LaunchServices hands the scheme over on install
+    /// without being asked, and hands it back when Rectangle is reinstalled or
+    /// the database is rebuilt. Neither is something the app is told about.
+    func applyRectangleURLs(_ config: Config, previous: Config?) {
+        let wanted = config.handleRectangleURLs
+        guard previous?.handleRectangleURLs != wanted else { return }
         DispatchQueue.global(qos: .userInitiated).async {
-            RectangleURLs.setHandled(on) { [weak self] holding in
+            RectangleURLs.setHandled(wanted) { [weak self] holding in
                 self?.model.holdsRectangleURLs = holding
             }
         }

--- a/App/Sources/plonk/AppDelegate+Screens.swift
+++ b/App/Sources/plonk/AppDelegate+Screens.swift
@@ -7,7 +7,7 @@ extension AppDelegate {
     @objc func screensChanged() {
         dragSnap.screensChanged()
         model.previewedZoneSet = nil
-        refreshZoneModel()
+        refreshScreenModel()
 
         // This notification also fires for a resolution change, a display
         // waking, and the Dock being resized or auto-hidden. Only a display

--- a/App/Sources/plonk/AppDelegate+Server.swift
+++ b/App/Sources/plonk/AppDelegate+Server.swift
@@ -12,18 +12,8 @@ extension AppDelegate {
             self?.eventBroadcaster.attach(conn, rev: rev)
         }
         // Every source of change funnels into the bus at its own choke point,
-        // so no caller has to remember to announce itself.
-        //
-        // Config is the widest of them: a settings row, an agent over the API
-        // and an imported Rectangle setup all end at ConfigStore.update, so
-        // applying a change is hung there rather than at each of the three.
-        // Set here, once the managers applyConfig reaches all exist — writes
-        // before this point are startup reading its own defaults back.
-        store.didMutate = { [weak self] in
-            guard let self else { return }
-            applyConfig()
-            router.changes.bump("config")
-        }
+        // so no caller has to remember to announce itself. Config, the widest
+        // of them, is wired in AppDelegate.watchConfig.
         windows.onDidPlace = { [weak self] in
             self?.router.changes.bump("windows")
             self?.markGettingStarted { $0.sawFirstSnap = true }

--- a/App/Sources/plonk/AppDelegate+Shortcuts.swift
+++ b/App/Sources/plonk/AppDelegate+Shortcuts.swift
@@ -9,15 +9,14 @@ extension AppDelegate {
             guard action == .voice else { return }
             self?.voice.finishCapture()
         }
-        hotkeys.bindings = store.config.resolvedHotkeys
-        if store.config.hotkeysEnabled { hotkeys.setEnabled(true) }
-        refreshHotkeyModel()
-        reconcileRectangleURLs()
+        hotkeys.apply(store.config)
         noticeRectangle()
     }
 
+    /// How the bindings read on the shortcuts pages, off what the manager
+    /// holds: the resolved set, so nothing is parsed a second time.
     func refreshHotkeyModel() {
-        let bindings = store.config.resolvedHotkeys
+        let bindings = hotkeys.bindings
         model.hotkeyDisplays = HotkeyAction.allCases.reduce(into: [:]) { result, action in
             result[action.rawValue] = bindings[action]?.display
                 ?? String(localized: .shortcutUnbound)
@@ -26,26 +25,6 @@ extension AppDelegate {
             result[action.rawValue] = bindings[action]?.parts ?? []
         }
         model.unavailableHotkeys = hotkeys.unavailable.map(\.rawValue)
-    }
-
-    /// Make what macOS does about `rectangle://` match what the setting says,
-    /// once, at launch.
-    ///
-    /// It can drift either way while the app is not running: LaunchServices
-    /// hands the scheme over on install without being asked, and hands it back
-    /// when Rectangle is reinstalled or the database is rebuilt. Neither is
-    /// something the app is told about, so the only reliable moment to check is
-    /// the next start.
-    ///
-    /// Off the main queue because asking costs a round trip to `lsd`, and
-    /// nothing on the launch path may wait on another process.
-    private func reconcileRectangleURLs() {
-        let wanted = store.config.handleRectangleURLs
-        DispatchQueue.global(qos: .utility).async {
-            RectangleURLs.setHandled(wanted) { [weak self] holding in
-                self?.model.holdsRectangleURLs = holding
-            }
-        }
     }
 
     func perform(_ action: HotkeyAction) {

--- a/App/Sources/plonk/AppDelegate+StatusMenu.swift
+++ b/App/Sources/plonk/AppDelegate+StatusMenu.swift
@@ -1,8 +1,8 @@
 import AppKit
 
 // Wiring for the menu bar item: what its dropdown asks the app for, and what
-// each entry in it does. Split out of AppDelegate, which is over the line
-// limit and may only shrink.
+// each entry in it does. One module, one file beside AppDelegate; see
+// AGENTS.md.
 
 extension AppDelegate {
     func setupStatusMenu() {

--- a/App/Sources/plonk/AppDelegate+Update.swift
+++ b/App/Sources/plonk/AppDelegate+Update.swift
@@ -16,7 +16,7 @@ extension AppDelegate {
         updates.onProgress = { [weak self] in
             self?.model.updateProgress = self?.updates.progress ?? 0
         }
-        updates.automatic = store.config.updateCheckAutomatically
+        updates.apply(store.config)
         statusMenu.updateVersion = { [weak self] in self?.updates.available?.version.text }
         statusMenu.onOpenUpdate = { [weak self] in self?.openPage("update") }
 

--- a/App/Sources/plonk/AppDelegate+Zones.swift
+++ b/App/Sources/plonk/AppDelegate+Zones.swift
@@ -1,8 +1,8 @@
 import AppKit
 
 // Everything the app does to a zone set: which screen wears it, what is in it,
-// and the two windows that edit it. Split out of AppDelegate, which is over
-// the line limit and may only shrink.
+// and the two windows that edit it. One module, one file beside AppDelegate;
+// see AGENTS.md.
 
 extension AppDelegate {
     /// "2 displays · Priority" — what the menu bar says it is running, above

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -37,6 +37,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Display UUIDs seen at the last screen-parameter change, so a Dock
     /// resize can be told apart from a monitor being plugged in.
     var knownDisplays: Set<String> = []
+    /// What applyConfig last handed out, so the few settings whose apply
+    /// costs a round trip to macOS run only when they moved.
+    var appliedConfig: Config?
+    var applyingConfig = false
+    var configApplyPending = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Before anything is on screen: a second copy would add its own menu bar
@@ -65,10 +70,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupRuler()
         setupServer()
         setupUpdates()
+        watchConfig()
         refreshModel()
-
-        applyLaunchAtLogin(store.config.launchAtLogin)
-        model.loginItemRegistered = isLaunchAtLoginEnabled
 
         knownDisplays = Self.attachedDisplays()
         watchForAccessibility()

--- a/App/Sources/plonk/AppModel.swift
+++ b/App/Sources/plonk/AppModel.swift
@@ -5,8 +5,7 @@ import SwiftUI
 //
 // A plain setting needs nothing here. `update` writes any field of `Config`
 // and every manager re-reads, so the list below is only the things that are
-// not a stored value: commands, and the few settings whose write also has to
-// tell macOS something.
+// not a stored value: commands.
 protocol AppActions: AnyObject {
     /// Write one setting. The single path a value takes from the UI to disk:
     /// `ConfigStore` clamps it, saves it, and every manager re-reads. Adding a
@@ -31,12 +30,6 @@ protocol AppActions: AnyObject {
     func importFromRectangle()
     /// Turn down the offer on Home, for good. See RectangleOffer.
     func dismissRectangleOffer()
-    /// Ask macOS to send rectangle:// URLs here too, or hand them back to an
-    /// installed Rectangle. Registers a scheme, so it is not a plain write.
-    func setRectangleURLs(_ on: Bool)
-    /// Asks macOS to register the login item, and reports what it settled on.
-    func setLaunchAtLogin(_ on: Bool)
-
     /// Hands the user the ruler: hover to size what is under the pointer, drag
     /// for a distance.
     func startRuler()
@@ -111,15 +104,9 @@ final class AppModel: ObservableObject {
     @Published var rectangleFound = false
 
     @Published var supportedTextLanguages: [String] = []
-    @Published var workspaceNames: [String] = []
     /// Non-empty only while a workspace is coming up.
     @Published var launchingWorkspace: String?
     @Published var launchStatuses: [LaunchStatus] = []
-    @Published var zoneSetNames: [String] = []
-    /// Every set that can be drawn, the built-in templates included, which is
-    /// more than `config.zoneSets` holds: that is only the ones the user made.
-    @Published var zoneSets: [String: [ZoneRect]] = [:]
-    @Published var customZoneSetNames: [String] = []
     @Published var previewedZoneSet: String?
     @Published var screenAssignments: [Int: String] = [:]
     @Published var screenCount = 1
@@ -135,9 +122,8 @@ final class AppModel: ObservableObject {
     @Published var shotStatus = ""
     // What macOS settled on, rather than what config asked for: a scheme is one
     // per machine and a login item can be refused, so the toggle shows what is
-    // actually true. Named apart from the config fields they answer for, so
-    // that `binding(\.launchAtLogin)` cannot quietly mean the wrong one: the
-    // Config overload writes the setting and never tells macOS.
+    // actually true. The write goes to config like any setting; applyConfig
+    // tells macOS and reads back what it did.
     @Published var loginItemRegistered = true
     @Published var holdsRectangleURLs = false
     @Published var connectedAgents: [String] = []
@@ -174,6 +160,24 @@ extension AppModel {
     /// The colour the app draws itself with, ready to hand to SwiftUI.
     var accent: Color { Color(nsColor: config.appearance.accent) }
 
+    // The lists, worked out from `config` when read rather than kept in step
+    // with it: a copy would need refreshing after every write, and one write
+    // path forgetting is a list that shows yesterday's names.
+    var workspaceNames: [String] { config.workspaces.keys.sorted() }
+    /// The sets the user made, by name.
+    var customZoneSetNames: [String] { config.zoneSets.keys.sorted() }
+    /// Every set that can be drawn: the user's first, then the built-in
+    /// templates they have not shadowed.
+    var zoneSetNames: [String] {
+        let custom = customZoneSetNames
+        return custom + BuiltinZoneSets.all.keys.sorted().filter { !custom.contains($0) }
+    }
+    /// Every set that can be drawn, the built-in templates included, which is
+    /// more than `config.zoneSets` holds: that is only the ones the user made.
+    var zoneSets: [String: [ZoneRect]] {
+        BuiltinZoneSets.all.merging(config.zoneSets) { _, user in user }
+    }
+
     /// A zone set name nobody has taken, which is `base` itself when it is free.
     func freeZoneSetName(base: String) -> String {
         if zoneSets[base] == nil { return base }
@@ -203,8 +207,8 @@ extension AppModel {
         )
     }
 
-    /// State a manager owns rather than the config, written through the command
-    /// that owns it: keep-awake, stay-active, the login item.
+    /// State a manager or macOS owns rather than the config, written through
+    /// the command that owns it: keep-awake, stay-active, the login item.
     func binding<Value>(_ keyPath: KeyPath<AppModel, Value>,
                         set: @escaping (AppActions, Value) -> Void) -> Binding<Value> {
         Binding(

--- a/App/Sources/plonk/DragSnapManager.swift
+++ b/App/Sources/plonk/DragSnapManager.swift
@@ -40,9 +40,8 @@ final class DragSnapManager {
     var requireModifier = true
     var modifierFlag: NSEvent.ModifierFlags = .shift
     var zonesForScreen: ((Int) -> [ZoneRect])?
-    /// Looks and spacing, read fresh on every drag so a settings change shows
-    /// up without restarting anything.
-    var appearance: (() -> ZoneAppearance)?
+    /// Looks and spacing, taken from config in `apply`.
+    var look = ZoneAppearance()
     /// Draw every screen's zones during a drag, not just the one under the
     /// cursor. Costs an overlay per display.
     var showOnAllMonitors = false
@@ -66,6 +65,7 @@ final class DragSnapManager {
         modifierFlag = config.zonesModifierFlag
         showOnAllMonitors = config.zonesOnAllMonitors
         edgeSpanPoints = config.zoneEdgeSpanPoints
+        look = ZoneAppearance(config)
     }
 
     func start() {
@@ -163,8 +163,6 @@ final class DragSnapManager {
         windows.apply(frac: zone.frac, toWindow: win, screenIndex: zone.screenIndex, gap: look.gap)
         onSnap?(win, startFrame, zone.frac, zone.screenIndex)
     }
-
-    var look: ZoneAppearance { appearance?() ?? ZoneAppearance() }
 
     // MARK: - Drags Plonk is driving itself
 

--- a/App/Sources/plonk/HomePage.swift
+++ b/App/Sources/plonk/HomePage.swift
@@ -215,7 +215,8 @@ struct HomePage: View {
             Divider()
             switchRow(.homeLaunchAtLogin, "power",
                       detail: .homeLaunchAtLoginDetail,
-                      toggle: model.binding(\.loginItemRegistered, set: { $0.setLaunchAtLogin($1) }))
+                      toggle: model.binding(\.loginItemRegistered,
+                                            set: { $0.update(\.launchAtLogin, to: $1) }))
         }
         .card()
     }

--- a/App/Sources/plonk/HotkeyManager.swift
+++ b/App/Sources/plonk/HotkeyManager.swift
@@ -28,10 +28,12 @@ final class HotkeyManager {
     var onActionUp: ((HotkeyAction) -> Void)?
 
     /// Take the settings as they now stand. Both halves guard on the value
-    /// changing, so this is safe after every config write.
+    /// changing, so this is safe after every config write. Bindings first:
+    /// enabling registers whatever is bound, and it should be the new set, not
+    /// the old one for a moment.
     func apply(_ config: Config) {
-        setEnabled(config.hotkeysEnabled)
         bindings = config.resolvedHotkeys
+        setEnabled(config.hotkeysEnabled)
     }
 
     func setEnabled(_ on: Bool) {

--- a/App/Sources/plonk/MouseTools.swift
+++ b/App/Sources/plonk/MouseTools.swift
@@ -38,18 +38,25 @@ final class MouseTools {
     /// behind it. Tearing that down because some other page's setting moved is
     /// a spotlight that blinks out under the user's hand.
     func apply(_ config: Config) {
+        let wasTint = tint
         tint = ZoneAppearance(config).tint
         highlightEnabled = config.highlightClicksEnabled
         crosshairsEnabled = config.crosshairsEnabled
         if config.highlightClicksEnabled || config.crosshairsEnabled {
             start()
+            // A crosshair already on screen is repainted in the new colour
+            // now rather than on the next mouse move.
+            if tint != wasTint { refreshPersistent() }
         } else if tap != nil {
             stop()
         }
     }
 
+    /// Nothing without Accessibility: the tap would fail to create, and this
+    /// runs after every config write, so it would fail and log on each. The
+    /// grant watcher applies the config again once it lands.
     func start() {
-        guard tap == nil else { return }
+        guard tap == nil, WindowAccess.isTrusted else { return }
         let mask: CGEventMask =
             (1 << CGEventType.leftMouseDown.rawValue) |
             (1 << CGEventType.rightMouseDown.rawValue) |

--- a/App/Sources/plonk/Resources/en.lproj/Localizable.strings
+++ b/App/Sources/plonk/Resources/en.lproj/Localizable.strings
@@ -30,9 +30,9 @@
 "awake.after2Hours" = "2 hours";
 "awake.power" = "Power";
 "awake.keepDisplayOn" = "Keep the display on";
-"awake.keepDisplayOnHelp" = "Off: only the system stays awake, the screen may still sleep";
+"awake.keepDisplayOnHelp" = "When off, only the system stays awake and the screen may still sleep";
 "awake.allowOnBattery" = "Allow on battery";
-"awake.allowOnBatteryHelp" = "Off: keep-awake pauses when unplugged and resumes on power";
+"awake.allowOnBatteryHelp" = "When off, keep-awake pauses while unplugged and resumes when you plug in";
 "awake.autoWhileCharging" = "Automatically while charging";
 "awake.autoWhileChargingHelp" = "Keeps the Mac awake whenever it is plugged in";
 
@@ -58,7 +58,7 @@
 "active.noApps" = "No apps yet";
 "active.power" = "Power";
 "active.allowOnBattery" = "Allow on battery";
-"active.allowOnBatteryHelp" = "Off: stay active pauses when unplugged and resumes on power";
+"active.allowOnBatteryHelp" = "When off, stay active pauses while unplugged and resumes when you plug in";
 "active.needsAccessibility" = "Plonk needs Accessibility to post the keypress. Without it nothing is sent.";
 "active.openSettings" = "Open Settings";
 "active.chooseApp" = "Choose app";

--- a/App/Sources/plonk/ShortcutsPage.swift
+++ b/App/Sources/plonk/ShortcutsPage.swift
@@ -80,7 +80,7 @@ struct ShortcutsPage: View {
             ToggleRow(title: .keysRectangleURLs,
                       detail: .keysRectangleURLsHelp,
                       isOn: model.binding(\.holdsRectangleURLs,
-                                          set: { $0.setRectangleURLs($1) }))
+                                          set: { $0.update(\.handleRectangleURLs, to: $1) }))
         }
     }
 

--- a/App/Sources/plonk/UpdateManager.swift
+++ b/App/Sources/plonk/UpdateManager.swift
@@ -33,8 +33,10 @@ final class UpdateManager {
     /// one update would bury every listener on /events under its own progress.
     var onProgress: (() -> Void)?
     /// Whether launch and the schedule check on their own. The user's
-    /// setting; a check they ask for explicitly always runs.
-    var automatic = true {
+    /// setting; a check they ask for explicitly always runs. Off until
+    /// applied, the same as the schedule behind it, so the first apply of an
+    /// "on" reaches it.
+    var automatic = false {
         didSet { if automatic != oldValue { schedule.automatic = automatic } }
     }
 
@@ -83,7 +85,6 @@ final class UpdateManager {
     // MARK: - Checking
 
     func start() {
-        schedule.automatic = automatic
         guard automatic else { return }
         check()
     }

--- a/App/Tests/plonkTests/AppModelListsTests.swift
+++ b/App/Tests/plonkTests/AppModelListsTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+@testable import plonk
+
+// The names the pickers and palettes list are worked out from the config the
+// model holds, so a write is enough to move them; nothing refreshes a copy.
+struct AppModelListsTests {
+
+    @Test func theListsFollowTheConfig() {
+        let model = AppModel()
+        #expect(model.workspaceNames.isEmpty)
+        #expect(model.customZoneSetNames.isEmpty)
+        #expect(model.zoneSetNames == BuiltinZoneSets.all.keys.sorted())
+
+        model.config.workspaces["work"] = Workspace(items: [])
+        model.config.workspaces["home"] = Workspace(items: [])
+        model.config.zoneSets["Mine"] = [ZoneRect(0, 0, 1, 1)]
+
+        #expect(model.workspaceNames == ["home", "work"])
+        #expect(model.customZoneSetNames == ["Mine"])
+        #expect(model.zoneSetNames.first == "Mine")
+        #expect(model.zoneSets["Mine"]?.count == 1)
+    }
+
+    /// A user's set named like a built-in template replaces it in the list
+    /// and in what is drawn, rather than appearing twice.
+    @Test func aUserSetShadowsTheBuiltInOfTheSameName() {
+        let model = AppModel()
+        let name = BuiltinZoneSets.defaultName
+        let mine = [ZoneRect(0, 0, 0.5, 1), ZoneRect(0.5, 0, 0.5, 1)]
+        model.config.zoneSets[name] = mine
+
+        #expect(model.zoneSetNames.filter { $0 == name }.count == 1)
+        #expect(model.zoneSets[name]?.map(\.w) == mine.map(\.w))
+        #expect(model.zoneSets.count == BuiltinZoneSets.all.count)
+    }
+
+    /// The name offered for a copy is one nobody has, built-ins included.
+    @Test func aFreeNameSkipsBuiltInsToo() {
+        let model = AppModel()
+        let name = BuiltinZoneSets.defaultName
+        #expect(model.freeZoneSetName(base: name) == "\(name) 2")
+        #expect(model.freeZoneSetName(base: "Fresh") == "Fresh")
+    }
+}

--- a/App/Tests/plonkTests/ConfigStoreTests.swift
+++ b/App/Tests/plonkTests/ConfigStoreTests.swift
@@ -1,0 +1,95 @@
+import Testing
+import Foundation
+@testable import plonk
+
+// The store: the one way a setting is written, and what it promises whoever
+// listens: clamped, saved, then told.
+struct ConfigStoreTests {
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plonk-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test func savesAndReloads() {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let store = ConfigStore(directory: dir)
+        store.update {
+            $0.workspaces["work"] = Workspace(items: [
+                WorkspaceItem(app: "Safari", x: 0, y: 0, w: 0.5, h: 1),
+            ])
+        }
+
+        let reopened = ConfigStore(directory: dir)
+        reopened.load()
+        #expect(reopened.config.workspaces["work"]?.items.count == 1)
+    }
+
+    @Test func corruptFileIsSetAsideInsteadOfSilentlyOverwritten() throws {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("config.json")
+        try Data("{ not json".utf8).write(to: file)
+
+        let store = ConfigStore(directory: dir)
+        store.load()
+
+        #expect(store.config.workspaces.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.json.bad").path))
+        // Losing every saved workspace has to reach the user, not just the log.
+        #expect(store.loadFailure?.contains("config.json.bad") == true)
+    }
+
+    /// The bounds live in Config.clamp and the store is what runs it, so a
+    /// caller that writes a raw number (a Rectangle import, a route) never
+    /// gets it saved as written.
+    @Test func updateClampsBeforeSavingAndTelling() {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ConfigStore(directory: dir)
+        var seen: Double?
+        store.didMutate = { seen = store.config.zoneGap }
+
+        store.update { $0.zoneGap = 4000 }
+        #expect(store.config.zoneGap == Config.gapLimit)
+        // Whoever listens sees the clamped, saved value, not the raw write.
+        #expect(seen == Config.gapLimit)
+
+        let reopened = ConfigStore(directory: dir)
+        reopened.load()
+        #expect(reopened.config.zoneGap == Config.gapLimit)
+    }
+
+    /// A listener that writes back (keep-awake persisting a session) does so
+    /// against the store's newest state, and each write is announced once.
+    @Test func aWriteMadeFromDidMutateSeesTheFirstWrite() {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ConfigStore(directory: dir)
+        var announced = 0
+        store.didMutate = {
+            announced += 1
+            guard store.config.zoneGap == 12, !store.config.sawFirstSnap else { return }
+            store.update { $0.sawFirstSnap = true }
+        }
+        store.update { $0.zoneGap = 12 }
+        #expect(store.config.zoneGap == 12)
+        #expect(store.config.sawFirstSnap)
+        #expect(announced == 2)
+    }
+
+    @Test func aReadableConfigReportsNoFailure() {
+        let dir = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = ConfigStore(directory: dir)
+        store.update { $0.shotFolder = "~/Pictures" }
+
+        let reopened = ConfigStore(directory: dir)
+        reopened.load()
+        #expect(reopened.loadFailure == nil)
+    }
+}

--- a/App/Tests/plonkTests/ConfigTests.swift
+++ b/App/Tests/plonkTests/ConfigTests.swift
@@ -212,58 +212,6 @@ struct ConfigTests {
     }
 }
 
-struct ConfigStoreTests {
-
-    private func temporaryDirectory() -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("plonk-tests-\(UUID().uuidString)", isDirectory: true)
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
-    @Test func savesAndReloads() {
-        let dir = temporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-
-        let store = ConfigStore(directory: dir)
-        store.update {
-            $0.workspaces["work"] = Workspace(items: [
-                WorkspaceItem(app: "Safari", x: 0, y: 0, w: 0.5, h: 1),
-            ])
-        }
-
-        let reopened = ConfigStore(directory: dir)
-        reopened.load()
-        #expect(reopened.config.workspaces["work"]?.items.count == 1)
-    }
-
-    @Test func corruptFileIsSetAsideInsteadOfSilentlyOverwritten() throws {
-        let dir = temporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let file = dir.appendingPathComponent("config.json")
-        try Data("{ not json".utf8).write(to: file)
-
-        let store = ConfigStore(directory: dir)
-        store.load()
-
-        #expect(store.config.workspaces.isEmpty)
-        #expect(FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.json.bad").path))
-        // Losing every saved workspace has to reach the user, not just the log.
-        #expect(store.loadFailure?.contains("config.json.bad") == true)
-    }
-
-    @Test func aReadableConfigReportsNoFailure() {
-        let dir = temporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let store = ConfigStore(directory: dir)
-        store.update { $0.shotFolder = "~/Pictures" }
-
-        let reopened = ConfigStore(directory: dir)
-        reopened.load()
-        #expect(reopened.loadFailure == nil)
-    }
-}
-
 struct FracRectParsingTests {
 
     @Test func parsesAFrameInRange() throws {

--- a/App/Tests/plonkTests/RouterTests.swift
+++ b/App/Tests/plonkTests/RouterTests.swift
@@ -166,11 +166,11 @@ struct RouterTests {
 
     @Test func workspaceChangesNotifyTheUI() {
         let h = Harness()
-        var notifications = 0
-        h.store.didMutate = { notifications += 1 }
+        var events: [String] = []
+        h.router.changes.onEvent = { _, what in events.append(what) }
         _ = h.post("/workspaces/save", ["name": "work", "items": [sampleItem]])
         _ = h.post("/workspaces/delete", ["name": "work"])
-        #expect(notifications == 2)
+        #expect(events.filter { $0 == "config" }.count == 2)
     }
 
     @Test func zoneSetsAreValidatedAgainstScreenBounds() {
@@ -435,10 +435,10 @@ struct RouterTests {
 
     @Test func agentChangesNotifyTheUI() {
         let h = Harness()
-        var notifications = 0
-        h.store.didMutate = { notifications += 1 }
+        var events: [String] = []
+        h.router.changes.onEvent = { _, what in events.append(what) }
         _ = h.post("/agents/select", ["name": "claude-code"])
         _ = h.post("/agents/exclusive", ["on": true])
-        #expect(notifications == 2)
+        #expect(events.filter { $0 == "config" }.count == 2)
     }
 }

--- a/scripts/line-limit-baseline
+++ b/scripts/line-limit-baseline
@@ -8,7 +8,7 @@
 # delete the line once it is under the limit.
 #
 # lines  path
-489   App/Tests/plonkTests/ConfigTests.swift
+437   App/Tests/plonkTests/ConfigTests.swift
 444   App/Tests/plonkTests/RouterTests.swift
 312   App/Sources/plonk/GrabMove.swift
 308   App/Sources/plonk/WorkspaceLauncher.swift


### PR DESCRIPTION
Follow-up to #68, from a review pass over the config fan-out.

- applyConfig no longer re-enters itself; a nested write (keep-awake persisting a session) is applied once after the outer run, so every manager sees the newest config in order.
- The fan-out is its own launch step (watchConfig) rather than a side effect of setupServer.
- Login item and rectangle:// handling are applied from applyConfig like every other setting; their two commands are gone.
- Less work per write: computed lists off model.config, screen assignments only when they moved, one hotkey parse, cheaper Getting Started check.
- HotkeyManager binds before enabling; UpdateManager.automatic starts off so the first apply reaches the schedule; MouseTools.start needs Accessibility and repaints crosshairs on a tint change; DragSnapManager keeps its look from apply.
- Setup functions call apply(store.config) instead of pushing fields.
- Tests: ConfigStore in its own file with clamp-on-update and write-from-listener coverage; Router notify tests watch the change bus; AppModel list tests.

swift build, scripts/test.sh (471 tests), scripts/lint.sh, check-strings all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)