### PR TITLE
zones: a layout can keep its own gap

### DIFF
--- a/App/Sources/plonk/AppDelegate+DragSnap.swift
+++ b/App/Sources/plonk/AppDelegate+DragSnap.swift
@@ -13,6 +13,7 @@ extension AppDelegate {
     func setupDragSnap() {
         dragSnap = DragSnapManager(windows: windows)
         dragSnap.zonesForScreen = { [weak self] index in self?.zones(onScreen: index) ?? [] }
+        dragSnap.gapForScreen = { [weak self] index in self?.zoneGapPoints(onScreen: index) ?? 0 }
         dragSnap.isExcluded = exclusionCheck
         dragSnap.onSnap = { [weak self] window, before, frac, screenIndex in
             guard let self else { return }
@@ -72,7 +73,7 @@ extension AppDelegate {
         newWindows = NewWindowWatcher(windows: windows)
         newWindows.apply(store.config)
         newWindows.isExcluded = exclusionCheck
-        newWindows.zoneGap = { [weak self] in self?.zoneGapPoints ?? 0 }
+        newWindows.zoneGap = { [weak self] index in self?.zoneGapPoints(onScreen: index) ?? 0 }
         newWindows.placement = { [weak self] app in
             guard let self, let key = app.bundleIdentifier,
                   let habit = snapMemory.habit(ofApp: key) else { return nil }

--- a/App/Sources/plonk/AppDelegate+Wiring.swift
+++ b/App/Sources/plonk/AppDelegate+Wiring.swift
@@ -21,13 +21,16 @@ extension AppDelegate {
         store.config.zones(forKeys: ScreenIdentity.keys(forIndex: index))
     }
 
-    var zoneGapPoints: CGFloat { CGFloat(store.config.zoneGap) }
+    /// The gap on a screen is the gap of the set it wears, or the default.
+    func zoneGapPoints(onScreen index: Int) -> CGFloat {
+        CGFloat(store.config.zoneGap(forKeys: ScreenIdentity.keys(forIndex: index)))
+    }
 
     func setupCommands() {
         commands.zonesForScreen = { [weak self] index in self?.zones(onScreen: index) ?? [] }
         commands.isExcluded = exclusionCheck
         commands.announce = { HUD.shared.show($0) }
-        commands.zoneGap = { [weak self] in self?.zoneGapPoints ?? 0 }
+        commands.zoneGap = { [weak self] index in self?.zoneGapPoints(onScreen: index) ?? 0 }
     }
 
     func setupPresenter() {

--- a/App/Sources/plonk/AppDelegate+Zones.swift
+++ b/App/Sources/plonk/AppDelegate+Zones.swift
@@ -21,8 +21,11 @@ extension AppDelegate {
         commands.relayout(screenIndex: index)
     }
 
-    func updateZoneSet(_ name: String, zones: [ZoneRect]) {
-        store.update { $0.zoneSets[name] = zones }
+    func updateZoneSet(_ name: String, zones: [ZoneRect], gap: Double?) {
+        store.update {
+            $0.zoneSets[name] = zones
+            $0.zoneSetGaps[name] = gap
+        }
         for index in NSScreen.screens.indices
         where store.config.zoneAssignment(forKeys: ScreenIdentity.keys(forIndex: index)) == name {
             commands.relayout(screenIndex: index)
@@ -38,6 +41,7 @@ extension AppDelegate {
         store.update {
             guard let zones = $0.zoneSets.removeValue(forKey: old) else { return }
             $0.zoneSets[new] = zones
+            $0.zoneSetGaps[new] = $0.zoneSetGaps.removeValue(forKey: old)
             $0.screenZoneSets = $0.screenZoneSets.mapValues { $0 == old ? new : $0 }
         }
         return true
@@ -54,7 +58,8 @@ extension AppDelegate {
             return
         }
         guard let zones = store.config.zoneSets[name] ?? BuiltinZoneSets.all[name] else { return }
-        dragSnap.showPreview(zones: zones, screenIndex: index)
+        dragSnap.showPreview(zones: zones, screenIndex: index,
+                             gap: CGFloat(store.config.zoneGap(forSet: name)))
         model.previewedZoneSet = name
 
         let token = previewToken

--- a/App/Sources/plonk/AppModel.swift
+++ b/App/Sources/plonk/AppModel.swift
@@ -37,7 +37,8 @@ protocol AppActions: AnyObject {
     func reportBug()
 
     func assignZoneSet(_ name: String?, toScreen index: Int)
-    func updateZoneSet(_ name: String, zones: [ZoneRect])
+    /// `gap` is the set's own spacing in points; nil means the default gap.
+    func updateZoneSet(_ name: String, zones: [ZoneRect], gap: Double?)
     /// False when `new` is already taken, which leaves both sets untouched.
     func renameZoneSet(_ old: String, to new: String) -> Bool
     func deleteZoneSet(_ name: String)

--- a/App/Sources/plonk/Config+Edits.swift
+++ b/App/Sources/plonk/Config+Edits.swift
@@ -34,6 +34,7 @@ extension Config {
     /// which is what kept the same clamp written out at three call sites.
     mutating func clamp() {
         zoneGap = zoneGap.clamped(to: 0...Self.gapLimit)
+        zoneSetGaps = zoneSetGaps.mapValues { $0.clamped(to: 0...Self.gapLimit) }
         zoneOpacity = zoneOpacity.clamped(to: Self.opacityRange)
         zoneEdgeSpanPoints = zoneEdgeSpanPoints.clamped(to: 0...Self.edgeSpanLimit)
         rulerEdgeTolerance = rulerEdgeTolerance.clamped(to: EdgeDetector.toleranceRange)

--- a/App/Sources/plonk/Config.swift
+++ b/App/Sources/plonk/Config.swift
@@ -111,6 +111,9 @@ struct Config: Codable {
     var appearance = AppearanceSettings()
     var workspaces: [String: Workspace] = [:]
     var zoneSets: [String: [ZoneRect]] = [:]
+    /// A set's own gap in points, keyed by set name. A set with no entry
+    /// uses `zoneGap`, the default; see `zoneGap(forSet:)`.
+    var zoneSetGaps: [String: Double] = [:]
     // Keyed by display UUID; configs written before that used the screen index,
     // which is why lookups take a list of candidate keys.
     var screenZoneSets: [String: String] = [:]
@@ -131,6 +134,17 @@ struct Config: Codable {
         return zoneSets[name] ?? BuiltinZoneSets.all[name] ?? []
     }
 
+    /// The gap for a set: its own if it has one, else the default. Nil is
+    /// the set an unassigned screen falls back to.
+    func zoneGap(forSet name: String?) -> Double {
+        zoneSetGaps[name ?? BuiltinZoneSets.defaultName] ?? zoneGap
+    }
+
+    /// The gap that applies on a screen, through the set it wears.
+    func zoneGap(forKeys keys: [String]) -> Double {
+        zoneGap(forSet: zoneAssignment(forKeys: keys))
+    }
+
     mutating func assignZoneSet(_ name: String?, forKeys keys: [String]) {
         keys.forEach { screenZoneSets.removeValue(forKey: $0) }
         if let name, let primary = keys.first { screenZoneSets[primary] = name }
@@ -149,6 +163,7 @@ struct Config: Codable {
 
     mutating func forgetZoneSet(named name: String) {
         zoneSets.removeValue(forKey: name)
+        zoneSetGaps.removeValue(forKey: name)
         screenZoneSets = screenZoneSets.filter { $0.value != name }
     }
 }

--- a/App/Sources/plonk/DragSnapManager+Zones.swift
+++ b/App/Sources/plonk/DragSnapManager+Zones.swift
@@ -39,7 +39,7 @@ extension DragSnapManager {
                 : straddle(from: hovered, at: p, in: zones, visible: v)
             overlay(for: index).show(zones: zones,
                                      highlighted: spanned?.indices ?? Set(hovered.map { [$0] } ?? []),
-                                     visible: v, appearance: look)
+                                     visible: v, appearance: look(on: index))
             showOthers(except: index)
             if let spanned {
                 currentZone = (index, spanned.frac)
@@ -48,7 +48,7 @@ extension DragSnapManager {
             }
         } else if let frac = edgeZone(at: p, on: screen) {
             overlay(for: index).show(zones: [ZoneRect(frac.x, frac.y, frac.w, frac.h)], highlighted: [0],
-                                     visible: screen.visibleFrame, appearance: look)
+                                     visible: screen.visibleFrame, appearance: look(on: index))
             showOthers(except: index)
             currentZone = (index, frac)
         } else {
@@ -103,7 +103,7 @@ extension DragSnapManager {
                 continue
             }
             overlay(for: index).show(zones: zones, highlighted: [], visible: screen.visibleFrame,
-                                     appearance: look)
+                                     appearance: look(on: index))
         }
     }
 

--- a/App/Sources/plonk/DragSnapManager.swift
+++ b/App/Sources/plonk/DragSnapManager.swift
@@ -40,8 +40,16 @@ final class DragSnapManager {
     var requireModifier = true
     var modifierFlag: NSEvent.ModifierFlags = .shift
     var zonesForScreen: ((Int) -> [ZoneRect])?
-    /// Looks and spacing, taken from config in `apply`.
+    /// Looks and spacing, taken from config in `apply`. The gap in it is
+    /// the default; `look(on:)` swaps in the gap of the set a screen wears.
     var look = ZoneAppearance()
+    var gapForScreen: ((Int) -> CGFloat)?
+
+    func look(on screenIndex: Int) -> ZoneAppearance {
+        var appearance = look
+        appearance.gap = gapForScreen?(screenIndex) ?? look.gap
+        return appearance
+    }
     /// Draw every screen's zones during a drag, not just the one under the
     /// cursor. Costs an overlay per display.
     var showOnAllMonitors = false
@@ -78,13 +86,17 @@ final class DragSnapManager {
     }
 
     /// Show one zone set on one screen until hidden (the picker's eye toggle).
-    func showPreview(zones: [ZoneRect], screenIndex: Int) {
+    /// The set previewed need not be the one the screen wears, so its gap
+    /// comes with it.
+    func showPreview(zones: [ZoneRect], screenIndex: Int, gap: CGFloat) {
         previewGeneration += 1
         let screens = NSScreen.screens
         guard screens.indices.contains(screenIndex), !zones.isEmpty else { return }
         hideAll()
+        var appearance = look
+        appearance.gap = gap
         overlay(for: screenIndex).show(zones: zones, highlighted: [],
-                                       visible: screens[screenIndex].visibleFrame, appearance: look)
+                                       visible: screens[screenIndex].visibleFrame, appearance: appearance)
     }
 
     func hidePreviews() {
@@ -102,7 +114,7 @@ final class DragSnapManager {
             guard !zones.isEmpty else { continue }
             shownAny = true
             overlay(for: index).show(zones: zones, highlighted: [], visible: screen.visibleFrame,
-                                     appearance: look)
+                                     appearance: look(on: index))
         }
         guard shownAny else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
@@ -154,7 +166,8 @@ final class DragSnapManager {
     }
 
     private func drop(_ win: AXUIElement, startFrame: CGRect, into zone: (screenIndex: Int, frac: FracRect)) {
-        windows.apply(frac: zone.frac, toWindow: win, screenIndex: zone.screenIndex, gap: look.gap)
+        windows.apply(frac: zone.frac, toWindow: win, screenIndex: zone.screenIndex,
+                      gap: look(on: zone.screenIndex).gap)
         onSnap?(win, startFrame, zone.frac, zone.screenIndex)
     }
 

--- a/App/Sources/plonk/FullscreenZoneEditorView.swift
+++ b/App/Sources/plonk/FullscreenZoneEditorView.swift
@@ -17,6 +17,10 @@ struct FullscreenZoneEditorView: View {
     @State private var name = ""
     @State private var error: String?
     @State private var selected: Int?
+    /// The set's own gap, edited as digits and kept only while `ownGap` is on;
+    /// off means the default gap in Zones › Overlay.
+    @State private var ownGap = false
+    @State private var gapText = ""
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -34,6 +38,10 @@ struct FullscreenZoneEditorView: View {
             name = setName
             let existing = seed ?? model.zoneSets[setName] ?? []
             draft = existing.isEmpty ? [ZoneRect(0, 0, 1, 1)] : existing
+            if seed == nil, let own = model.config.zoneSetGaps[setName] {
+                ownGap = true
+                gapText = String(Int(own))
+            }
         }
     }
 
@@ -42,6 +50,7 @@ struct FullscreenZoneEditorView: View {
             TextField(String(localized: .zoneEditorName), text: $name)
                 .textFieldStyle(.roundedBorder)
                 .font(.headline)
+            gapRow
             VStack(alignment: .leading, spacing: 3) {
                 Text(.zoneEditorSplit)
                 Text(.zoneEditorResize)
@@ -66,6 +75,43 @@ struct FullscreenZoneEditorView: View {
         .frame(width: 460)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
         .padding(.bottom, 60)
+    }
+
+    /// The gap this layout keeps around its windows: the default from
+    /// Zones › Overlay, or a number of its own. A layout of wide zones can
+    /// afford air that a six-zone one cannot.
+    private var gapRow: some View {
+        HStack(spacing: 10) {
+            Text(.zoneEditorGap)
+            Picker("", selection: $ownGap) {
+                Text(.zoneEditorGapDefault(Int(model.config.zoneGap))).tag(false)
+                Text(.zoneEditorGapOwn).tag(true)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .fixedSize()
+            if ownGap {
+                TextField(text: $gapText, prompt: Text("0")) { EmptyView() }
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+                    .multilineTextAlignment(.trailing)
+                    .monospacedDigit()
+                    .frame(width: 56)
+                    .onChange(of: gapText) { typed in
+                        let digits = typed.filter(\.isNumber)
+                        if digits != typed { gapText = digits }
+                    }
+                Text(.commonPoints).foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// What `gapRow` says, as a value: nil for the default. Anything above
+    /// the limit is held to it, the way `Config.clamp` would on load.
+    private var gap: Double? {
+        guard ownGap else { return nil }
+        return Double(Int(gapText) ?? 0).clamped(to: 0...Config.gapLimit)
     }
 
     /// Editing without a mouse. Every edit goes through the same geometry the
@@ -116,7 +162,7 @@ struct FullscreenZoneEditorView: View {
                 return
             }
         }
-        actions.updateZoneSet(target, zones: draft)
+        actions.updateZoneSet(target, zones: draft, gap: gap)
         actions.assignZoneSet(target, toScreen: screenIndex)
         done()
     }

--- a/App/Sources/plonk/NewWindowWatcher.swift
+++ b/App/Sources/plonk/NewWindowWatcher.swift
@@ -35,7 +35,8 @@ final class NewWindowWatcher {
     /// Called after a new window has been placed, so it can be remembered like
     /// any other move.
     var onPlaced: ((NSRunningApplication, AXUIElement, CGRect, FracRect, Int) -> Void)?
-    var zoneGap: (() -> CGFloat)?
+    /// The gap for a screen: that of the set it wears.
+    var zoneGap: ((Int) -> CGFloat)?
 
     init(windows: WindowManager) {
         self.windows = windows
@@ -114,7 +115,7 @@ final class NewWindowWatcher {
               let before = windows.frame(ofWindow: window),
               let target = placement?(app) else { return }
         windows.apply(frac: target.frac, toWindow: window, screenIndex: target.screenIndex,
-                      gap: zoneGap?() ?? 0)
+                      gap: zoneGap?(target.screenIndex) ?? 0)
         onPlaced?(app, window, before, target.frac, target.screenIndex)
     }
 }

--- a/App/Sources/plonk/Resources/en.lproj/Localizable.strings
+++ b/App/Sources/plonk/Resources/en.lproj/Localizable.strings
@@ -264,8 +264,8 @@
 "zones.placeNewWindowsDetail" = "Once an app's window has been put in a zone, its next one lands there too. Forgotten when Plonk quits";
 "zones.overlay" = "Overlay";
 "zones.overlayHelp" = "The gap is real, not decoration: a window dropped into a zone keeps that much space around it. Edge spanning covers both zones when the cursor comes that close to the line between them, without holding anything; zero switches it off.";
-"zones.gap" = "Gap";
-"zones.gapHelp" = "Empty space kept around every snapped window";
+"zones.gap" = "Default gap";
+"zones.gapHelp" = "Empty space kept around every snapped window, unless the layout sets its own in the editor";
 "zones.opacity" = "Opacity";
 "zones.colour" = "Colour";
 "zones.colourFollowsAccent" = "Following the app's accent colour";
@@ -502,6 +502,9 @@
 "zoneEditor.delete" = "Delete: ✕ removes a zone and neighbors fill the space.";
 "zoneEditor.keyboard" = "Keyboard: ⇥ selects, arrows move, ⇧arrows resize, S splits, ⇧S splits vertically, ⌫ deletes.";
 "zoneEditor.saveAndApply" = "Save & Apply";
+"zoneEditor.gap" = "Gap";
+"zoneEditor.gapDefault %lld" = "Default (%lld pt)";
+"zoneEditor.gapOwn" = "Own";
 "zoneEditor.nameTaken %@" = "A layout named \"%@\" already exists.";
 
 /* The screenshot editor. */

--- a/App/Sources/plonk/Router+State.swift
+++ b/App/Sources/plonk/Router+State.swift
@@ -37,6 +37,8 @@ extension Router {
                 ] as [String: Any]
             },
             "zone_sets": zoneSets,
+            "zone_gap": store.config.zoneGap,
+            "zone_set_gaps": store.config.zoneSetGaps,
             "screen_zone_sets": assignments,
             "screens": screens.map { s in
                 [

--- a/App/Sources/plonk/Router+Zones.swift
+++ b/App/Sources/plonk/Router+Zones.swift
@@ -10,20 +10,36 @@ import AppKit
 extension Router {
     func saveZoneSetRoute(_ body: [String: Any]) -> HTTPResponse {
         guard let name = Self.trimmedName(body["name"]), let raw = body["zones"] as? [[String: Any]] else {
-            return .badRequest("body must be {\"name\", \"zones\": [{x,y,w,h}], \"screen\"?}")
+            return .badRequest("body must be {\"name\", \"zones\": [{x,y,w,h}], \"screen\"?, \"gap\"?}")
         }
         let zones = raw.compactMap { ZoneRect(dict: $0) }
         guard !zones.isEmpty, zones.count == raw.count else {
             return .badRequest("every zone needs x,y,w,h within 0..1, with w and h above 0")
         }
+        // A gap given is the set's own; null or absent leaves whatever it had,
+        // so a client that only knows zones does not silently reset it.
+        var gap: Double??
+        if body["gap"] is NSNull {
+            gap = .some(nil)
+        } else if let number = body["gap"] as? NSNumber {
+            guard number.doubleValue >= 0, number.doubleValue <= Config.gapLimit else {
+                return .badRequest("gap must be 0...\(Int(Config.gapLimit)) points")
+            }
+            gap = .some(number.doubleValue)
+        } else if body["gap"] != nil {
+            return .badRequest("gap must be a number of points, or null for the default")
+        }
         store.update {
             $0.zoneSets[name] = zones
+            if let gap { $0.zoneSetGaps[name] = gap }
             if let screen = (body["screen"] as? NSNumber)?.intValue {
                 $0.assignZoneSet(name, forKeys: ScreenIdentity.keys(forIndex: screen))
             }
         }
         didChangeZones?()
-        return .ok(["ok": true, "saved": name, "zones": zones.count])
+        var reply: [String: Any] = ["ok": true, "saved": name, "zones": zones.count]
+        reply["gap"] = store.config.zoneSetGaps[name] ?? NSNull()
+        return .ok(reply)
     }
 
     func assignZoneSetRoute(_ body: [String: Any]) -> HTTPResponse {
@@ -83,7 +99,8 @@ extension Router {
             return .badRequest("screen \(screen) has zones 1...\(zones.count)")
         }
         let error = windows.place(app: app, titleContains: title, screen: screen,
-                                  frac: zones[number - 1].frac, gap: CGFloat(store.config.zoneGap))
+                                  frac: zones[number - 1].frac,
+                                  gap: CGFloat(store.config.zoneGap(forKeys: ScreenIdentity.keys(forIndex: screen))))
         if let error { return .failed(error) }
         return .ok(["ok": true, "app": app, "screen": screen, "zone": number, "zones": zones.count])
     }

--- a/App/Sources/plonk/Router.swift
+++ b/App/Sources/plonk/Router.swift
@@ -14,7 +14,8 @@ import Network
 //   POST /workspaces/delete { name }
 //   POST /workspaces/rename { from, to }
 //   POST /layouts/*         aliases of save/launch/delete, kept for older clients
-//   POST /zones/save     { name, zones: [{x,y,w,h}], screen? }
+//   POST /zones/save     { name, zones: [{x,y,w,h}], screen?, gap? }
+//                        gap in points is the set's own; null or absent keeps the default
 //   POST /zones/assign   { screen, name? }
 //   POST /zones/delete   { name }
 //   POST /shot/capture   { mode?, annotate?, path?, clipboard?, preview? }

--- a/App/Sources/plonk/Strings+ZoneSets.swift
+++ b/App/Sources/plonk/Strings+ZoneSets.swift
@@ -59,6 +59,11 @@ extension LocalizedStringResource {
     static let zoneEditorDelete = Self.key("zoneEditor.delete")
     static let zoneEditorKeyboard = Self.key("zoneEditor.keyboard")
     static let zoneEditorSaveAndApply = Self.key("zoneEditor.saveAndApply")
+    static let zoneEditorGap = Self.key("zoneEditor.gap")
+    static let zoneEditorGapOwn = Self.key("zoneEditor.gapOwn")
+    static func zoneEditorGapDefault(_ points: Int) -> LocalizedStringResource {
+        Self.key("zoneEditor.gapDefault \(points)")
+    }
 
     static func zoneEditorNameTaken(_ name: String) -> LocalizedStringResource {
         Self.key("zoneEditor.nameTaken \(name)")

--- a/App/Sources/plonk/WindowCommands.swift
+++ b/App/Sources/plonk/WindowCommands.swift
@@ -16,7 +16,8 @@ final class WindowCommands {
     var isExcluded: ((NSRunningApplication) -> Bool)?
     var announce: ((String) -> Void)?
     /// Empty space left around a snapped window, in points.
-    var zoneGap: (() -> CGFloat)?
+    /// The gap for a screen: that of the set it wears.
+    var zoneGap: ((Int) -> CGFloat)?
 
     init(windows: WindowManager, memory: SnapMemory) {
         self.windows = windows
@@ -57,7 +58,7 @@ final class WindowCommands {
         }
         let frac = zones[number - 1].frac
         remember(target, frac: frac, screen: screen, zoneIndex: number - 1)
-        windows.apply(frac: frac, toWindow: target.window, screenIndex: screen, gap: zoneGap?() ?? 0)
+        windows.apply(frac: frac, toWindow: target.window, screenIndex: screen, gap: zoneGap?(screen) ?? 0)
     }
 
     /// Give a window back the frame it had before Plonk first moved it.
@@ -117,11 +118,11 @@ final class WindowCommands {
     /// placed on. Windows whose display is gone are left alone: guessing a new
     /// screen for them would scatter a layout rather than preserve it.
     func restorePlacements() {
-        let gap = zoneGap?() ?? 0
         for placement in memory.placements {
             guard let uuid = placement.screenUUID, let index = ScreenIdentity.index(forUUID: uuid),
                   mayTouch(placement.window) else { continue }
-            windows.apply(frac: placement.frac, toWindow: placement.window, screenIndex: index, gap: gap)
+            windows.apply(frac: placement.frac, toWindow: placement.window, screenIndex: index,
+                          gap: zoneGap?(index) ?? 0)
         }
     }
 
@@ -132,7 +133,7 @@ final class WindowCommands {
     func relayout(screenIndex: Int) {
         let zones = zonesForScreen?(screenIndex) ?? []
         guard !zones.isEmpty, let uuid = ScreenIdentity.uuid(forIndex: screenIndex) else { return }
-        let gap = zoneGap?() ?? 0
+        let gap = zoneGap?(screenIndex) ?? 0
         for placement in memory.placements {
             guard placement.screenUUID == uuid, let zone = placement.zoneIndex,
                   zones.indices.contains(zone), mayTouch(placement.window) else { continue }

--- a/App/Sources/plonk/ZoneSetCanvas.swift
+++ b/App/Sources/plonk/ZoneSetCanvas.swift
@@ -66,7 +66,7 @@ struct ZoneSetCanvas: View {
         }
         return String(localized: .zoneSetSummary(screen + 1, size,
                                                  String(localized: .zoneSetZoneCount(zones.count)),
-                                                 Int(model.config.zoneGap)))
+                                                 Int(model.config.zoneGap(forSet: assigned))))
     }
 
     private var actions: some View {

--- a/App/Tests/plonkTests/ZoneGapConfigTests.swift
+++ b/App/Tests/plonkTests/ZoneGapConfigTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import plonk
+
+/// A zone set's own gap in config: which screen gets it, and what happens to
+/// it when the set goes.
+struct ZoneGapConfigTests {
+    @Test func forgettingASetDropsItsGap() {
+        var config = Config()
+        config.zoneSets["Mine"] = [ZoneRect(0, 0, 1, 1)]
+        config.zoneSetGaps["Mine"] = 12
+        config.forgetZoneSet(named: "Mine")
+        #expect(config.zoneSetGaps["Mine"] == nil)
+    }
+
+    @Test func aSetGapOverridesTheDefaultOnlyForThatSet() {
+        var config = Config()
+        config.zoneGap = 8
+        config.zoneSets["Airy"] = [ZoneRect(0, 0, 1, 1)]
+        config.zoneSetGaps["Airy"] = 24
+        config.assignZoneSet("Airy", forKeys: ["uuid-1"])
+        config.assignZoneSet("Thirds", forKeys: ["uuid-2"])
+        #expect(config.zoneGap(forKeys: ["uuid-1"]) == 24)
+        #expect(config.zoneGap(forKeys: ["uuid-2"]) == 8)
+        // An unassigned screen wears the default set, which can have its own.
+        #expect(config.zoneGap(forKeys: ["uuid-3"]) == 8)
+        config.zoneSetGaps[BuiltinZoneSets.defaultName] = 2
+        #expect(config.zoneGap(forKeys: ["uuid-3"]) == 2)
+    }
+
+    @Test func setGapsAreClampedLikeTheDefault() {
+        var config = Config()
+        config.zoneSetGaps["Wild"] = Config.gapLimit + 100
+        config.zoneSetGaps["Neg"] = -5
+        config.clamp()
+        #expect(config.zoneSetGaps["Wild"] == Config.gapLimit)
+        #expect(config.zoneSetGaps["Neg"] == 0)
+    }
+}

--- a/App/Tests/plonkTests/ZoneGapRoutesTests.swift
+++ b/App/Tests/plonkTests/ZoneGapRoutesTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import plonk
+
+/// A zone set's own gap, over the wire: how it is given, kept, dropped and read.
+struct ZoneGapRoutesTests {
+    @Test func savingAZoneSetCanGiveItAGap() {
+        let h = RouterHarness()
+        let zones: [[String: Any]] = [["x": 0, "y": 0, "w": 1, "h": 1]]
+        #expect(h.post("/zones/save", ["name": "airy", "zones": zones, "gap": 20]).status == 200)
+        #expect(h.store.config.zoneSetGaps["airy"] == 20)
+        // Saving without a gap leaves the one it has.
+        #expect(h.post("/zones/save", ["name": "airy", "zones": zones]).status == 200)
+        #expect(h.store.config.zoneSetGaps["airy"] == 20)
+        // Null puts it back on the default.
+        #expect(h.post("/zones/save", ["name": "airy", "zones": zones, "gap": NSNull()]).status == 200)
+        #expect(h.store.config.zoneSetGaps["airy"] == nil)
+        #expect(h.post("/zones/save", ["name": "airy", "zones": zones, "gap": -1]).status == 400)
+        #expect(h.post("/zones/save", ["name": "airy", "zones": zones, "gap": "wide"]).status == 400)
+    }
+
+    @Test func stateListsTheDefaultGapAndTheSetsThatKeepTheirOwn() {
+        let h = RouterHarness()
+        let zones: [[String: Any]] = [["x": 0, "y": 0, "w": 1, "h": 1]]
+        _ = h.post("/zones/save", ["name": "airy", "zones": zones, "gap": 20])
+        let state = h.get("/state").json
+        #expect((state["zone_set_gaps"] as? [String: Double]) == ["airy": 20])
+        #expect(state["zone_gap"] as? Double == h.store.config.zoneGap)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ one of those.
 
 ### Added
 
+- **A layout can keep its own gap.** The gap in Zones › Overlay is the default;
+  the editor's Gap row lets one layout set its own number of points instead,
+  or go back to following the default. Six narrow zones can sit tight while a
+  two-zone layout keeps its air. Drag snapping, numbered zones, previews and
+  the flash all draw and place with the gap of the set on that screen.
+  `save_zone_set` takes `gap` (points, or `null` for the default) and
+  `get_state` lists `zone_gap` and `zone_set_gaps`.
 - **Switching from Rectangle costs nothing now.** The ten placement shortcuts
   were already the same keys in both apps — `⌃⌥` and an arrow, a corner letter,
   return or C — because that is the one combination macOS leaves alone and both

--- a/docs/zones.md
+++ b/docs/zones.md
@@ -25,7 +25,7 @@ it.
 | **Or hover the line** | Bring the cursor near the border between two zones and both light up, no modifier at all |
 | **Whole sets** | `⌃⌥⇧1`–`⌃⌥⇧9` swap the set on the screen the cursor is on. Windows already sitting in a numbered zone move to where that number is now |
 | **Picking one** | `⌃⌥L` draws the sets for that screen as a list: arrows or the digit to pick, `return` to use it, `E` to open it in the editor, `N` for a new one |
-| **Looks** | Gap, colour, opacity, numbers on or off, every monitor's zones shown while dragging. The gap is real — a window keeps that much space around it |
+| **Looks** | Gap, colour, opacity, numbers on or off, every monitor's zones shown while dragging. The gap is real — a window keeps that much space around it. That gap is the default; a layout can set its own in the editor's Gap row, or follow the default again |
 | **Exceptions** | A list of apps Plonk keeps its hands off — games, remote desktops, anything that manages its own geometry. Asking an agent to place one still works; that names the window on purpose |
 | **New windows** | Optionally, a window that opens goes where that app's last one went |
 

--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -74,6 +74,8 @@ export interface State {
   saved_layouts: string[];
   workspaces: Record<string, Workspace>;
   zone_sets: Record<string, Frame[]>;
+  zone_gap: number;
+  zone_set_gaps: Record<string, number>;
   screen_zone_sets: Record<string, string>;
   screens: Screen[];
   windows: WindowInfo[];

--- a/mcp/src/tools/zones.ts
+++ b/mcp/src/tools/zones.ts
@@ -6,14 +6,20 @@ import { zonesSchema } from "../schemas.js";
 export function register(server: McpServer): void {
   server.tool(
     "save_zone_set",
-    "Create or replace a named zone set used for drag snapping. Zones are rectangles {x,y,w,h} as fractions 0..1 of a screen's visible area, origin TOP-LEFT; each zone must stay inside the screen, but zones may overlap each other (the smallest one under the cursor wins). Pass 'screen' to also assign the set to that monitor so it becomes active immediately. Built-in sets already exist: Halves, Thirds, 60 / 40, Quarters, Priority.",
+    "Create or replace a named zone set used for drag snapping. Zones are rectangles {x,y,w,h} as fractions 0..1 of a screen's visible area, origin TOP-LEFT; each zone must stay inside the screen, but zones may overlap each other (the smallest one under the cursor wins). Pass 'screen' to also assign the set to that monitor so it becomes active immediately. Pass 'gap' to give this set its own spacing around windows in points, or null to make it follow the default gap again; omitting it keeps whatever the set had. Built-in sets already exist: Halves, Thirds, 60 / 40, Quarters, Priority.",
     {
       name: z.string().describe("Zone set name, e.g. 'coding'"),
       zones: zonesSchema,
       screen: z.number().int().optional().describe("Monitor index to assign this set to (0 = primary)"),
+      gap: z
+        .number()
+        .min(0)
+        .nullable()
+        .optional()
+        .describe("This set's own gap in points; null follows the default gap (get_state.zone_gap); omit to leave unchanged"),
     },
-    async ({ name, zones, screen }) =>
-      text(await call("/zones/save", { method: "POST", body: { name, zones, screen } }))
+    async ({ name, zones, screen, gap }) =>
+      text(await call("/zones/save", { method: "POST", body: { name, zones, screen, gap } }))
   );
 
   server.tool(


### PR DESCRIPTION
The gap in Zones > Overlay becomes the default. A layout can set its own gap in the editor's new Gap row (Default / Own + points), or go back to following the default.

- `Config.zoneSetGaps` maps set name to points; `zoneGap(forSet:)` and `zoneGap(forKeys:)` resolve to the set's own or the default. Clamped like the default, dropped with the set, moved on rename.
- Every consumer of the gap now asks per screen: drag snapping (drawn and applied), numbered zones, relayout and restore, new-window placement, the flash, the picker preview (which uses the previewed set's gap, not the assigned one), and `snap_window` into a zone.
- `POST /zones/save` and `save_zone_set` take `gap` (points, or `null` for the default; absent leaves it unchanged). `get_state` lists `zone_gap` and `zone_set_gaps`.
- Zones page summary shows the gap that applies to the assigned set. The tuning field is labelled "Default gap".

Tests: config resolution, clamping, forget; route save/keep/null/invalid, state. 461 pass, lint and strings clean, MCP typecheck and tests pass.