### PR TITLE
ui: the sidebar is a panel set into the window, and the page comes forward

### DIFF
--- a/App/Sources/plonk/AppearancePage.swift
+++ b/App/Sources/plonk/AppearancePage.swift
@@ -77,12 +77,37 @@ struct AppearancePage: View {
     }
 
     private var accents: some View {
+        // The swatches and the switch share a line where there is room and
+        // stack where there is not; either way the label stays on one line
+        // instead of folding into a column beside the switch.
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 9) {
+                swatches
+                Spacer(minLength: 12)
+                systemAccent
+            }
+            VStack(alignment: .leading, spacing: 12) {
+                swatches
+                systemAccent
+            }
+        }
+        .padding(13)
+        .card()
+    }
+
+    private var swatches: some View {
         HStack(spacing: 9) {
             ForEach(AppearanceSettings.accentChoices, id: \.self) { hex in
                 swatch(hex)
             }
-            Spacer(minLength: 8)
+        }
+        .fixedSize()
+    }
+
+    private var systemAccent: some View {
+        HStack(spacing: 9) {
             Text(.appearanceMatchSystemAccent).font(.system(size: 12)).foregroundStyle(.secondary)
+                .lineLimit(1)
             Toggle("", isOn: Binding(
                 get: { model.config.appearance.accentHex == nil },
                 set: { chooseAccent($0 ? nil : AppearanceSettings.accentChoices.last) }
@@ -90,8 +115,7 @@ struct AppearancePage: View {
             .labelsHidden().toggleStyle(.switch).controlSize(.small)
             .help(String(localized: .appearanceFollowSystemAccent))
         }
-        .padding(13)
-        .card()
+        .fixedSize()
     }
 
     private func swatch(_ hex: String) -> some View {

--- a/App/Sources/plonk/ExcludedApps.swift
+++ b/App/Sources/plonk/ExcludedApps.swift
@@ -27,26 +27,19 @@ struct ExcludedApps: View {
         ForEach(model.config.excludedApps, id: \.self) { pattern in
             row(for: pattern)
         }
-        HStack(spacing: 8) {
-            Button(String(localized: .excludedChooseApp), action: chooseApp)
-            Menu(String(localized: .excludedAddRunning)) {
-                ForEach(running, id: \.bundleIdentifier) { app in
-                    Button(app.localizedName ?? String(localized: .excludedUnnamed)) {
-                        add(app.bundleIdentifier ?? app.localizedName ?? "")
-                    }
-                }
+        // One line where there is room, two where there is not: a button
+        // squeezed to "Choo…" is not a button, so the pickers keep their width
+        // and the typed-name field is what gives.
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                pickers
+                Spacer(minLength: 8)
+                typedName
             }
-            .fixedSize()
-            Spacer(minLength: 8)
-            // The escape hatch for anything the two buttons above cannot
-            // reach: a helper process, a game that is not installed yet, or a
-            // word that should match a family of apps.
-            TextField(String(localized: .excludedOrType), text: $typed)
-                .textFieldStyle(.roundedBorder)
-                .frame(width: 150)
-                .onSubmit { add(typed) }
-            Button(String(localized: .excludedAdd)) { add(typed) }
-                .disabled(typed.trimmingCharacters(in: .whitespaces).isEmpty)
+            VStack(alignment: .leading, spacing: 8) {
+                pickers
+                typedName
+            }
         }
         .onAppear { running = AppPicker.runningApps }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
@@ -54,6 +47,37 @@ struct ExcludedApps: View {
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)) { _ in
             running = AppPicker.runningApps
+        }
+    }
+
+    private var pickers: some View {
+        HStack(spacing: 8) {
+            Button(String(localized: .excludedChooseApp), action: chooseApp)
+                .buttonStyle(.chip)
+            Menu(String(localized: .excludedAddRunning)) {
+                ForEach(running, id: \.bundleIdentifier) { app in
+                    Button(app.localizedName ?? String(localized: .excludedUnnamed)) {
+                        add(app.bundleIdentifier ?? app.localizedName ?? "")
+                    }
+                }
+            }
+        }
+        .fixedSize()
+    }
+
+    /// The escape hatch for anything the two buttons cannot reach: a helper
+    /// process, a game that is not installed yet, or a word that should match
+    /// a family of apps.
+    private var typedName: some View {
+        HStack(spacing: 8) {
+            TextField(String(localized: .excludedOrType), text: $typed)
+                .textFieldStyle(.roundedBorder)
+                .frame(minWidth: 120, maxWidth: 190)
+                .onSubmit { add(typed) }
+            Button(String(localized: .excludedAdd)) { add(typed) }
+                .buttonStyle(.chip)
+                .fixedSize()
+                .disabled(typed.trimmingCharacters(in: .whitespaces).isEmpty)
         }
     }
 

--- a/App/Sources/plonk/HomeStatus.swift
+++ b/App/Sources/plonk/HomeStatus.swift
@@ -9,10 +9,7 @@ struct HomeStatus: View {
     @ObservedObject var model: AppModel
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            agents
-            api
-        }
+        Columns { agents } trailing: { api }
     }
 
     // MARK: - Agents

--- a/App/Sources/plonk/Ink+Zones.swift
+++ b/App/Sources/plonk/Ink+Zones.swift
@@ -64,6 +64,15 @@ extension Ink {
             : .white
     }
 
+    /// Toward ink: the same hue, more saturated and darker, for a glyph or a
+    /// line on a light surface. Sun at full brightness is invisible there.
+    static func deeper(_ color: Color) -> Color {
+        rebuilt(color) { _, saturation, brightness in
+            saturation = min(saturation + 0.15, 1)
+            brightness = max(brightness - 0.22, 0)
+        }
+    }
+
     /// Toward white, in HSB, so a mint stays mint instead of turning grey the
     /// way a straight blend with white would.
     static func lighter(_ color: Color) -> Color {

--- a/App/Sources/plonk/Ink.swift
+++ b/App/Sources/plonk/Ink.swift
@@ -1,50 +1,63 @@
 import AppKit
 import SwiftUI
 
-// The look every page is built from: three surfaces, one hairline, one radius.
+// The look every page is built from: four surfaces, one hairline, one radius.
 //
-// Stated as real colours rather than opacities over whatever macOS supplies.
-// Tinted greys layered on the window background gave two panes that were nearly
-// the same value, and the whole window read flat; a page that is definitely
-// darker than its cards is what makes the cards look like cards.
+// The window is a dark ground. The sidebar is a panel set into it, a step
+// darker; every card on a page is a step lighter. That order is the whole
+// design: the menu recedes, the page comes forward, and the ground between them
+// is what makes both read as things rather than as one flat sheet.
 //
 // Both themes are spelled out because the app has a theme of its own now: a
 // window forced to light while the system is dark cannot ask NSColor what grey
 // to use and get an answer that suits the window it is actually in.
 
 enum Ink {
-    static let radius: CGFloat = 11
+    static let radius: CGFloat = 16
+    /// The sidebar panel's corner, and how far it sits from the window edge.
+    static let panelRadius: CGFloat = 14
+    static let inset: CGFloat = 12
 
-    /// Behind the pages. The sidebar keeps the system material, and this sits
-    /// beside it, a shade further back.
+    /// The ground: what the window is, behind the sidebar and the page.
     static func page(_ scheme: ColorScheme) -> Color {
-        scheme == .dark ? Color(red: 0.047, green: 0.051, blue: 0.067)
-                        : Color(red: 0.957, green: 0.961, blue: 0.973)
+        scheme == .dark ? Color(red: 0.141, green: 0.141, blue: 0.165)
+                        : Color(red: 0.945, green: 0.947, blue: 0.961)
     }
 
-    /// The bar above the page: a shade in front of it, so the page reads as
-    /// something the window contains rather than as the window itself.
-    static func chrome(_ scheme: ColorScheme) -> Color {
-        scheme == .dark ? Color(red: 0.067, green: 0.075, blue: 0.098) : .white
+    /// The sidebar panel, a step behind the ground.
+    static func sidebar(_ scheme: ColorScheme) -> Color {
+        scheme == .dark ? Color(red: 0.063, green: 0.063, blue: 0.075)
+                        : Color(red: 0.796, green: 0.812, blue: 0.859)
     }
 
-    /// Everything that is not the page background sits on one of these.
+    /// The bar above a page where one still has one. Same as the ground: the
+    /// window has one surface behind everything now, not two.
+    static func chrome(_ scheme: ColorScheme) -> Color { page(scheme) }
+
+    /// Everything that is not the ground sits on one of these, a step in front.
     static func card(_ scheme: ColorScheme) -> Color {
-        scheme == .dark ? Color(red: 0.086, green: 0.098, blue: 0.129) : .white
+        scheme == .dark ? Color(red: 0.204, green: 0.204, blue: 0.243) : .white
     }
 
     /// A step above a card: selected rows, insets, the strip behind a preview.
     static func raised(_ scheme: ColorScheme) -> Color {
-        scheme == .dark ? Color(red: 0.110, green: 0.125, blue: 0.161)
+        scheme == .dark ? Color(red: 0.255, green: 0.255, blue: 0.298)
                         : Color(red: 0.949, green: 0.953, blue: 0.969)
     }
 
+    /// The pill under the sidebar row that is open: a lift, not the accent.
+    /// The accent belongs to controls; a row that is merely where you are
+    /// does not need to shout it.
+    static func selection(_ scheme: ColorScheme) -> Color {
+        Color.primary.opacity(scheme == .dark ? 0.12 : 0.12)
+    }
+
     static func stroke(_ scheme: ColorScheme) -> Color {
-        Color.primary.opacity(scheme == .dark ? 0.10 : 0.09)
+        Color.primary.opacity(scheme == .dark ? 0.07 : 0.06)
     }
 
     static func shadow(_ scheme: ColorScheme) -> Color {
-        Color.black.opacity(scheme == .dark ? 0.32 : 0.06)
+        Color.black.opacity(scheme == .dark ? 0.24 : 0.10)
     }
 
     static var hairline: Color { Color.primary.opacity(0.08) }
@@ -146,7 +159,7 @@ private struct CardSurface: ViewModifier {
         // redrawn on each resize and scroll.
         return content
             .background(shape.fill(Ink.card(scheme))
-                .shadow(color: Ink.shadow(scheme), radius: 7, y: 2))
+                .shadow(color: Ink.shadow(scheme), radius: scheme == .dark ? 7 : 10, y: 3))
             .overlay(shape.strokeBorder(Ink.stroke(scheme)))
     }
 }
@@ -221,4 +234,33 @@ struct StatusPill: View {
         .background(Capsule().fill(ok ? Ink.card(scheme) : Color.orange.opacity(0.12)))
         .overlay(Capsule().strokeBorder(ok ? Ink.stroke(scheme) : Color.orange.opacity(0.35)))
     }
+}
+
+/// A button drawn as a chip: the label in the text colour on a lift off the
+/// card, or in white on the accent when it is the one thing to press. The
+/// system bordered button paints its label in the accent on a barely-there
+/// fill, which reads as a link on the dark card and gets lost next to a title.
+struct ChipButtonStyle: ButtonStyle {
+    var prominent = false
+    @Environment(\.colorScheme) private var scheme
+    @Environment(\.isEnabled) private var enabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 12.5, weight: .semibold))
+            .lineLimit(1)
+            .foregroundStyle(prominent ? Color.white : Color.primary)
+            .padding(.horizontal, 12)
+            .frame(height: 27)
+            .background(RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(prominent ? AnyShapeStyle(Color.accentColor)
+                                : AnyShapeStyle(Color.primary.opacity(scheme == .dark ? 0.10 : 0.07))))
+            .opacity(configuration.isPressed ? 0.7 : enabled ? 1 : 0.4)
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+extension ButtonStyle where Self == ChipButtonStyle {
+    static var chip: ChipButtonStyle { ChipButtonStyle() }
+    static var chipProminent: ChipButtonStyle { ChipButtonStyle(prominent: true) }
 }

--- a/App/Sources/plonk/MainSidebar.swift
+++ b/App/Sources/plonk/MainSidebar.swift
@@ -8,8 +8,11 @@ import SwiftUI
 // a click that told you nothing — a heading is not a control, and drawing it as
 // one only hid the list it was labelling. Headings now label; rows navigate.
 //
-// Metrics come from the design's macOS mock: a 220pt sidebar, 13pt rows, 11pt
-// headings, and a selected row that is the accent rather than a grey fill.
+// Metrics come from the design's macOS mock: a 228pt panel, 30pt rows at 13pt,
+// 11pt headings in plain case, and a selected row that is a lift off the panel
+// rather than a splash of accent. Colour is carried by the icons instead: each
+// destination's rows take one of the zone hues, so the menu reads in the same
+// palette as the zones it is about.
 
 struct MainSidebar: View {
     @ObservedObject var model: AppModel
@@ -19,10 +22,27 @@ struct MainSidebar: View {
 
     /// Clears the traffic lights: the window runs its content under the title
     /// bar, so the first thing in the sidebar would sit behind them.
-    private static let lights: CGFloat = 34
+    private static let lights: CGFloat = 40
 
     private func pages(of group: SettingsGroup) -> [SettingsPage] {
         model.settingsPages.filter { $0.parent == group.id }
+    }
+
+    /// The hue a destination's icons carry. Home and Layout share plum, the
+    /// app's own colour; the rest step through the palette in the order the
+    /// groups are listed.
+    private func hue(of group: SettingsGroup) -> Color {
+        let zone: Int
+        switch group.id {
+        case "capture": zone = 2
+        case "automation": zone = 3
+        case "settings": zone = 4
+        default: zone = 1
+        }
+        // The zone hues are tuned to fill a rectangle, and sun and mint are too
+        // pale to draw a 13pt glyph on a light panel. Pulled toward ink there,
+        // kept as they are on dark.
+        return scheme == .dark ? Ink.zone(zone) : Ink.deeper(Ink.zone(zone))
     }
 
     var body: some View {
@@ -36,13 +56,16 @@ struct MainSidebar: View {
                         // A destination holding one page is that page, and a
                         // heading over a list of one is noise.
                         if children.count > 1, !rail { heading(group.title) }
-                        ForEach(children) { row($0, icon: children.count > 1 ? $0.icon : group.icon) }
+                        ForEach(children) {
+                            row($0, icon: children.count > 1 ? $0.icon : group.icon, hue: hue(of: group))
+                        }
                     }
                     if !rail, !model.workspaceNames.isEmpty { workspaces }
                 }
                 .padding(.horizontal, 8)
                 .padding(.bottom, 10)
             }
+            if !rail { status }
             footer
         }
     }
@@ -53,23 +76,24 @@ struct MainSidebar: View {
         Button {
             model.actions?.openCommandPalette()
         } label: {
-            HStack(spacing: 7) {
-                Image(systemName: "magnifyingglass").font(.system(size: 12))
+            HStack(spacing: 9) {
+                Image(systemName: "magnifyingglass").font(.system(size: 12, weight: .medium))
                 if !rail {
                     Text(.appRunACommand).font(.system(size: 12.5))
                     Spacer(minLength: 0)
-                    Text("⌘K").font(.system(size: 11, design: .monospaced))
+                    Text("⌘K").font(.system(size: 11, design: .monospaced)).opacity(0.7)
                 }
             }
             .foregroundStyle(.secondary)
-            .padding(.horizontal, 9)
-            .frame(height: 27)
+            .padding(.horizontal, 10)
+            .frame(height: 30)
             .frame(maxWidth: .infinity, alignment: rail ? .center : .leading)
-            .background(RoundedRectangle(cornerRadius: 7, style: .continuous).fill(Ink.capFill))
+            .background(RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(Color.primary.opacity(0.08)))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 10)
         .padding(.bottom, 12)
         .help(String(localized: .appRunACommand))
     }
@@ -77,9 +101,11 @@ struct MainSidebar: View {
     // MARK: - Rows
 
     private func heading(_ title: LocalizedStringResource) -> some View {
-        Eyebrow(title, size: 11, kerning: 0.45)
-            .padding(.horizontal, 8)
-            .padding(.top, 9)
+        Text(title)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(.primary.opacity(0.4))
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
             .padding(.bottom, 4)
     }
 
@@ -96,36 +122,35 @@ struct MainSidebar: View {
         }
     }
 
-    private func row(_ page: SettingsPage, icon: String) -> some View {
+    private func row(_ page: SettingsPage, icon: String, hue: Color) -> some View {
         let selected = model.currentPage?.id == page.id
         return Button {
             model.selectedPage = page.id
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: 10) {
                 Image(systemName: icon)
-                    .font(.system(size: 12.5))
+                    .font(.system(size: rail ? 14 : 12.5, weight: .medium))
                     .frame(width: 16)
-                    .foregroundStyle(selected ? AnyShapeStyle(.white) : AnyShapeStyle(.secondary))
+                    .foregroundStyle(hue)
                 if !rail {
                     Text(page.title).font(.system(size: 13, weight: selected ? .semibold : .regular))
                     Spacer(minLength: 6)
                     if let badge = badge(page) {
                         Text(badge)
-                            .font(.system(size: 11, design: .monospaced))
+                            .font(.system(size: 11.5))
                             .lineLimit(1)
-                            .foregroundStyle(selected ? AnyShapeStyle(.white.opacity(0.75))
-                                                      : AnyShapeStyle(.tertiary))
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
-            .foregroundStyle(selected ? Color.white : Color.primary)
-            .padding(.horizontal, 8)
-            .frame(height: 27)
+            .foregroundStyle(Color.primary)
+            .padding(.leading, 12)
+            .padding(.trailing, 10)
+            .frame(height: 30)
             .frame(maxWidth: .infinity, alignment: rail ? .center : .leading)
             .background(
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .fill(selected ? AnyShapeStyle(Ink.gradient(model.accent))
-                                   : AnyShapeStyle(Color.clear))
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(selected ? Ink.selection(scheme) : Color.clear)
             )
             .contentShape(Rectangle())
         }
@@ -134,28 +159,63 @@ struct MainSidebar: View {
     }
 
     private var workspaces: some View {
-        VStack(alignment: .leading, spacing: 1) {
+        VStack(alignment: .leading, spacing: 2) {
             heading(.appWorkspaces)
             // A row opens the Workspaces page, where each one has its own
             // Launch button. Launching opens apps and moves windows, and a
             // sidebar click is too easy to land by accident for that.
-            ForEach(model.workspaceNames.prefix(4), id: \.self) { name in
+            ForEach(Array(model.workspaceNames.prefix(4).enumerated()), id: \.offset) { index, name in
                 Button {
                     model.selectedPage = "workspaces"
                 } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: "rectangle.3.group").font(.system(size: 12.5)).frame(width: 16)
+                    HStack(spacing: 10) {
+                        // A dot in a zone hue with the initial in it: the same
+                        // mark the workspace carries everywhere else it is
+                        // drawn, and colour in a menu that is otherwise grey.
+                        ZStack {
+                            Circle().fill(Ink.zone([0, 5, 4, 2][index % 4]))
+                            Text(String(name.prefix(1)).uppercased())
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(.white)
+                        }
+                        .frame(width: 16, height: 16)
                         Text(name).font(.system(size: 13)).lineLimit(1)
                         Spacer(minLength: 0)
                     }
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 8)
-                    .frame(height: 27)
+                    .foregroundStyle(Color.primary)
+                    .padding(.leading, 12)
+                    .padding(.trailing, 10)
+                    .frame(height: 30)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help(String(localized: .appOpenWorkspace(name)))
             }
+        }
+    }
+
+    // MARK: - Status
+
+    /// Whether the app can do its job, said only when something is wrong.
+    /// Three green chips that are green every day teach people to stop reading
+    /// them, and then the one that matters goes unread too. Agents that are
+    /// connected are a fact, not a fault, and sit in the footer.
+    @ViewBuilder private var status: some View {
+        if !model.allPermissionsGranted {
+            VStack(alignment: .leading, spacing: 5) {
+                if !model.accessibilityGranted {
+                    StatusPill(title: .appAccessibility, ok: false, fix: PrivacySettings.openAccessibility)
+                }
+                if !model.screenRecordingGranted {
+                    StatusPill(title: .appScreenRecording, ok: false,
+                               fix: PrivacySettings.openScreenRecording)
+                }
+                if let warning = model.apiWarning {
+                    StatusPill(title: .aiLocalApi, ok: false).help(warning)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 10)
         }
     }
 
@@ -186,6 +246,19 @@ struct MainSidebar: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                 Spacer(minLength: 0)
+                // Who is driving, in the same quiet type as the version: a
+                // green dot and a count, not a chip that outshouts the menu.
+                if !model.connectedAgents.isEmpty {
+                    HStack(spacing: 5) {
+                        Circle().fill(Color.green).frame(width: 5, height: 5)
+                        Text(.appAgentCount(model.connectedAgents.count))
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .help(model.connectedAgents.joined(separator: ", "))
+                    .padding(.trailing, 4)
+                }
                 Button { model.actions?.reportBug() } label: {
                     Image(systemName: "ladybug").font(.system(size: 12)).foregroundStyle(.secondary)
                 }

--- a/App/Sources/plonk/MainWindowView.swift
+++ b/App/Sources/plonk/MainWindowView.swift
@@ -1,54 +1,53 @@
 import AppKit
 import SwiftUI
 
-// The app's main window: sidebar, a bar that says where you are and whether
-// anything is wrong, and the page itself.
+// The app's main window: a sidebar set into the ground as its own panel, and
+// the page beside it.
 //
 // Deliberately not a NavigationSplitView: its collapse button hides the sidebar
 // outright and floats over the content pane. And no collapse button of our own
 // either, because a bare toggle sitting in the corner of a sidebar is not a
 // control macOS has. The sidebar drops to an icon rail on its own when the
 // window gets narrow, and never goes away.
+//
+// No bar over the page: the sidebar already says where you are, and the page
+// opens with its own title. Whether anything is wrong is said in the sidebar,
+// above the footer, and only when something is.
 
 struct MainWindowView: View {
     @ObservedObject var model: AppModel
     @Environment(\.colorScheme) private var scheme
 
-    private static let wide: CGFloat = 220
-    private static let rail: CGFloat = 58
-    private static let railBelow: CGFloat = 780
-    /// The unified toolbar height macOS uses, and the design with it.
-    private static let bar: CGFloat = 38
-
-    /// The page, and only the page. The destination it belongs to is a heading
-    /// in the sidebar now, so repeating it here said the same word twice.
-    private var title: String {
-        guard let current = model.currentPage else { return String(localized: .appName) }
-        return String(localized: current.title)
-    }
+    static let wide: CGFloat = 228
+    /// Wide enough for the traffic lights, which sit inside the panel now.
+    static let rail: CGFloat = 76
+    /// Under this window width the sidebar is the icon rail. The presenter
+    /// reads it too, to centre the traffic lights in whichever panel is drawn.
+    static let railBelow: CGFloat = 780
+    /// Between the sidebar panel and the page.
+    private static let gutter: CGFloat = 14
 
     var body: some View {
         GeometryReader { geo in
             let rail = geo.size.width < Self.railBelow
-            HStack(spacing: 0) {
+            HStack(spacing: Self.gutter) {
                 MainSidebar(model: model, rail: rail)
                     .frame(width: rail ? Self.rail : Self.wide)
-                    .background(VisualEffect(material: .sidebar, state: .followsWindowActiveState))
-                Divider()
-                VStack(spacing: 0) {
-                    topBar
-                    Divider()
-                    Group {
-                        if let current = model.currentPage { current.make(model) }
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(page)
+                    .background(RoundedRectangle(cornerRadius: Ink.panelRadius, style: .continuous)
+                        .fill(Ink.sidebar(scheme)))
+                    .overlay(RoundedRectangle(cornerRadius: Ink.panelRadius, style: .continuous)
+                        .strokeBorder(Ink.stroke(scheme)))
+                Group {
+                    if let current = model.currentPage { current.make(model) }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            .padding(Ink.inset)
+            .background(page)
         }
-        // The window hides its title bar so our own header is the only one, but
-        // the hosting view still insets the content by its height. Without this
-        // the top bar hangs below an empty strip the width of the window.
+        // The window hides its title bar so the sidebar reaches the top edge,
+        // but the hosting view still insets the content by its height. Without
+        // this everything hangs below an empty strip the width of the window.
         .ignoresSafeArea(.container, edges: .top)
         .frame(minWidth: 620, minHeight: 520)
         // Both, and deliberately: `tint` is what system controls read, and the
@@ -68,50 +67,17 @@ struct MainWindowView: View {
         .onAppear { if model.selectedPage == nil { model.selectedPage = model.settingsPages.first?.id } }
     }
 
-    // MARK: - Top bar
-
-    // Permissions only earn room when one is missing. Three chips that are
-    // green every day teach people to stop reading them, and then the one that
-    // matters goes unread too.
-    private var topBar: some View {
-        HStack(spacing: 7) {
-            Text(title).font(.system(size: 13, weight: .bold))
-            Spacer(minLength: 12)
-            if model.allPermissionsGranted {
-                StatusPill(title: .appAllPermissionsGranted, ok: true)
-            } else {
-                if !model.accessibilityGranted {
-                    StatusPill(title: .appAccessibility, ok: false, fix: PrivacySettings.openAccessibility)
-                }
-                if !model.screenRecordingGranted {
-                    StatusPill(title: .appScreenRecording, ok: false,
-                               fix: PrivacySettings.openScreenRecording)
-                }
-                if let warning = model.apiWarning {
-                    StatusPill(title: .aiLocalApi, ok: false).help(warning)
-                }
-            }
-            if !model.connectedAgents.isEmpty {
-                StatusPill(title: .appAgentCount(model.connectedAgents.count), ok: true)
-                    .help(model.connectedAgents.joined(separator: ", "))
-            }
-        }
-        // No search button here: the sidebar already carries "Run a command"
-        // with the same shortcut on it, and one way in is one way in.
-        .padding(.horizontal, 14)
-        .frame(height: Self.bar)
-        .background(Ink.chrome(scheme))
-    }
-
-    /// The page background, with the accent bleeding in from the corners the
-    /// way it does behind the hero. Flat charcoal is correct and lifeless; this
-    /// is the one place the window is allowed a bit of colour.
+    /// The ground: the desktop showing through, the page colour over it, and
+    /// the accent bleeding in from two corners the way it does behind the hero.
+    /// Flat charcoal is correct and lifeless; this is the one place the window
+    /// is allowed a bit of colour.
     private var page: some View {
         ZStack {
-            Ink.page(scheme)
-            RadialGradient(colors: [model.accent.opacity(scheme == .dark ? 0.16 : 0.10), .clear],
+            VisualEffect(material: .underWindowBackground, state: .followsWindowActiveState)
+            Ink.page(scheme).opacity(scheme == .dark ? 0.88 : 0.92)
+            RadialGradient(colors: [model.accent.opacity(scheme == .dark ? 0.16 : 0.20), .clear],
                            center: .init(x: 0.85, y: -0.05), startRadius: 0, endRadius: 620)
-            RadialGradient(colors: [Ink.warmer(model.accent).opacity(scheme == .dark ? 0.10 : 0.07),
+            RadialGradient(colors: [Ink.warmer(model.accent).opacity(scheme == .dark ? 0.10 : 0.14),
                                     .clear],
                            center: .init(x: 0.02, y: 1.05), startRadius: 0, endRadius: 520)
         }

--- a/App/Sources/plonk/SettingRows.swift
+++ b/App/Sources/plonk/SettingRows.swift
@@ -90,10 +90,13 @@ struct SettingRow<Trailing: View>: View {
         VStack(spacing: 0) {
             Divider()
             if stacked {
+                // Leading, and stated: a VStack takes the width of its widest
+                // child, and the row's own VStack then centred it in the card.
                 VStack(alignment: .leading, spacing: 8) {
                     labels
                     trailing
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal, 13)
                 .padding(.vertical, 10)
             } else {
@@ -170,5 +173,37 @@ struct SettingBlock<Content: View>: View {
                 .padding(.horizontal, 13)
                 .padding(.vertical, 10)
         }
+    }
+}
+
+/// Two cards side by side where both get room to say what is in them, and one
+/// under the other where they do not. Measured on the row itself rather than
+/// on the window: the sidebar and the insets have already taken their share.
+struct Columns<Leading: View, Trailing: View>: View {
+    var breakpoint: CGFloat = 640
+    @ViewBuilder var leading: Leading
+    @ViewBuilder var trailing: Trailing
+    @State private var width: CGFloat = 0
+
+    var body: some View {
+        Group {
+            if width >= breakpoint {
+                HStack(alignment: .top, spacing: 12) {
+                    leading
+                    trailing
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 16) {
+                    leading
+                    trailing
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(GeometryReader { geo in
+            Color.clear
+                .onAppear { width = geo.size.width }
+                .onChange(of: geo.size.width) { width = $0 }
+        })
     }
 }

--- a/App/Sources/plonk/ShortcutRows.swift
+++ b/App/Sources/plonk/ShortcutRows.swift
@@ -21,7 +21,7 @@ struct ShortcutRows: View {
             // Spacer in it is the whole fix.
             HStack(spacing: 10) {
                 thumbnail(action)
-                Text(action.title)
+                Text(action.title).lineLimit(1).truncationMode(.tail)
                 Spacer(minLength: 12)
                 if model.unavailableHotkeys.contains(action.rawValue) {
                     Image(systemName: "exclamationmark.triangle.fill")

--- a/App/Sources/plonk/ShotPage.swift
+++ b/App/Sources/plonk/ShotPage.swift
@@ -13,10 +13,16 @@ struct ShotPage: View {
             SettingsCard(title: .shotCapture) {
                 SettingBlock {
                     HStack(spacing: 8) {
+                        // Chips, not system buttons: bordered draws its label in
+                        // the accent on a barely-there fill, so next to one
+                        // prominent button the other two read as a segmented
+                        // control with Region selected, not as three actions.
                         Button(String(localized: .shotCaptureRegion)) { model.actions?.capture(.region) }
-                            .buttonStyle(.borderedProminent)
+                            .buttonStyle(.chipProminent)
                         Button(String(localized: .shotCaptureWindow)) { model.actions?.capture(.window) }
+                            .buttonStyle(.chip)
                         Button(String(localized: .shotCaptureScreen)) { model.actions?.capture(.screen) }
+                            .buttonStyle(.chip)
                     }
                 }
             }
@@ -53,9 +59,14 @@ struct ShotPage: View {
                         TextField(text: $folderDraft) { Text(.shotSaveFolder) }
                             .textFieldStyle(.roundedBorder)
                             .labelsHidden()
-                            .frame(width: 190)
+                            // Flexible: with a rigid 190 the row keeps its width
+                            // when the card runs out, and it is the button that
+                            // gets crushed to a sliver. The field gives instead.
+                            .frame(minWidth: 120, maxWidth: 190)
                             .onSubmit(commitFolder)
                         Button(String(localized: .commonChoose), action: chooseFolder)
+                            .buttonStyle(.chip)
+                            .fixedSize()
                     }
                     .controlSize(.small)
                 }

--- a/App/Sources/plonk/TrafficLights.swift
+++ b/App/Sources/plonk/TrafficLights.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+// The sidebar is a panel set into the window by `Ink.inset` on every side, and
+// macOS puts the traffic lights where the panel's corner now is. They move in
+// so they sit inside the panel, the way the design draws them.
+
+enum TrafficLights {
+    /// AppKit lays the buttons out again on every resize and when the window
+    /// enters or leaves full screen, so the move is re-applied then, and it is
+    /// stated against where the buttons started so applying it twice lands in
+    /// the same place.
+    static func inset(in window: NSWindow) {
+        // Where AppKit put them, taken once. The move is stated against that
+        // rather than against wherever the button is now, so applying it a
+        // second time lands in the same place instead of a step further.
+        let kinds: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+        let home = kinds.compactMap { kind in window.standardWindowButton(kind).map { ($0, $0.frame.origin) } }
+        guard let first = home.first?.1.x, let last = home.last else { return }
+        let span = last.1.x + last.0.frame.width - first
+        let nudge = { [weak window] in
+            guard let window else { return }
+            // Where the close button's left edge goes, from the window's edge.
+            // In the wide sidebar it lines up with the search field, ten points
+            // into the panel. In the rail the three sit centred, because a row
+            // of lights that nearly spans the panel reads as crooked the moment
+            // it is off by a little.
+            let rail = window.frame.width < MainWindowView.railBelow
+            let left = Ink.inset + (rail ? (MainWindowView.rail - span) / 2 : 10)
+            for (button, origin) in home {
+                button.setFrameOrigin(NSPoint(x: origin.x - first + left,
+                                              y: origin.y - Ink.inset - 6))
+            }
+        }
+        nudge()
+        for name in [NSWindow.didResizeNotification, NSWindow.didEndLiveResizeNotification,
+                     NSWindow.didEnterFullScreenNotification, NSWindow.didExitFullScreenNotification,
+                     NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
+            NotificationCenter.default.addObserver(forName: name, object: window, queue: .main) { _ in
+                nudge()
+            }
+        }
+    }
+}

--- a/App/Sources/plonk/WindowPresenter.swift
+++ b/App/Sources/plonk/WindowPresenter.swift
@@ -38,9 +38,10 @@ final class WindowPresenter: NSObject {
     func showMainWindow() {
         if main == nil {
             let window = panel(title: String(localized: .appName),
-                               size: NSSize(width: 1000, height: 700),
+                               size: NSSize(width: 1140, height: 820),
                                unified: true,
                                content: MainWindowView(model: model))
+            TrafficLights.inset(in: window)
             main = window
         }
         present(main)

--- a/App/Sources/plonk/ZoneSetCanvas.swift
+++ b/App/Sources/plonk/ZoneSetCanvas.swift
@@ -44,19 +44,31 @@ struct ZoneSetCanvas: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(assigned ?? String(localized: .zoneSetEdgeSnapping))
-                    .font(.system(size: 26, weight: .heavy))
-                    .kerning(-0.7)
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(.system(size: 12.5))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+        // Beside the title where there is room, under it where there is not:
+        // a button that has been squeezed to "Du…" is not a button.
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                titles
+                Spacer(minLength: 8)
+                actions.fixedSize()
             }
-            Spacer(minLength: 8)
-            actions
+            VStack(alignment: .leading, spacing: 10) {
+                titles
+                actions.fixedSize()
+            }
+        }
+    }
+
+    private var titles: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(assigned ?? String(localized: .zoneSetEdgeSnapping))
+                .font(.system(size: 26, weight: .heavy))
+                .kerning(-0.7)
+                .lineLimit(1)
+            Text(subtitle)
+                .font(.system(size: 12.5))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
         }
     }
 
@@ -89,10 +101,10 @@ struct ZoneSetCanvas: View {
                 Button(String(localized: .zoneSetEdit)) {
                     model.actions?.editZoneSet(assigned, seed: nil, onScreen: screen)
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.chipProminent)
             }
         }
-        .controlSize(.small)
+        .buttonStyle(.chip)
     }
 
     // MARK: - Tabs

--- a/App/Sources/plonk/ZonesPage.swift
+++ b/App/Sources/plonk/ZonesPage.swift
@@ -18,10 +18,7 @@ struct ZonesPage: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 16) {
                 ZoneSetCanvas(model: model)
-                HStack(alignment: .top, spacing: 12) {
-                    dragging
-                    shortcuts
-                }
+                Columns { dragging } trailing: { shortcuts }
                 numbered
                 switching
                 focus
@@ -48,7 +45,8 @@ struct ZonesPage: View {
                          selection: model.binding(\.zonesModifier),
                          options: [(.zonesModifierShift, "shift"),
                                    (.zonesModifierOption, "option"),
-                                   (.zonesModifierControl, "control")])
+                                   (.zonesModifierControl, "control")],
+                         stacked: true)
         }
     }
 


### PR DESCRIPTION
## What

A new window chrome, built from the approved "Ink" direction.

- The window is one ground; the sidebar is a dark panel set into it with a 12pt inset, cards are a step lighter, no bar over the page. Traffic lights move into the panel and centre themselves in the icon rail.
- The menu carries the zone palette: one hue per destination (deeper tints on light), the ⌘K search under the lights, workspaces as coloured dots, connected agents as a line in the footer, permission pills only when one is missing.
- Light mode gets the same three steps: darker menu, accent glow on the ground, white cards with a shadow.
- Narrow windows: two-column blocks collapse under 640pt (`Columns`), the zone set header drops its buttons under the title, shortcut names truncate, and field-plus-button rows (save folder, exclusions, accent) let the field give and wrap instead of crushing the button.
- Header and picker buttons are chips (`ChipButtonStyle`): label in the text colour, or white on the accent for the one to press.

## Checked

- `swift build`, `./scripts/lint.sh` clean, `./scripts/test.sh`: 461 tests pass.
- Looked at Home, Zones, Screenshot, Appearance in dark and light, wide and rail, in the built app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)