### PR TITLE
fix: pin scorecard-action to a tag that exists

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,12 @@ jobs:
           # .git/config while it does.
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2
+      # A full version tag, unlike every other action here. ossf publishes no
+      # moving v2: `git ls-remote --tags` on that repository lists v2.4.4 down
+      # to v2.1.2 and no bare major, so @v2 resolves to nothing and the job
+      # fails before it runs a step. Dependabot watches this file, so the pin
+      # moves with a pull request rather than by hand.
+      - uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## What changed, and why

Every Scorecard run since it was added has failed. All five of them, before executing a single step:

```
##[error]Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

ossf publishes no moving major tag. `git ls-remote --tags` on that repository lists `v2.4.4` down to `v2.1.2` and nothing bare. `@v2` names a ref that was never created.

I checked this before writing the file and got it wrong: I read the releases page, which says the latest major version is v2, and treated that as a tag anyone can check out. It is a statement about the release series. The only way to answer the question is to ask git for the refs, which I have now done, for this and for every other action in the repository:

```
OK      actions/attest-build-provenance@v4
OK      actions/checkout@v5
OK      actions/setup-node@v7
OK      actions/upload-artifact@v4
OK      github/codeql-action/analyze@v4
OK      github/codeql-action/init@v4
OK      github/codeql-action/upload-sarif@v4
BROKEN  ossf/scorecard-action@v2
```

One broken pin, now `v2.4.4`. Dependabot watches `.github/workflows/`, so the pin moves by pull request from here rather than by hand.

## The visible symptom

The OpenSSF Scorecard badge in `README.md`. It reads a public API populated by a successful run publishing to it, and no run had ever got as far as publishing, so the badge had nothing to show and never would have. It has been broken since it was added in #70 and would have stayed broken silently, because a red workflow on a schedule is easy not to look at.

The CodeQL badge next to it is fine and reads real data, since that workflow does succeed.

## What you ran

```
./scripts/lint.sh                                  clean
python3 -c "import yaml; yaml.safe_load(...)"      parses
git ls-remote --tags https://github.com/ossf/scorecard-action | grep -E 'refs/tags/v[0-9]+$'
                                                   no output, confirming no bare major tag
```

Whether the run now succeeds end to end can only be answered by merging it, same as the rest of this workflow. The failure it fixes was at action resolution, which is the first thing the runner does, so nothing beyond that point has ever been exercised.

## Checks

- [x] `swift build` passes on every commit in the branch, not just the last one — one commit, no Swift touched
- [x] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be — a workflow pin
- [x] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [x] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — the README badge starts telling the truth once this lands
- [ ] Screenshots below for anything visual — nothing visual beyond the badge

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcrjVns8WTBv1Y9GJU6VSv)_