### PR TITLE
fix: validate click style during config clamp

### DIFF
--- a/App/Sources/plonk/Config+Edits.swift
+++ b/App/Sources/plonk/Config+Edits.swift
@@ -55,6 +55,9 @@ extension Config {
         clickRadius = clickRadius.clamped(to: Self.clickRadiusRange)
         clickLineWidth = clickLineWidth.clamped(to: Self.clickLineWidthRange)
         clickFadeSeconds = clickFadeSeconds.clamped(to: Self.clickFadeRange)
+        if PointerAppearance.ClickStyle(rawValue: clickStyle) == nil {
+            clickStyle = PointerAppearance.ClickStyle.ring.rawValue
+        }
         crosshairLineWidth = crosshairLineWidth.clamped(to: Self.crosshairLineWidthRange)
         crosshairOpacity = crosshairOpacity.clamped(to: Self.opacityRange)
         spotlightRadius = spotlightRadius.clamped(to: Self.spotlightRadiusRange)

--- a/App/Tests/plonkTests/PointerAppearanceTests.swift
+++ b/App/Tests/plonkTests/PointerAppearanceTests.swift
@@ -48,6 +48,16 @@ struct PointerAppearanceTests {
         #expect(PointerAppearance(config).clickStyle == .dot)
     }
 
+    @Test func clampReplacesAnUnknownStyleButKeepsAKnownOne() {
+        var config = Config()
+        config.clickStyle = "sunburst"
+        config.clamp()
+        #expect(config.clickStyle == "ring")
+        config.clickStyle = "both"
+        config.clamp()
+        #expect(config.clickStyle == "both")
+    }
+
     @Test func theNumbersAreHeldInsideTheirBounds() {
         var config = Config()
         config.clickRadius = 4000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ one of those.
   right under its rows. They are the longest thing on the page and the least
   often changed.
 
+### Fixed
+
+- **An invalid click-ring style in a hand-edited config repairs itself.** The
+  overlay already drew a ring for an unknown value, but the settings picker
+  showed no selected style and the invalid value was saved again.
+
 ## 0.3.5 — 2026-08-23
 
 ### Changed


### PR DESCRIPTION
Fixes #110.\n\nConfig clamp now replaces an unknown click-ring style with the ring default, so hand-edited config cannot leave the settings picker without a selected segment or persist an invalid value. Known styles remain unchanged.\n\nVerified with:\n- `swift build` in `App/`\n- `./scripts/test.sh` (575 tests)\n- `./scripts/lint.sh`\n- `node scripts/check-strings.mjs`\n- `./scripts/check-security-claims.sh`