### PR TITLE
fix: reduce background pointer CPU usage

### DIFF
--- a/App/Sources/plonk/DragSnapManager.swift
+++ b/App/Sources/plonk/DragSnapManager.swift
@@ -83,15 +83,23 @@ final class DragSnapManager {
         edgeSpanPoints = config.zoneEdgeSpanPoints
         shakeEnabled = config.shakeToSnap
         look = ZoneAppearance(config)
+        if enabled { start() } else { stop() }
     }
 
     func start() {
+        guard monitors.isEmpty else { return }
         if let m = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDragged, handler: { [weak self] event in
             self?.handleDrag(event)
         }) { monitors.append(m) }
         if let m = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp, handler: { [weak self] _ in
             self?.handleMouseUp()
         }) { monitors.append(m) }
+    }
+
+    func stop() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors.removeAll()
+        _ = endExternalDrag()
     }
 
     /// Show one zone set on one screen until hidden (the picker's eye toggle).

--- a/App/Sources/plonk/MouseTools.swift
+++ b/App/Sources/plonk/MouseTools.swift
@@ -23,6 +23,8 @@ final class MouseTools {
     private var tap: EventTap?
     private var spotlightToken = 0
     private var lastCrosshair: NSPoint?
+    private var pendingCrosshair: NSPoint?
+    private var crosshairUpdateScheduled = false
 
     var highlightEnabled = false
     var crosshairsEnabled = false {
@@ -38,9 +40,15 @@ final class MouseTools {
     /// a spotlight that blinks out under the user's hand.
     func apply(_ config: Config) {
         let was = look
+        let wasHighlighting = highlightEnabled
+        let wasCrosshairs = crosshairsEnabled
         look = PointerAppearance(config)
         highlightEnabled = config.highlightClicksEnabled && config.isEnabled(.mouse)
         crosshairsEnabled = config.crosshairsEnabled && config.isEnabled(.mouse)
+        if tap != nil,
+           highlightEnabled != wasHighlighting || crosshairsEnabled != wasCrosshairs {
+            stop()
+        }
         if highlightEnabled || crosshairsEnabled {
             start()
             // A crosshair already on screen is repainted the way it now looks,
@@ -56,11 +64,15 @@ final class MouseTools {
     /// grant watcher applies the config again once it lands.
     func start() {
         guard tap == nil, WindowAccess.isTrusted else { return }
-        let mask: CGEventMask =
-            (1 << CGEventType.leftMouseDown.rawValue) |
-            (1 << CGEventType.rightMouseDown.rawValue) |
-            (1 << CGEventType.mouseMoved.rawValue) |
-            (1 << CGEventType.leftMouseDragged.rawValue)
+        var mask: CGEventMask = 0
+        if highlightEnabled {
+            mask |= (1 << CGEventType.leftMouseDown.rawValue)
+                | (1 << CGEventType.rightMouseDown.rawValue)
+        }
+        if crosshairsEnabled {
+            mask |= (1 << CGEventType.mouseMoved.rawValue)
+                | (1 << CGEventType.leftMouseDragged.rawValue)
+        }
 
         // A listen-only tap: these tools watch the pointer, they never take an
         // event away from anybody.
@@ -73,6 +85,9 @@ final class MouseTools {
 
     func stop() {
         tap = nil
+        pendingCrosshair = nil
+        crosshairUpdateScheduled = false
+        lastCrosshair = nil
         overlay.hide()
     }
 
@@ -142,8 +157,16 @@ final class MouseTools {
         case .mouseMoved, .leftMouseDragged:
             guard crosshairsEnabled, spotlightToken == 0 || !overlay.isSpotlighting else { return }
             let point = event.unflippedLocation
+            guard point != lastCrosshair else { return }
+            pendingCrosshair = point
+            guard !crosshairUpdateScheduled else { return }
+            crosshairUpdateScheduled = true
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
+                crosshairUpdateScheduled = false
+                guard let point = pendingCrosshair else { return }
+                pendingCrosshair = nil
+                lastCrosshair = point
                 overlay.show(.crosshairs, at: point, look: look)
             }
         default:
@@ -161,8 +184,11 @@ final class MouseTools {
             return
         }
         if crosshairsEnabled {
-            overlay.show(.crosshairs, at: NSEvent.mouseLocation, look: look)
+            let point = NSEvent.mouseLocation
+            lastCrosshair = point
+            overlay.show(.crosshairs, at: point, look: look)
         } else {
+            lastCrosshair = nil
             overlay.hide()
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 What changed in each release, from a user's side. The commit log has the rest.
 
+## Unreleased
+
+### Changed
+
+- **Background pointer work stays asleep when it is not needed.** Click
+  highlighting no longer listens to every mouse movement, crosshair movement
+  coalesces bursts before redrawing, and drag snapping removes its global
+  monitors while the feature is switched off.
+
 Versions before 0.1.0 shipped in two days and are summarized rather than
 itemized. The dates are real; the tidiness is not — most of what is listed
 under 0.0.4 was written the same afternoon it went out.


### PR DESCRIPTION
<!--
CONTRIBUTING.md has the long version. Delete any section that does not apply —
a one-line docs fix should not carry a geometry checklist.

The title does not have to be clever. `fix: nil display UUID on unplug` is a
good title. So is `Add a setup page for Windsurf`.
-->

## What changed, and why

<!-- One paragraph. The why matters more than the what; the diff has the what. -->

## What you ran

<!--
The loop CI runs, from the repository root. Paste the ones you ran:

  (cd App && swift build)
  ./scripts/test.sh
  ./scripts/lint.sh
  (cd mcp && npm ci && npm test)
  node scripts/check-zone-sets.mjs
  node scripts/check-strings.mjs
  ./scripts/check-security-claims.sh

None of them need a signing certificate.
-->

## Checks

- [ ] `swift build` passes on every commit in the branch, not just the last one
- [ ] New logic is covered in `App/Tests/plonkTests/` or `mcp/test/`, or it is not the kind that can be
- [ ] Commits use `feat:` / `fix:` / `docs:` / `chore:` / `refactor:`
- [ ] If this touches the network, the permissions, the entitlements or the update path, `README.md` and `SECURITY.md` still tell the truth — fixed in this PR if not
- [ ] Screenshots below for anything visual

<!-- ===================================================================== -->

## If this moves windows

<!--
Delete this whole section unless the change touches zones, snapping, drag,
workspaces, focus, or anything else that decides where a window ends up.

Nothing in the unit suite can see a real desktop, so this is the only evidence
there is. `scripts/testbench.sh` opens throwaway TextEdit windows so you never
have to move your real ones:

  ./scripts/testbench.sh up 4     open four windows
  ./scripts/testbench.sh state    print where they landed, as fractions
  ./scripts/testbench.sh down     close them, delete the files

Run `state` before and after and paste both. Fractions travel between machines;
pixels do not.

You are not expected to own every arrangement below. Tick what you ran, and
write "no hardware" against the rest — an honest gap is more useful than a
blank, and it is what the `needs-hardware` label is for.
-->

**Setup:** macOS <!-- 15.2 -->, <!-- 1 built-in display @ 2x -->

- [ ] **One screen.** Snap into a zone by drag and by `⌃⌥1`–`⌃⌥9`. Both land in the same place.
- [ ] **Put it back.** `⌃⌥0` returns the window to the frame it had before Plonk first touched it.
- [ ] **A second monitor.** A window snapped on each screen stays on its own, and the zone numbers follow the screen the cursor is on.
- [ ] **Mixed scale factors.** A Retina screen beside a 1x one, a window snapped on each. Nothing is half-size or double-size.
- [ ] **Unplug and plug back in.** Windows return to the monitor they were on, not to index 0.
- [ ] **An excluded app.** A window of an app on the exclusions list is left alone by drag and by shortcut, and still moves when an agent names it on purpose.

<details>
<summary>Before / after from <code>testbench.sh state</code></summary>

```
```

</details>
