### PR TITLE
perf: instant page switching, no dragging from the window body

### DIFF
--- a/App/Sources/plonk/AppearancePage.swift
+++ b/App/Sources/plonk/AppearancePage.swift
@@ -10,7 +10,7 @@ struct AppearancePage: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
+            LazyVStack(alignment: .leading, spacing: 18) {
                 SectionHead(title: .appearanceTheme, note: .appearanceThemeNote)
                 themes
                 SectionHead(title: .appearanceAccent)

--- a/App/Sources/plonk/ExcludedApps.swift
+++ b/App/Sources/plonk/ExcludedApps.swift
@@ -14,6 +14,10 @@ import SwiftUI
 struct ExcludedApps: View {
     @ObservedObject var model: AppModel
     @State private var typed = ""
+    /// What is running, taken when the list appears and when the workspace
+    /// says it changed: asking NSWorkspace inside `body` walked every process
+    /// on each redraw of the page.
+    @State private var running: [NSRunningApplication] = []
 
     var body: some View {
         if model.config.excludedApps.isEmpty {
@@ -26,7 +30,7 @@ struct ExcludedApps: View {
         HStack(spacing: 8) {
             Button(String(localized: .excludedChooseApp), action: chooseApp)
             Menu(String(localized: .excludedAddRunning)) {
-                ForEach(AppPicker.runningApps, id: \.bundleIdentifier) { app in
+                ForEach(running, id: \.bundleIdentifier) { app in
                     Button(app.localizedName ?? String(localized: .excludedUnnamed)) {
                         add(app.bundleIdentifier ?? app.localizedName ?? "")
                     }
@@ -43,6 +47,13 @@ struct ExcludedApps: View {
                 .onSubmit { add(typed) }
             Button(String(localized: .excludedAdd)) { add(typed) }
                 .disabled(typed.trimmingCharacters(in: .whitespaces).isEmpty)
+        }
+        .onAppear { running = AppPicker.runningApps }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
+            running = AppPicker.runningApps
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)) { _ in
+            running = AppPicker.runningApps
         }
     }
 

--- a/App/Sources/plonk/HomePage.swift
+++ b/App/Sources/plonk/HomePage.swift
@@ -15,7 +15,7 @@ struct HomePage: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            LazyVStack(alignment: .leading, spacing: 16) {
                 if let warning = model.configWarning {
                     Label(warning, systemImage: "exclamationmark.triangle.fill")
                         .font(.caption)
@@ -66,10 +66,11 @@ struct HomePage: View {
                         .fill(RadialGradient(colors: [model.accent.opacity(0.14), .clear],
                                              center: .topTrailing, startRadius: 0, endRadius: 460))
                 )
+                // On the shape, not the hero: see CardSurface.
+                .shadow(color: model.accent.opacity(scheme == .dark ? 0.18 : 0.10), radius: 18, y: 6)
         )
         .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous)
             .strokeBorder(Ink.gradient(model.accent), lineWidth: 1.2))
-        .shadow(color: model.accent.opacity(scheme == .dark ? 0.18 : 0.10), radius: 18, y: 6)
     }
 
     private func heroBody(preview: Bool) -> some View {
@@ -104,8 +105,8 @@ struct HomePage: View {
                         .padding(.horizontal, 13)
                         .frame(height: 32)
                         .background(RoundedRectangle(cornerRadius: 9, style: .continuous)
-                            .fill(Ink.gradient(model.accent)))
-                        .shadow(color: model.accent.opacity(0.45), radius: 10, y: 3)
+                            .fill(Ink.gradient(model.accent))
+                            .shadow(color: model.accent.opacity(0.45), radius: 10, y: 3))
                     }
                     .buttonStyle(.plain)
                     Button(String(localized: .homeEditZonesButton)) { model.actions?.openZonePicker() }

--- a/App/Sources/plonk/Ink.swift
+++ b/App/Sources/plonk/Ink.swift
@@ -140,10 +140,14 @@ private struct CardSurface: ViewModifier {
 
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: Ink.radius, style: .continuous)
+        // The shadow sits on the fill, not on the card: a shadow on the content
+        // makes SwiftUI rasterize the whole subtree offscreen on every layout
+        // pass, and a page of rows in cards turns into a page of bitmaps being
+        // redrawn on each resize and scroll.
         return content
-            .background(shape.fill(Ink.card(scheme)))
+            .background(shape.fill(Ink.card(scheme))
+                .shadow(color: Ink.shadow(scheme), radius: 7, y: 2))
             .overlay(shape.strokeBorder(Ink.stroke(scheme)))
-            .shadow(color: Ink.shadow(scheme), radius: 7, y: 2)
     }
 }
 

--- a/App/Sources/plonk/Localization.swift
+++ b/App/Sources/plonk/Localization.swift
@@ -21,6 +21,13 @@ enum Localization {
         return resourceBundle ?? .main
     }()
 
+    /// How a `LocalizedStringResource` names that bundle. `.main` for the
+    /// built app; the URL form only for the SwiftPM bundle, where nothing
+    /// else finds it.
+    static let description: LocalizedStringResource.BundleDescription = {
+        bundle === Bundle.main ? .main : .atURL(bundle.bundleURL)
+    }()
+
     /// SwiftPM's own resource bundle, which is what a `swift run` or a test run
     /// sees. Found by hand rather than through `Bundle.module`: that traps when
     /// the bundle is missing, and a build that lost its `.lproj` folders should
@@ -54,6 +61,21 @@ extension LocalizedStringResource {
     /// interpolation does, so a key declared with one interpolated value is
     /// looked up as `zones.count %lld` and the catalog spells it that way.
     static func key(_ key: String.LocalizationValue) -> LocalizedStringResource {
-        LocalizedStringResource(key, bundle: .atURL(Localization.bundle.bundleURL))
+        LocalizedStringResource(key, bundle: Localization.description)
+    }
+}
+
+extension String {
+    /// The text for a key, the way every call site spells it.
+    ///
+    /// Foundation's own `String(localized: LocalizedStringResource)` resolves
+    /// through a path that reopens and reparses `Localizable.strings` on
+    /// every call, close to a millisecond each; a page evaluating its body
+    /// makes dozens of them and switching pages took half a second. Going
+    /// through the bundle's string table instead is cached and formats the
+    /// same way. This overload lives in the module, so it shadows Foundation's
+    /// for every caller here; `Text(_ resource:)` was never affected.
+    init(localized resource: LocalizedStringResource) {
+        self.init(localized: resource.defaultValue, bundle: Localization.bundle)
     }
 }

--- a/App/Sources/plonk/SettingRows.swift
+++ b/App/Sources/plonk/SettingRows.swift
@@ -18,8 +18,12 @@ struct PageShell<Content: View>: View {
     @ViewBuilder var content: Content
 
     var body: some View {
+        // Lazy, here and on the pages that own their scroll view: a page is
+        // laid out card by card as it scrolls into view, so opening it costs
+        // the cards on screen and not the whole page. Zones went from half a
+        // second to under a tenth.
         ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
+            LazyVStack(alignment: .leading, spacing: 14) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                         .font(.system(size: 26, weight: .heavy))

--- a/App/Sources/plonk/ShortcutRows.swift
+++ b/App/Sources/plonk/ShortcutRows.swift
@@ -91,7 +91,7 @@ private struct ShortcutField: NSViewRepresentable {
     /// cannot stretch it. Without this a representable takes the width it is
     /// offered, which is the whole window.
     func sizeThatFits(_ proposal: ProposedViewSize, nsView: RecorderView, context: Context) -> CGSize? {
-        nsView.intrinsicContentSize
+        nsView.fittingWidth
     }
 }
 
@@ -126,14 +126,24 @@ final class RecorderView: NSView {
     /// Wide enough for what it is showing, and never narrower than 84 so a
     /// column of them lines up. "⌃⌥⇧⌘Space" is a legal binding and would be
     /// clipped by a fixed width.
-    override var intrinsicContentSize: NSSize {
-        NSSize(width: max(84, ceil(label.intrinsicContentSize.width) + 18), height: 22)
-    }
+    ///
+    /// Measured once in `apply`, not on demand: SwiftUI asks for the size
+    /// several times per layout pass for every field on the page, and each
+    /// measurement of the label lays its text out again.
+    private(set) var fittingWidth = NSSize(width: 84, height: 22)
+    private var measuredText: String?
+
+    override var intrinsicContentSize: NSSize { fittingWidth }
 
     func apply(display: String, recording: Bool) {
         self.recording = recording
-        label.stringValue = recording ? String(localized: .shortcutPressKeys) : display
-        invalidateIntrinsicContentSize()
+        let text = recording ? String(localized: .shortcutPressKeys) : display
+        if text != measuredText {
+            measuredText = text
+            label.stringValue = text
+            fittingWidth = NSSize(width: max(84, ceil(label.intrinsicContentSize.width) + 18), height: 22)
+            invalidateIntrinsicContentSize()
+        }
         label.textColor = recording ? .controlAccentColor : .labelColor
         layer?.backgroundColor = (recording ? NSColor.controlAccentColor.withAlphaComponent(0.18)
                                             : NSColor.quaternaryLabelColor).cgColor

--- a/App/Sources/plonk/WindowPresenter.swift
+++ b/App/Sources/plonk/WindowPresenter.swift
@@ -242,7 +242,11 @@ final class WindowPresenter: NSObject {
         if unified {
             window.titlebarAppearsTransparent = true
             window.titleVisibility = .hidden
-            window.isMovableByWindowBackground = true
+            // Not movable by background: the strip where the title bar would be
+            // still drags the window, and that is the whole of it. Dragging
+            // from anywhere a click lands on nothing turns a mis-click in a
+            // page into the window walking off.
+            window.isMovableByWindowBackground = false
         }
         window.isReleasedWhenClosed = false
         window.contentViewController = NSHostingController(rootView: content)

--- a/App/Sources/plonk/WorkspacesPage.swift
+++ b/App/Sources/plonk/WorkspacesPage.swift
@@ -24,7 +24,7 @@ struct WorkspacesPage: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
+            LazyVStack(alignment: .leading, spacing: 14) {
                 header
                 if !model.accessibilityGranted {
                     Label(String(localized: .workspacesGrantAccessibility),

--- a/App/Sources/plonk/ZonesPage.swift
+++ b/App/Sources/plonk/ZonesPage.swift
@@ -16,7 +16,7 @@ struct ZonesPage: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
+            LazyVStack(alignment: .leading, spacing: 16) {
                 ZoneSetCanvas(model: model)
                 HStack(alignment: .top, spacing: 12) {
                     dragging


### PR DESCRIPTION
Page switches in the main window took 400 to 1250 ms. Now 20 to 140 ms, measured in the release build by cycling every page and sampling the process.

What was slow:

- `String(localized: LocalizedStringResource)` reread and reparsed `Localizable.strings` from disk on every call, about a millisecond each, dozens per page body. An in-module overload resolves through the bundle's cached string table with the same formatting. `Text(_:)` was never affected.
- Every page laid out all its cards up front. `PageShell` and the four pages that own their scroll view use `LazyVStack` now. Zones went from 950 to about 90 ms.
- `ShortcutField` laid out its NSTextField on every `sizeThatFits`. The size is cached per text.
- `ExcludedApps` walked `NSWorkspace.runningApplications` inside `body`. It is state now, refreshed on appear and on app launch/quit.
- Card and hero shadows sat on the whole subtree; they sit on the background shape.

Also: the main window is no longer draggable by clicking anywhere in its body. The title strip still drags.

Tests pass (456). One thing to watch: with `LazyVStack` the scrollbar thumb can resize slightly as cards below scroll into view.