### PR TITLE
fix: name the node types the server has always relied on

### DIFF
--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
+    "types": ["node"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## What changed, and why

One line in `mcp/tsconfig.json`: `"types": ["node"]`.

TypeScript 5 pulls in every `@types` package it finds under `node_modules` whether or not anything asked for it, so this project compiled for its whole life without ever saying it needs `@types/node`. TypeScript 7 stopped doing that, and the omission surfaces as 27 errors that read like the types are missing when they are installed and always were:

```
src/api.ts(183,30):    error TS2591: Cannot find name 'node:fs'
src/http.ts(29,13):    error TS2591: Cannot find name 'Buffer'
src/factory.ts(50,48): error TS2339: Property 'unref' does not exist on type 'number'
src/cli.ts(102,24):    error TS7006: Parameter 'err' implicitly has an 'any' type
```

The `unref` one is the clearest tell. Without the node types, `setTimeout` resolves to the DOM signature that returns a `number`, so the `.unref()` calls in `factory.ts` have nothing to attach to. The implicit-any errors are downstream of the same thing: once the `node:*` imports resolve to nothing, every callback parameter loses its type.

Naming the dependency is the fix, rather than pinning away from the compiler that noticed it. It also makes the tsconfig more honest: this is a server built out of `node:fs`, `node:http`, `node:child_process` and `node:async_hooks`, and the file now says so.

This unblocks #78, which is otherwise a straightforward `typescript` bump that fails for a reason that has nothing to do with the bump.

## What you ran

Locally, in `mcp/` with dependencies installed, against both compilers:

```
typescript 5.9.3    tsc --noEmit: 27 errors -> 0     npm test: 27 pass, 0 fail
typescript 7.0.2    tsc --noEmit: 27 errors -> 0     npm test: 27 pass, 0 fail
./scripts/lint.sh   clean
```

The 5.9.3 run is the one that matters for merging this on its own: `package.json` still pins `typescript: ^5.5.0`, so this has to be a no-op today and a fix tomorrow. It is.

## Checks

- [x] `swift build` passes on every commit in the branch, not just the last one — one commit, no Swift touched
- [x] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be — compiler configuration, covered by the existing suite passing under both compilers
- [x] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [x] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — touches none of them
- [ ] Screenshots below for anything visual — nothing visual

## Note

I closed #73 earlier calling this a migration that needed doing deliberately. Dependabot then re-proposed the same bump as #78, which is worth knowing on its own: closing one of its pull requests does not stop it offering that version again. Having actually reproduced it, the migration turned out to be this single line, so it was not worth deferring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcrjVns8WTBv1Y9GJU6VSv)_