### PR TITLE
fix: tell a shell user where Plonk.app comes from when it is not running

### DIFF
--- a/mcp/src/api.ts
+++ b/mcp/src/api.ts
@@ -2,6 +2,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
 import type { workspaceItemsSchema } from "./schemas.js";
+import { notRunningMessage } from "./messages.js";
 
 export const BASE = "http://127.0.0.1:43917";
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -114,9 +115,6 @@ export interface ApiError {
 }
 
 export type ApiResponse = Record<string, unknown>;
-
-const NOT_RUNNING =
-  "Plonk menu bar app is not running. Ask the user to launch Plonk.app (its icon should appear in the menu bar).";
 
 // Stamped on every request so the app can attribute it to a client and, in
 // exclusive mode, gate on it. One mechanism, one shape: the identity always
@@ -273,7 +271,7 @@ export async function call<T extends object = ApiResponse>(
     if (timeout.aborted) {
       return { error: `Plonk did not answer within ${timeoutMs / 1000}s. It may be waiting on a dialog.` };
     }
-    return { error: NOT_RUNNING };
+    return { error: notRunningMessage(agentIdentityName()) };
   }
 
   const text = await res.text();

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -7,6 +7,7 @@
 import { spawn } from "node:child_process";
 import { BASE, call, INTERACTIVE_TIMEOUT_MS, processIdentityHolder, type State } from "./api.js";
 import { options } from "./args.js";
+import { CLI_NAME } from "./messages.js";
 
 const USAGE = `plonk — drive the Plonk menu bar app from a shell
 
@@ -235,7 +236,7 @@ async function main(): Promise<void> {
 
 // Named so the app can attribute the calls, and so "only the active agent
 // controls" can be pointed at the shell like anything else.
-processIdentityHolder().identity = { name: "plonk-cli", version: "", pid: process.pid };
+processIdentityHolder().identity = { name: CLI_NAME, version: "", pid: process.pid };
 try {
   await main();
 } catch (err) {

--- a/mcp/src/messages.ts
+++ b/mcp/src/messages.ts
@@ -1,0 +1,20 @@
+// Errors the client composes itself, worded for whoever will read them.
+
+/** The identity `plonk` registers before its first call, so a refusal can be
+ * addressed to a person at a prompt rather than to a model. */
+export const CLI_NAME = "plonk-cli";
+
+const NOT_RUNNING_FOR_AGENT =
+  "Plonk menu bar app is not running. Ask the user to launch Plonk.app (its icon should appear in the menu bar).";
+
+// A person who ran `npm i -g plonk-mcp` first has no reason to know the app is
+// a separate install, so the cask is the useful half of this sentence.
+const NOT_RUNNING_FOR_CLI =
+  "Plonk.app is not running. Launch it (its icon appears in the menu bar), or install it first: brew install --cask ostapondo/plonk/plonk";
+
+/** The refused-connection message for the client named `agent`. Same cause
+ * either way; the CLI's form tells the reader what to do instead of telling
+ * them to ask themselves. */
+export function notRunningMessage(agent: string): string {
+  return agent === CLI_NAME ? NOT_RUNNING_FOR_CLI : NOT_RUNNING_FOR_AGENT;
+}

--- a/mcp/test/api.test.js
+++ b/mcp/test/api.test.js
@@ -6,6 +6,7 @@ import {
   runWithIdentity,
   processIdentityHolder,
 } from "../dist/api.js";
+import { notRunningMessage, CLI_NAME } from "../dist/messages.js";
 
 test("a reply carrying an error is flagged as one", () => {
   // Without isError the model reads a refusal as a successful call and carries
@@ -57,4 +58,17 @@ test("the process-wide holder is the one stdio fills", () => {
   } finally {
     holder.identity = undefined;
   }
+});
+
+test("a refused connection tells an agent to ask the user", () => {
+  assert.match(notRunningMessage("claude-code"), /Ask the user/);
+});
+
+test("a refused connection tells a person at the shell where the app comes from", () => {
+  // `plonk state` goes through the same call() as the tools, but the reader is
+  // the user: "ask the user" would mean asking themselves, and someone who
+  // installed the npm package first may not know there is a separate app.
+  const message = notRunningMessage(CLI_NAME);
+  assert.doesNotMatch(message, /Ask the user/);
+  assert.match(message, /brew install --cask ostapondo\/plonk\/plonk/);
 });


### PR DESCRIPTION
## What changed, and why

Closes #21. The refused-connection message in `mcp/src/api.ts` was written for an agent, but `plonk state` goes through the same `call()`, so a person with the app closed was told to ask themselves to launch it. `call()` now picks the message by the identity the surface already set: `cli.ts` registers as `plonk-cli`, and that reader gets told to launch Plonk.app or install the cask (`brew install --cask ostapondo/plonk/plonk`), which someone who ran `npm i -g plonk-mcp` first has no reason to know about. The MCP path returns the same text as before.

The two messages and the picker live in a new `mcp/src/messages.ts` because `api.ts` was already at the 300-line limit and the lint refuses to let it grow.

## What you ran

```
(cd mcp && npm ci && npm test)   # 29 pass, 0 fail
./scripts/lint.sh                # clean
```

## Checks

- [x] New logic is covered in `mcp/test/api.test.js`
- [x] Commits use `fix:`
- [x] No change to the network, permissions, entitlements or update path