### PR TITLE
ui: one click no longer launches a workspace or swaps a zone set

### DIFF
--- a/App/Sources/plonk/MainSidebar.swift
+++ b/App/Sources/plonk/MainSidebar.swift
@@ -136,9 +136,12 @@ struct MainSidebar: View {
     private var workspaces: some View {
         VStack(alignment: .leading, spacing: 1) {
             heading(.appWorkspaces)
+            // A row opens the Workspaces page, where each one has its own
+            // Launch button. Launching opens apps and moves windows, and a
+            // sidebar click is too easy to land by accident for that.
             ForEach(model.workspaceNames.prefix(4), id: \.self) { name in
                 Button {
-                    model.actions?.launchWorkspace(named: name, onScreen: nil)
+                    model.selectedPage = "workspaces"
                 } label: {
                     HStack(spacing: 8) {
                         Image(systemName: "rectangle.3.group").font(.system(size: 12.5)).frame(width: 16)
@@ -151,7 +154,7 @@ struct MainSidebar: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help(String(localized: .appLaunchWorkspace(name)))
+                .help(String(localized: .appOpenWorkspace(name)))
             }
         }
     }

--- a/App/Sources/plonk/Resources/en.lproj/Localizable.strings
+++ b/App/Sources/plonk/Resources/en.lproj/Localizable.strings
@@ -365,7 +365,7 @@
 "app.nameVersion %@" = "Plonk %@";
 "app.runACommand" = "Run a command";
 "app.workspaces" = "Workspaces";
-"app.launchWorkspace %@" = "Launch %@";
+"app.openWorkspace %@" = "Open %@ in Workspaces";
 "app.reportBug" = "Report a Bug";
 "app.allPermissionsGranted" = "All permissions granted";
 "app.accessibility" = "Accessibility";
@@ -490,7 +490,7 @@
 "zoneSet.editThis" = "Edit this set";
 "zoneSet.editCopy" = "Edit a copy of this template";
 "zoneSet.hintPick" = "pick";
-"zoneSet.hintUse" = "use it";
+"zoneSet.hintUse" = "or double-click to use it";
 "zoneSet.hintEdit" = "edit";
 "zoneSet.hintNew" = "new";
 "zoneSet.hintClose" = "close";

--- a/App/Sources/plonk/Strings+Window.swift
+++ b/App/Sources/plonk/Strings+Window.swift
@@ -22,8 +22,8 @@ extension LocalizedStringResource {
         Self.key("app.nameVersion \(version)")
     }
 
-    static func appLaunchWorkspace(_ name: String) -> LocalizedStringResource {
-        Self.key("app.launchWorkspace \(name)")
+    static func appOpenWorkspace(_ name: String) -> LocalizedStringResource {
+        Self.key("app.openWorkspace \(name)")
     }
 
     static func appAgentCount(_ count: Int) -> LocalizedStringResource {

--- a/App/Sources/plonk/ZoneSetPaletteView.swift
+++ b/App/Sources/plonk/ZoneSetPaletteView.swift
@@ -122,7 +122,11 @@ struct ZoneSetPaletteView: View {
             Rectangle().fill(selected ? Color.accentColor : .clear).frame(width: 2.5)
         }
         .contentShape(Rectangle())
-        .onTapGesture { selection = index; apply(row) }
+        // A single click only moves the highlight, the same as an arrow key: a
+        // relayout moves every window on the screen, and one stray click should
+        // not be enough to do that. Return or a double click commits.
+        .onTapGesture(count: 2) { selection = index; apply(row) }
+        .onTapGesture(count: 1) { selection = index }
         .id(row.id)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ one of those.
 
 ### Fixed
 
+- **A single click no longer moves your windows.** Clicking a workspace in the
+  sidebar launched it on the spot, and clicking a row in the zone set palette
+  swapped the layout and relaid out every window on the screen. Both were one
+  stray click away from a mess. The sidebar row now opens the Workspaces page,
+  where each workspace has its own Launch button; in the palette a click only
+  moves the highlight, and return, a digit or a double click applies it.
 - **`snap_window` with a title that matches nothing no longer reports the app
   as not running.** Placing a window into a zone by app and title, without
   naming a screen, looked for the window one way and moved it another: the


### PR DESCRIPTION
## What

- Sidebar Workspaces rows opened a workspace on a single click (apps launched, windows moved). They now open the Workspaces page, which already has a Launch button and a per-monitor menu for each workspace.
- Zone set palette rows applied the set and relaid out every window on a single click. A click now only moves the highlight; return, a digit or a double click applies. Footer hint updated.

## Why

Both were one accidental click away from rearranging the desktop, with no undo. Reported after it happened several times.

## Ran

- `cd App && swift build`
- `./scripts/test.sh` (461 tests pass)
- `node scripts/check-strings.mjs`
- `./scripts/build.sh`, launched Plonk.app, checked both paths by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)