### PR TITLE
ci: pin actions by commit, add token scopes, publish attestations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,12 @@ updates:
       interval: weekly
     commit-message:
       prefix: app
+
+  # mcp/Dockerfile pins node:20-slim by digest, so the base image only moves
+  # when a pull request moves it. This is what opens that pull request.
+  - package-ecosystem: docker
+    directory: /mcp
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# A checkout is all any job here needs, so the token can only read. Nothing
+# in this file publishes anything.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -18,7 +23,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: ./scripts/lint.sh
 
   # SECURITY.md asks people to grant Accessibility and Screen Recording on the
@@ -30,14 +35,14 @@ jobs:
   security-claims:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: ./scripts/check-security-claims.sh
 
   app:
     # macos-14 still ships Swift 5.10; Package.swift needs tools version 6.0.
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build
         run: swift build
         working-directory: App
@@ -47,8 +52,8 @@ jobs:
   mcp:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: npm
@@ -65,8 +70,8 @@ jobs:
   strings:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - run: node scripts/check-strings.mjs
@@ -77,8 +82,8 @@ jobs:
   zone-sets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - run: node scripts/check-zone-sets.mjs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ name: CodeQL
 # Findings land in the Security tab. `security-and-quality` is the wider of the
 # two query suites, so some of what it reports is a correctness smell rather
 # than a vulnerability; both are worth a look on a codebase this size.
+# Read by default. The analysis job asks below for the one write scope it
+# needs, security-events, to file its findings under the Security tab.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -50,9 +55,9 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: swift
           queries: security-and-quality
@@ -71,6 +76,6 @@ jobs:
         run: swift build
         working-directory: App
 
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:swift"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ name: Release
 # signed with it — and only one signed with it. Losing it means no user can
 # auto-update again; leaking it means someone else can offer them a build.
 
+# Read by default. The jobs that upload to the release and sign it ask for
+# their own write scopes below, one job at a time.
+permissions:
+  contents: read
+
 on:
   push:
     tags: ["v*"]
@@ -53,7 +58,7 @@ jobs:
       id-token: write # sign the attestation
       attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Read the version
         id: version
@@ -136,11 +141,21 @@ jobs:
       # What ties Plonk-<version>.zip to this repository, this commit and this
       # workflow run. Without it the app's own promises are only checkable at
       # runtime, on a binary nobody can trace back to the source.
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        id: attest
         with:
           subject-path: |
             Plonk-${{ steps.version.outputs.version }}.zip
             Plonk-${{ steps.version.outputs.version }}.zip.sha256
+
+      # The attestation lives in GitHub's store, which is what `gh attestation
+      # verify` reads. A copy goes on the release too, so the provenance is
+      # visible next to the file it covers and checkable without gh.
+      - name: Copy the attestation next to the archive
+        env:
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: cp "$BUNDLE" "Plonk-$VERSION.zip.sigstore.json"
 
       - name: Publish the archive
         env:
@@ -181,7 +196,7 @@ jobs:
                 "sha256: \`$SHA\`"
             )"
           fi
-          gh release upload "v$VERSION" "$ZIP" "$ZIP.sha256" --clobber
+          gh release upload "v$VERSION" "$ZIP" "$ZIP.sha256" "$ZIP.sigstore.json" --clobber
 
           {
             echo "### Plonk $VERSION"
@@ -198,7 +213,7 @@ jobs:
       # workflow by, and what it records the tarball's origin from.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Node 24 for npm 11, which is the first that can publish over OIDC.
       #
       # No registry-url on purpose. Given one, setup-node writes an .npmrc with
@@ -207,7 +222,7 @@ jobs:
       # never tries OIDC at all, because OIDC is what it falls back to only
       # when nothing else claims to be a credential. The default registry is
       # registry.npmjs.org anyway.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -300,8 +315,15 @@ jobs:
             echo "$VERSION is already in the registry; nothing to do."
             exit 0
           fi
-          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" \
-            | tar xz mcp-publisher
+          # A fixed release and its checksum, not `latest`: whatever the
+          # registry ships next week does not get to run in this job until
+          # someone reads its release notes and moves these two lines.
+          MCP_PUBLISHER_VERSION=1.8.1
+          MCP_PUBLISHER_SHA256=a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+          curl -sSfL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v$MCP_PUBLISHER_VERSION/mcp-publisher_linux_amd64.tar.gz"
+          echo "$MCP_PUBLISHER_SHA256  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
           ./mcp-publisher login github-oidc
           cd mcp && ../mcp-publisher publish
 
@@ -326,9 +348,9 @@ jobs:
       id-token: write # sign the attestation
       attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm
@@ -346,15 +368,22 @@ jobs:
 
       - run: ./scripts/build-mcpb.sh
 
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        id: attest
         with:
           subject-path: mcp/plonk-${{ steps.version.outputs.version }}.mcpb
 
+      # Same as the app: the attestation is in GitHub's store, and a copy sits
+      # on the release beside the bundle it covers.
       - name: Publish the bundle
         env:
           GH_TOKEN: ${{ github.token }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
           VERSION: ${{ steps.version.outputs.version }}
-        run: gh release upload "v$VERSION" "mcp/plonk-$VERSION.mcpb" --clobber
+        run: |
+          set -eu
+          cp "$BUNDLE" "mcp/plonk-$VERSION.mcpb.sigstore.json"
+          gh release upload "v$VERSION" "mcp/plonk-$VERSION.mcpb" "mcp/plonk-$VERSION.mcpb.sigstore.json" --clobber
 
       # Smithery listed 0.2.2 for six days after 0.2.5 shipped, because the
       # first publish was run by hand and nothing ran the second. These two

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,18 +27,15 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Scorecard reads the checkout; it has no use for a token sitting in
           # .git/config while it does.
           persist-credentials: false
 
-      # A full version tag, unlike every other action here. ossf publishes no
-      # moving v2: `git ls-remote --tags` on that repository lists v2.4.4 down
-      # to v2.1.2 and no bare major, so @v2 resolves to nothing and the job
-      # fails before it runs a step. Dependabot watches this file, so the pin
-      # moves with a pull request rather than by hand.
-      - uses: ossf/scorecard-action@v2.4.4
+      # Pinned by commit like every action here; the comment is the tag that
+      # commit carries, and Dependabot moves both together in one pull request.
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -46,12 +43,12 @@ jobs:
 
       # Kept for the run itself: if the upload below is rejected, the findings
       # are still downloadable from the run rather than lost.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ command fails and tells you so.
 Every release also carries a small `Plonk-<version>.zip.sha256` file. Put it
 beside the zip and run `shasum -a 256 -c Plonk-<version>.zip.sha256` to confirm
 the download arrived complete and unchanged. That file is signed the same way
-as the zip, so `gh attestation verify` works on it too.
+as the zip, so `gh attestation verify` works on it too. The attestation itself
+is also on the release as `Plonk-<version>.zip.sigstore.json`, for anyone who
+wants to check it offline with `gh attestation verify --bundle` or with
+[cosign](https://github.com/sigstore/cosign) instead of asking GitHub.
 
 <details>
 <summary>Installing by hand, Intel Macs, tiling managers, and removing it</summary>

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -2,7 +2,7 @@
 # The Mac menu bar app is not available in a container, so tools respond
 # with a "Plonk.app is not reachable" error when invoked — but the server
 # starts, lists its tools, and speaks MCP over stdio.
-FROM node:20-slim
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
 WORKDIR /app
 COPY package.json package-lock.json tsconfig.json ./
 COPY src ./src


### PR DESCRIPTION
Raises the OpenSSF Scorecard from 5.1 by fixing the three checks that carried most of the loss.

- **Pinned-Dependencies**: all 23 actions pinned by commit (tag kept in a comment for Dependabot), `node:20-slim` pinned by digest with a `docker` Dependabot entry, mcp-publisher downloaded at a fixed release and verified by sha256.
- **Token-Permissions**: top-level `contents: read` in ci, codeql, release.
- **Signed-Releases**: the provenance bundle is uploaded to the release as `*.sigstore.json` next to the artifact it covers.
- **Branch-Protection**: a `main` ruleset mirroring the classic protection was created on GitHub, so Scorecard can read it with the default token.

Verified: `actionlint` (one pre-existing shellcheck note untouched), `scripts/check-security-claims.sh`, `scripts/lint.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)