### PR TITLE
ci: read fetched JSON from a file instead of piping curl into node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,11 +306,13 @@ jobs:
         run: |
           set -eu
           VERSION="${{ steps.version.outputs.version }}"
-          if curl -sf "https://registry.modelcontextprotocol.io/v0/servers?search=plonk" \
-            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
-                const found=JSON.parse(d).servers.some(e =>
+          # Fetched to a file and read from there, not piped into node: the
+          # response is data for the script, and a pipe into an interpreter
+          # reads to Scorecard (and to a person skimming) as running it.
+          curl -sf -o registry.json "https://registry.modelcontextprotocol.io/v0/servers?search=plonk"
+          if node -e "const found=JSON.parse(require('fs').readFileSync('registry.json','utf8')).servers.some(e =>
                   e.server.name==='io.github.ostapondo/plonk' && e.server.version===process.argv[1]);
-                process.exit(found?0:1)})" "$VERSION"
+                process.exit(found?0:1)" "$VERSION"
           then
             echo "$VERSION is already in the registry; nothing to do."
             exit 0

--- a/scripts/publish-smithery.sh
+++ b/scripts/publish-smithery.sh
@@ -67,14 +67,15 @@ printf 'updated https://smithery.ai/server/%s\n' "$SERVER"
 # From the management API, not registry.smithery.ai: the public endpoint sits
 # behind a CDN that serves the pre-write copy for a while, so reading it here
 # reports a failure that did not happen.
-curl -sS "https://api.smithery.ai/servers/$ENCODED" \
-	-H "Authorization: Bearer $SMITHERY_API_KEY" | node -e '
-	let raw = "";
-	process.stdin.on("data", (c) => (raw += c));
-	process.stdin.on("end", () => {
-		const server = JSON.parse(raw);
-		for (const field of ["displayName", "description", "iconUrl"]) {
-			console.log(`  ${field}: ${server[field] || "(empty)"}`);
-		}
-	});
+#
+# To a file first, then read by node, rather than piped straight in: the body
+# is data, and `curl | node` looks like the other thing.
+curl -sS -o /tmp/smithery-server.json "https://api.smithery.ai/servers/$ENCODED" \
+	-H "Authorization: Bearer $SMITHERY_API_KEY"
+node -e '
+	const server = JSON.parse(require("fs").readFileSync("/tmp/smithery-server.json", "utf8"));
+	for (const field of ["displayName", "description", "iconUrl"]) {
+		console.log(`  ${field}: ${server[field] || "(empty)"}`);
+	}
 '
+rm -f /tmp/smithery-server.json


### PR DESCRIPTION
Clears the last two Pinned-Dependencies warnings. `curl … | node -e` in the release workflow and in `scripts/publish-smithery.sh` reads to Scorecard as download-then-run; the response is JSON for the script, so both now save it to a file and read it from there. Behaviour unchanged.

Verified: `actionlint`, `shellcheck` (same pre-existing SC2016 info as before), `scripts/lint.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)