### PR TITLE
zones: draw the gap where the zones are drawn

### DIFF
--- a/App/Sources/plonk/AppDelegate+Model.swift
+++ b/App/Sources/plonk/AppDelegate+Model.swift
@@ -128,6 +128,7 @@ extension AppDelegate {
     func refreshScreenModel() {
         model.screenCount = NSScreen.screens.count
         model.screenDescriptions = NSScreen.screens.map { "\(Int($0.frame.width)) × \(Int($0.frame.height))" }
+        model.screenSizes = NSScreen.screens.map(\.visibleFrame.size)
         refreshScreenAssignments()
     }
 

--- a/App/Sources/plonk/AppModel.swift
+++ b/App/Sources/plonk/AppModel.swift
@@ -110,6 +110,8 @@ final class AppModel: ObservableObject {
     @Published var screenAssignments: [Int: String] = [:]
     @Published var screenCount = 1
     @Published var screenDescriptions: [String] = []
+    /// Each screen's visible area in points, for drawing to scale.
+    @Published var screenSizes: [CGSize] = []
     @Published var accessibilityGranted = false
     @Published var screenRecordingGranted = false
     @Published var apiWarning: String?
@@ -210,6 +212,10 @@ extension AppModel {
     /// The size line for a screen, or nothing for one that has gone away.
     func screenDescription(_ index: Int) -> String {
         screenDescriptions.indices.contains(index) ? screenDescriptions[index] : ""
+    }
+
+    func screenSize(_ index: Int) -> CGSize {
+        screenSizes.indices.contains(index) ? screenSizes[index] : CGSize(width: 1440, height: 900)
     }
 
     /// A zone set name nobody has taken, which is `base` itself when it is free.

--- a/App/Sources/plonk/FullscreenZoneEditorView.swift
+++ b/App/Sources/plonk/FullscreenZoneEditorView.swift
@@ -25,7 +25,8 @@ struct FullscreenZoneEditorView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             Color.black.opacity(0.35).ignoresSafeArea()
-            ZoneCanvas(zones: draft, editable: true, fullscreen: true, selected: selected) { draft = $0 }
+            ZoneCanvas(zones: draft, editable: true, fullscreen: true, selected: selected,
+                       gap: gap ?? model.config.zoneGap) { draft = $0 }
                 .ignoresSafeArea()
             // Sits behind the panel and takes nothing but keys, so the mouse
             // still reaches the canvas.

--- a/App/Sources/plonk/ZoneCanvas.swift
+++ b/App/Sources/plonk/ZoneCanvas.swift
@@ -10,6 +10,10 @@ struct ZoneCanvas: View {
     var fullscreen = false
     /// Ringed while the keyboard is editing it.
     var selected: Int?
+    /// Fullscreen only: the set's gap in points, drawn as the inset a window
+    /// gets, so the editor shows the layout the way it will land. Nil keeps
+    /// the hairline gutter the thumbnails use.
+    var gap: Double?
     var onChange: (([ZoneRect]) -> Void)?
 
     private struct Edges: OptionSet {
@@ -41,10 +45,12 @@ struct ZoneCanvas: View {
                     RoundedRectangle(cornerRadius: 6).fill(Color.gray.opacity(0.12))
                     RoundedRectangle(cornerRadius: 6).strokeBorder(Color.gray.opacity(0.35))
                 }
+                let inset = gap.map { CGFloat($0) } ?? 2
                 ForEach(Array(shown.enumerated()), id: \.offset) { index, z in
                     zoneView(z, index: index, shown: shown, size: geo.size)
-                        .frame(width: max(z.w * geo.size.width - 4, 8), height: max(z.h * geo.size.height - 4, 8))
-                        .offset(x: z.x * geo.size.width + 2, y: z.y * geo.size.height + 2)
+                        .frame(width: max(z.w * geo.size.width - 2 * inset, 8),
+                               height: max(z.h * geo.size.height - 2 * inset, 8))
+                        .offset(x: z.x * geo.size.width + inset, y: z.y * geo.size.height + inset)
                         // Sized and placed by the modifiers above, so the ring
                         // only has to fill what it is drawn over.
                         .overlay {

--- a/App/Sources/plonk/ZoneOverlay.swift
+++ b/App/Sources/plonk/ZoneOverlay.swift
@@ -122,8 +122,8 @@ final class ZoneOverlay {
         // The gap is drawn as well as applied, so the overlay is a preview of
         // where the window will actually land — which means it is clamped the
         // same way, or a wide gap on a narrow zone draws a rect that no window
-        // will ever be given. Five points is the inset the rounded corners need
-        // to read as separate tiles at all.
+        // will ever be given. And nothing but the gap: a layout with gap 0
+        // draws zones that touch, because that is where its windows go.
 
         for (index, z) in zones.enumerated() {
             let rect = NSRect(
@@ -131,7 +131,7 @@ final class ZoneOverlay {
                 y: visible.height - (z.y + z.h) * visible.height,
                 width: z.w * visible.width,
                 height: z.h * visible.height
-            ).insetBy(dx: 5, dy: 5)
+            )
             let gapped = ZoneGeometry.inset(rect, by: appearance.gap)
 
             let view = NSView(frame: gapped)

--- a/App/Sources/plonk/ZoneSetCanvas.swift
+++ b/App/Sources/plonk/ZoneSetCanvas.swift
@@ -28,6 +28,8 @@ struct ZoneSetCanvas: View {
     }
 
     private var zones: [ZoneRect] { model.zones(onScreen: screen) }
+    /// The gap the set on this screen keeps, in points on the real screen.
+    private var gap: Double { model.config.zoneGap(forSet: assigned) }
     private var size: String { model.screenDescription(screen) }
 
     var body: some View {
@@ -171,9 +173,14 @@ struct ZoneSetCanvas: View {
     }
 
     private func tile(index: Int, zone: ZoneRect, in size: CGSize) -> some View {
+        // The canvas is the screen to scale, so the gap is too: the same
+        // points on the real screen, shrunk by the same factor as the zones,
+        // and a window's inset drawn on every side the way ZoneGeometry.inset
+        // applies it. Gap 0 draws zones that touch, which is what happens.
+        let inset = gap * size.width / max(model.screenSize(screen).width, 1)
         // Colour is the zone number, and the fraction printed on it is the same
         // number an agent sends over MCP, so the picture and the API agree.
-        RoundedRectangle(cornerRadius: 9, style: .continuous)
+        return RoundedRectangle(cornerRadius: 9, style: .continuous)
             .fill(Ink.zoneGradient(index))
             .overlay(alignment: .bottomLeading) {
                 Text("\(index + 1)")
@@ -187,9 +194,9 @@ struct ZoneSetCanvas: View {
                     .foregroundStyle(Ink.zoneInk(index).opacity(0.85))
                     .padding(9)
             }
-            .frame(width: max(zone.w * size.width - 5, 1),
-                   height: max(zone.h * size.height - 5, 1))
-            .offset(x: zone.x * size.width + 2.5, y: zone.y * size.height + 2.5)
+            .frame(width: max(zone.w * size.width - 2 * inset, 1),
+                   height: max(zone.h * size.height - 2 * inset, 1))
+            .offset(x: zone.x * size.width + inset, y: zone.y * size.height + inset)
     }
 
     /// "0.22 × 0.5". Two decimals, and no trailing zeros to read past.


### PR DESCRIPTION
Follow-up to #89. The gap is now visible everywhere zones are drawn, at the value the layout actually uses:

- Zones page canvas: each tile inset by the gap of the set on that screen, scaled to the canvas.
- Fullscreen editor: tiles inset by the gap live as the Gap row changes (Default or Own).
- Drag overlay: previously added a fixed 5 pt inset on top of the gap, so gap 0 still showed seams while windows landed flush. Removed; the overlay draws exactly the gap.

Also `AppModel.screenSizes` (visible area per screen) so the canvas can scale points.

461 tests pass.