### PR TITLE
ci: CodeQL, Scorecard, Dependabot, and a checksum beside the zip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+# Weekly rather than daily. Nothing here has enough dependencies to make a
+# daily pull request anything but noise, and a week is well inside the window
+# that matters for a menu bar app with no server behind it.
+updates:
+  # The actions in .github/workflows/. This is the one that earns its keep: an
+  # action is third-party code running with write access to the repository and
+  # the release, and it is the only place in this project where that is true.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+
+  # mcp/package.json, two dependencies: the official MCP SDK and zod.
+  - package-ecosystem: npm
+    directory: /mcp
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: mcp
+
+  # App/Package.swift declares no third-party dependencies at all, so this
+  # opens nothing today. It is here so that the day one is added, it is watched
+  # from the commit that adds it rather than from whenever someone remembers.
+  - package-ecosystem: swift
+    directory: /App
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: app

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: CodeQL
+
+# Static analysis of the Swift app, on GitHub's free tier for public
+# repositories. It reads the code the way an attacker would rather than the way
+# a compiler does, so what it catches is the class of thing tests do not: a
+# value that reaches a shell, a path built from something a caller controls.
+#
+# Findings land in the Security tab. `security-and-quality` is the wider of the
+# two query suites, so some of what it reports is a correctness smell rather
+# than a vulnerability; both are worth a look on a codebase this size.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, because a query suite that ships a new rule should find last
+    # week's code with it, not wait for the next commit to that file.
+    - cron: "27 5 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze Swift
+    # Swift analysis only runs on macOS, and macos-14 still ships Swift 5.10
+    # while Package.swift asks for tools version 6.0 — the same reason
+    # ci.yml pins its Swift jobs above it.
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      security-events: write # write the findings to the Security tab
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+          queries: security-and-quality
+          # Manual rather than autobuild. Autobuild exists to guess at an
+          # Xcode project and a scheme, and there is no .xcodeproj or
+          # .xcworkspace in this repository to guess at: the app is a Swift
+          # package under App/, built by the one command below. Naming it is
+          # both shorter than the guess and the same command scripts/build.sh
+          # runs, so the tree CodeQL reads is the tree that ships.
+          build-mode: manual
+
+      # Debug rather than `-c release` as in scripts/build.sh: CodeQL reads the
+      # source through the compiler as it runs, and the optimiser makes no
+      # difference to what it sees. This is the line ci.yml already builds with.
+      - name: Build
+        run: swift build
+        working-directory: App
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@v4
         with:
           languages: swift
           queries: security-and-quality
@@ -52,6 +52,6 @@ jobs:
         run: swift build
         working-directory: App
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@v4
         with:
           category: "/language:swift"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,12 +114,24 @@ jobs:
           PLONK_SIGN_IDENTITY: Plonk Signing
         run: ./scripts/release.sh
 
+      # A plain checksum file next to the archive, for anyone who has shasum
+      # but not gh: `shasum -a 256 -c Plonk-<version>.zip.sha256`. On its own
+      # that only proves the download finished, since a tampered zip would
+      # arrive with a tampered checksum beside it — so it is attested below
+      # along with the zip, and the pair can be checked the same way.
+      - name: Write the checksum
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: shasum -a 256 "Plonk-$VERSION.zip" > "Plonk-$VERSION.zip.sha256"
+
       # What ties Plonk-<version>.zip to this repository, this commit and this
       # workflow run. Without it the app's own promises are only checkable at
       # runtime, on a binary nobody can trace back to the source.
       - uses: actions/attest-build-provenance@v4
         with:
-          subject-path: Plonk-${{ steps.version.outputs.version }}.zip
+          subject-path: |
+            Plonk-${{ steps.version.outputs.version }}.zip
+            Plonk-${{ steps.version.outputs.version }}.zip.sha256
 
       - name: Publish the archive
         env:
@@ -128,7 +140,7 @@ jobs:
         run: |
           set -eu
           ZIP="Plonk-$VERSION.zip"
-          SHA=$(shasum -a 256 "$ZIP" | cut -d' ' -f1)
+          SHA=$(cut -d' ' -f1 < "$ZIP.sha256")
 
           STATE=$(gh release view "v$VERSION" --json isDraft \
             --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo missing)
@@ -160,7 +172,7 @@ jobs:
                 "sha256: \`$SHA\`"
             )"
           fi
-          gh release upload "v$VERSION" "$ZIP" --clobber
+          gh release upload "v$VERSION" "$ZIP" "$ZIP.sha256" --clobber
 
           {
             echo "### Plonk $VERSION"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+name: Scorecard
+
+# OpenSSF Scorecard grades this repository's supply chain against a fixed list
+# of checks: are actions pinned, is the release signed, is there a security
+# policy, does a dependency update ever land. It reads only what is already
+# public — no account, no agent, nothing sent from a user's machine.
+#
+# publish_results is what puts the score on the public OpenSSF API, which is
+# what the badge in README.md reads. It publishes the grade and the repository
+# name, nothing about anyone who runs Plonk.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "41 5 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # write the findings to the Security tab
+      id-token: write # sign the published result
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Scorecard reads the checkout; it has no use for a token sitting in
+          # .git/config while it does.
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Kept for the run itself: if the upload below is rejected, the findings
+      # are still downloadable from the run rather than lost.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ out loud.</strong><br>
   <img alt="No dependencies" src="https://img.shields.io/badge/dependencies-0-12d3a4?style=flat-square">
   <img alt="MIT" src="https://img.shields.io/badge/license-MIT-ffc531?style=flat-square">
   <img alt="MCP" src="https://img.shields.io/badge/MCP-20_tools-8b5cf6?style=flat-square">
+  <img alt="CodeQL" src="https://img.shields.io/github/actions/workflow/status/ostapondo/Plonk/codeql.yml?style=flat-square&label=CodeQL">
+  <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/ostapondo/Plonk?style=flat-square&label=OpenSSF%20Scorecard">
 </p>
 
 <p align="center">
@@ -103,6 +105,28 @@ The cask takes care of that for you.
 
 Running it alongside Rectangle or Magnet is fine, as long as their shortcuts do
 not collide.
+
+**Checking what you downloaded.** Notarizing an app means paying Apple for a
+developer account, and this project does not have one, so Plonk is signed with
+a certificate it made itself. That means macOS cannot tell you who built the
+app. There is a check that answers a more useful question, and you can run it
+yourself: was this exact file built by GitHub from the source in this
+repository?
+
+```sh
+gh attestation verify Plonk-<version>.zip --repo ostapondo/Plonk
+```
+
+Put the number from the file name in place of `<version>`. The command comes
+with the [GitHub CLI](https://cli.github.com), which is `brew install gh`. It
+prints the commit and the workflow run that built the archive. If the file was
+altered after it was built, or was not built from this repository at all, the
+command fails and tells you so.
+
+Every release also carries a small `Plonk-<version>.zip.sha256` file. Put it
+beside the zip and run `shasum -a 256 -c Plonk-<version>.zip.sha256` to confirm
+the download arrived complete and unchanged. That file is signed the same way
+as the zip, so `gh attestation verify` works on it too.
 
 <details>
 <summary>Installing by hand, Intel Macs, tiling managers, and removing it</summary>


### PR DESCRIPTION
## What changed, and why

The release already left with a provenance attestation GitHub signs, so the zip could be tied back to a commit. What was missing was everything around it: nothing read the Swift for the class of bug the unit suite cannot reach, nothing watched the third-party actions that run with write access to the release, and the sha256 existed only as text in the release notes, where it cannot be piped into `shasum -c`. This adds those three, and lifts the verification instructions out of the collapsed block in `README.md` to where someone installing will actually meet them.

Three new files, plus two hunks in the existing release workflow.

**CodeQL** (`.github/workflows/codeql.yml`) uses `build-mode: manual` rather than `autobuild`. Autobuild exists to guess at an Xcode project and a scheme, and there is no `.xcodeproj` or `.xcworkspace` in this repository to guess at: the app is a Swift package under `App/`. Naming `swift build` is shorter than the guess and is the same command `scripts/build.sh` runs, so the tree CodeQL reads is the tree that ships. Debug rather than `-c release`, since the optimiser makes no difference to what the extractor sees, and that is the line `ci.yml` already builds with.

**Scorecard** (`.github/workflows/scorecard.yml`) grades the supply chain against a fixed public list and publishes the result, which is what the new badge reads. It publishes the grade and the repository name and nothing else; no account, and nothing from a user's machine.

**Dependabot** (`.github/dependabot.yml`) covers `github-actions` at `/` and `npm` at `/mcp`. It also lists `swift` at `/App`, which opens nothing today because `App/Package.swift` declares no third-party dependencies at all. It is there so that the day one is added, it is watched from the commit that adds it rather than from whenever someone remembers.

**The checksum** is the change to `release.yml`. It now writes `Plonk-<version>.zip.sha256` beside the archive and attests both files. On its own a checksum sitting next to the file it describes proves only that the download finished, since anyone who could tamper with the zip could tamper with the checksum too. Attested, the pair can be checked the same way the zip is, and someone with `shasum` but not `gh` still gets the weaker check for free.

Deliberately not a second release workflow. `release.yml` already triggers on `v*`, builds through `scripts/release.sh`, and uploads `Plonk-<version>.zip`; a second workflow on the same tag would race it for the same asset name, and `release.yml` hard-fails on an already-published release by design.

## What you ran

```
./scripts/lint.sh                # clean
./scripts/check-security-claims.sh   # security claims hold
```

`actionlint` is not reachable from the environment this was written in, so the YAML was checked another way: every file under `.github/workflows/` plus `.github/dependabot.yml` parsed, then walked for unknown top-level, job and step keys, a `runs-on` on every job, permission values restricted to `read`/`write`/`none`, exactly one of `uses`/`run` per step, and a version on every `uses`. All four pass. Worth running `actionlint` on the branch if you have it.

Not run: `swift build`, `./scripts/test.sh` and the `mcp` suite, since no Swift toolchain or macOS runner was available here. No app source, no test, and no shell script changed, so CI on this PR is the first real exercise of them.

## Checks

- [x] `swift build` passes on every commit in the branch, not just the last one — one commit, and it touches no Swift
- [x] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be — workflow definitions, which only CI itself can exercise
- [x] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [x] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — fixed in this PR if not
- [ ] Screenshots below for anything visual — nothing visual beyond two README badges

On the fourth: this touches the release path, so `README.md` gained the new `.sha256` file and the two badges. `SECURITY.md` needed no change; what it says about attestation is still exactly true, and `./scripts/check-security-claims.sh` passes.

## Notes for review

Two judgement calls worth a second opinion:

- The `swift` Dependabot ecosystem is a no-op until a dependency exists. Drop it if a stanza that does nothing reads worse than one added later.
- The two new workflows are on `macos-latest` and `ubuntu-latest` rather than the pinned `macos-15` the rest of the repo uses. `ci.yml` pins because `macos-14` shipped Swift 5.10 and `Package.swift` asks for tools version 6.0; `macos-latest` is past that now, but pinning to `macos-15` for consistency is a one-word change if you would rather.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcrjVns8WTBv1Y9GJU6VSv)_