### PR TITLE
fix: harden background runtime behavior

### DIFF
--- a/App/Sources/plonk/AgentAdapterRunner.swift
+++ b/App/Sources/plonk/AgentAdapterRunner.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Runs command-line adapters away from AppDelegate. Output goes to a file so
+/// a verbose tool cannot fill a pipe and deadlock before anybody reads it.
+final class AgentAdapterRunner {
+    struct Finished {
+        let status: Int32
+        let lastError: String
+        let seconds: Int
+    }
+
+    enum Result {
+        case finished(Finished)
+        case couldNotStart(String)
+    }
+
+    private let lock = NSLock()
+    private var running: [UUID: Process] = [:]
+
+    func run(_ adapter: AgentAdapter, prompt: String, completion: @escaping (Result) -> Void) {
+        let invocation = AgentAdapter.invocation(command: adapter.command, prompt: prompt)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-lc", invocation.command]
+        process.environment = ProcessInfo.processInfo.environment
+            .merging(invocation.environment) { _, prompt in prompt }
+
+        let id = UUID()
+        let started = Date()
+        let errorLog = FileManager.default.temporaryDirectory
+            .appendingPathComponent("plonk-adapter-\(id.uuidString).log")
+        FileManager.default.createFile(atPath: errorLog.path, contents: nil)
+        let errors = try? FileHandle(forWritingTo: errorLog)
+        process.standardError = errors ?? FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+
+        process.terminationHandler = { [weak self] finished in
+            try? errors?.close()
+            let complaint = (try? String(contentsOf: errorLog, encoding: .utf8)) ?? ""
+            try? FileManager.default.removeItem(at: errorLog)
+            self?.remove(id)
+            let result = Finished(
+                status: finished.terminationStatus,
+                lastError: complaint.split(separator: "\n").last.map(String.init) ?? "",
+                seconds: Int(Date().timeIntervalSince(started).rounded())
+            )
+            DispatchQueue.main.async { completion(.finished(result)) }
+        }
+
+        lock.withLock { running[id] = process }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            do {
+                try process.run()
+            } catch {
+                try? errors?.close()
+                try? FileManager.default.removeItem(at: errorLog)
+                self?.remove(id)
+                DispatchQueue.main.async { completion(.couldNotStart(error.localizedDescription)) }
+            }
+        }
+    }
+
+    private func remove(_ id: UUID) {
+        _ = lock.withLock { running.removeValue(forKey: id) }
+    }
+}

--- a/App/Sources/plonk/AppDelegate+Shell.swift
+++ b/App/Sources/plonk/AppDelegate+Shell.swift
@@ -70,32 +70,6 @@ extension AppDelegate {
     /// an NSLog nobody reads — which from the palette looked exactly like a
     /// window closing and nothing happening.
     func launchAdapter(_ adapter: AgentAdapter, prompt: String) {
-        let invocation = AgentAdapter.invocation(command: adapter.command, prompt: prompt)
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = ["-lc", invocation.command]
-        process.environment = ProcessInfo.processInfo.environment
-            .merging(invocation.environment) { _, prompt in prompt }
-
-        // A file, not a pipe. A pipe nobody is reading fills at about 64 KB and
-        // the adapter blocks on the write for ever — and `claude -p` printing
-        // its answer clears that easily, so attaching one and reading it only
-        // after exit produces exactly the hang this is supposed to report.
-        // Draining it concurrently would work and needs a lock and a reader;
-        // a file cannot block, and the tail is all the HUD ever shows.
-        let errorLog = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("plonk-adapter-\(UUID().uuidString).log")
-        FileManager.default.createFile(atPath: errorLog.path, contents: nil)
-        let errors = try? FileHandle(forWritingTo: errorLog)
-        process.standardError = errors ?? FileHandle.nullDevice
-        // Discarded outright: nothing reads it, and that is the same trap.
-        process.standardOutput = FileHandle.nullDevice
-
-        // A ticking HUD for as long as it runs. The agent takes tens of seconds
-        // and moves nothing until it has decided what to move, so without this
-        // the whole middle of the job looks identical to nothing happening —
-        // which is exactly what it was mistaken for. The count is what makes it
-        // readable as progress rather than as a stuck label.
         let started = Date()
         var ticks = 0
         var progress: Timer?
@@ -107,48 +81,23 @@ extension AppDelegate {
             // beats, and short enough to clear itself if this stops ticking.
             HUD.shared.show(.hudWorking(adapter.name, dots, seconds), duration: 3)
         }
-        // Both halves are queued on the main thread and the start is queued
-        // first, so FIFO keeps stop after start.
-        let stop = {
+        let stopProgress = {
             progress?.invalidate()
             progress = nil
         }
-
-        DispatchQueue.main.async {
-            beat()
-            progress = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: true) { _ in beat() }
-        }
-
-        process.terminationHandler = { finished in
-            try? errors?.close()
-            let complaint = (try? String(contentsOf: errorLog, encoding: .utf8)) ?? ""
-            try? FileManager.default.removeItem(at: errorLog)
-            let last = complaint.split(separator: "\n").last.map(String.init) ?? ""
-            let seconds = Int(Date().timeIntervalSince(started).rounded())
-            DispatchQueue.main.async {
-                stop()
-                if finished.terminationStatus == 0 {
-                    HUD.shared.show(.hudFinished(adapter.name, seconds))
-                } else {
-                    let failure = String(localized: .hudFailed(adapter.name,
-                                                               Int(finished.terminationStatus)))
-                    HUD.shared.show(failure + (last.isEmpty ? "" : ": \(last.prefix(70))"))
-                }
-            }
-        }
-
-        // Adapters may run for minutes, so they never touch the main thread.
-        DispatchQueue.global(qos: .userInitiated).async {
-            do {
-                try process.run()
-            } catch {
-                // terminationHandler never runs for a process that never ran,
-                // so the ticking has to be stopped from here or it ticks for ever.
-                DispatchQueue.main.async {
-                    stop()
-                    HUD.shared.show(.hudWouldNotStart(adapter.name,
-                                                        error.localizedDescription))
-                }
+        beat()
+        progress = Timer.scheduledTimer(withTimeInterval: 0.6, repeats: true) { _ in beat() }
+        adapterRunner.run(adapter, prompt: prompt) { result in
+            stopProgress()
+            switch result {
+            case .finished(let finished) where finished.status == 0:
+                HUD.shared.show(.hudFinished(adapter.name, finished.seconds))
+            case .finished(let finished):
+                let failure = String(localized: .hudFailed(adapter.name, Int(finished.status)))
+                let detail = finished.lastError.isEmpty ? "" : ": \(finished.lastError.prefix(70))"
+                HUD.shared.show(failure + detail)
+            case .couldNotStart(let message):
+                HUD.shared.show(.hudWouldNotStart(adapter.name, message))
             }
         }
     }

--- a/App/Sources/plonk/AppDelegate.swift
+++ b/App/Sources/plonk/AppDelegate.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let awake = AwakeManager()
     let lidSleep = LidSleep()
     let agents = AgentRegistry()
+    let adapterRunner = AgentAdapterRunner()
     let eventBroadcaster = EventBroadcaster()
     let voice = VoiceManager()
     let hotkeys = HotkeyManager()

--- a/App/Sources/plonk/AwakeManager+Triggers.swift
+++ b/App/Sources/plonk/AwakeManager+Triggers.swift
@@ -75,8 +75,9 @@ extension AwakeManager {
     /// the timers run for the life of the app, because a window can open at any
     /// time.
     func startWatching() {
+        guard watchTimer == nil else { return }
         watchTimer = Timer.common(every: Self.watchSeconds) { [weak self] in self?.reevaluate() }
-        NSWorkspace.shared.notificationCenter.addObserver(
+        wakeToken = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
         ) { [weak self] _ in
             // A Mac that slept through the start of the window never saw the
@@ -90,7 +91,21 @@ extension AwakeManager {
             DispatchQueue.main.async { manager.reevaluate() }
         }, context)?.takeRetainedValue() {
             CFRunLoopAddSource(CFRunLoopGetMain(), source, .defaultMode)
+            powerSource = source
         }
         reevaluate()
+    }
+
+    func stopWatching() {
+        watchTimer?.invalidate()
+        watchTimer = nil
+        if let wakeToken {
+            NSWorkspace.shared.notificationCenter.removeObserver(wakeToken)
+            self.wakeToken = nil
+        }
+        if let powerSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), powerSource, .defaultMode)
+            self.powerSource = nil
+        }
     }
 }

--- a/App/Sources/plonk/AwakeManager.swift
+++ b/App/Sources/plonk/AwakeManager.swift
@@ -47,6 +47,8 @@ final class AwakeManager {
     /// Watches the clock and the app list; owned here because an extension
     /// cannot hold a stored property. Started by `startWatching`.
     var watchTimer: Timer?
+    var wakeToken: NSObjectProtocol?
+    var powerSource: CFRunLoopSource?
     var onChange: (() -> Void)?
 
     /// How often a process-bound session checks that its process is still
@@ -79,6 +81,10 @@ final class AwakeManager {
         }
     }
     var timeoutMinutes = 0
+
+    deinit {
+        stopWatching()
+    }
 
     /// Take the settings as they now stand. Called after every config change,
     /// so it has to be cheap and safe to run when nothing it reads moved.

--- a/App/Sources/plonk/DragSnapManager.swift
+++ b/App/Sources/plonk/DragSnapManager.swift
@@ -83,15 +83,23 @@ final class DragSnapManager {
         edgeSpanPoints = config.zoneEdgeSpanPoints
         shakeEnabled = config.shakeToSnap
         look = ZoneAppearance(config)
+        if enabled { start() } else { stop() }
     }
 
     func start() {
+        guard monitors.isEmpty else { return }
         if let m = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDragged, handler: { [weak self] event in
             self?.handleDrag(event)
         }) { monitors.append(m) }
         if let m = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp, handler: { [weak self] _ in
             self?.handleMouseUp()
         }) { monitors.append(m) }
+    }
+
+    func stop() {
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors.removeAll()
+        _ = endExternalDrag()
     }
 
     /// Show one zone set on one screen until hidden (the picker's eye toggle).

--- a/App/Sources/plonk/DragSnapManager.swift
+++ b/App/Sources/plonk/DragSnapManager.swift
@@ -20,6 +20,8 @@ final class DragSnapManager {
     static let spanFlag: NSEvent.ModifierFlags = .command
 
     let windows: WindowManager
+    private let addMonitor: (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> Any?
+    private let removeMonitor: (Any) -> Void
     private var monitors: [Any] = []
     var overlays: [Int: ZoneOverlay] = [:]
     var currentZone: (screenIndex: Int, frac: FracRect)?
@@ -69,8 +71,16 @@ final class DragSnapManager {
     /// Reports a finished snap, so the frame the window had can be given back.
     var onSnap: ((_ window: AXUIElement, _ before: CGRect, _ frac: FracRect, _ screenIndex: Int) -> Void)?
 
-    init(windows: WindowManager) {
+    init(
+        windows: WindowManager,
+        addMonitor: @escaping (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> Any? = {
+            NSEvent.addGlobalMonitorForEvents(matching: $0, handler: $1)
+        },
+        removeMonitor: @escaping (Any) -> Void = { NSEvent.removeMonitor($0) }
+    ) {
         self.windows = windows
+        self.addMonitor = addMonitor
+        self.removeMonitor = removeMonitor
     }
 
     /// Take the settings as they now stand. Called after every config change,
@@ -88,16 +98,16 @@ final class DragSnapManager {
 
     func start() {
         guard monitors.isEmpty else { return }
-        if let m = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseDragged, handler: { [weak self] event in
+        if let m = addMonitor(.leftMouseDragged, { [weak self] event in
             self?.handleDrag(event)
         }) { monitors.append(m) }
-        if let m = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp, handler: { [weak self] _ in
+        if let m = addMonitor(.leftMouseUp, { [weak self] _ in
             self?.handleMouseUp()
         }) { monitors.append(m) }
     }
 
     func stop() {
-        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        for monitor in monitors { removeMonitor(monitor) }
         monitors.removeAll()
         _ = endExternalDrag()
     }

--- a/App/Sources/plonk/EventTap.swift
+++ b/App/Sources/plonk/EventTap.swift
@@ -1,21 +1,25 @@
 import AppKit
 
+typealias EventTapHandler = (CGEventType, CGEvent) -> Unmanaged<CGEvent>?
+
+protocol EventTapToken: AnyObject {}
+
 /// A CGEvent tap on the main run loop, with the one piece of upkeep every tap
 /// needs: the system disables a tap that ever takes too long, and turning it
 /// back on is the documented recovery. Losing it silently would strand every
 /// event after, so that lives here rather than in each owner. The tap is torn
 /// down when this is released.
-final class EventTap {
+final class EventTap: EventTapToken {
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    private let handler: (CGEventType, CGEvent) -> Unmanaged<CGEvent>?
+    private let handler: EventTapHandler
 
     /// nil when the tap cannot be created, which is what happens without
     /// Accessibility. `handler` returns nil to swallow an event; a listen-only
     /// tap's return value is ignored.
     init?(
         mask: CGEventMask, options: CGEventTapOptions, name: String,
-        handler: @escaping (CGEventType, CGEvent) -> Unmanaged<CGEvent>?
+        handler: @escaping EventTapHandler
     ) {
         self.handler = handler
         let context = Unmanaged.passUnretained(self).toOpaque()

--- a/App/Sources/plonk/MouseTools.swift
+++ b/App/Sources/plonk/MouseTools.swift
@@ -20,11 +20,15 @@ import AppKit
 
 final class MouseTools {
     private let overlay = MouseOverlay()
-    private var tap: EventTap?
+    private let tapFactory: (CGEventMask, CGEventTapOptions, String,
+                             @escaping EventTapHandler) -> EventTapToken?
+    private let isTrusted: () -> Bool
+    private var tap: EventTapToken?
     private var spotlightToken = 0
     private var lastCrosshair: NSPoint?
     private var pendingCrosshair: NSPoint?
     private var crosshairUpdateScheduled = false
+    private var tapGeneration = 0
 
     var highlightEnabled = false
     var crosshairsEnabled = false {
@@ -32,6 +36,17 @@ final class MouseTools {
     }
     /// Colours, sizes and how long a ring lasts; see PointerAppearance.
     var look = PointerAppearance()
+
+    init(
+        tapFactory: @escaping (CGEventMask, CGEventTapOptions, String,
+                               @escaping EventTapHandler) -> EventTapToken? = {
+            EventTap(mask: $0, options: $1, name: $2, handler: $3)
+        },
+        isTrusted: @escaping () -> Bool = { WindowAccess.isTrusted }
+    ) {
+        self.tapFactory = tapFactory
+        self.isTrusted = isTrusted
+    }
 
     /// Take the settings as they now stand. Called after every config change,
     /// so it stops only a tap that is actually running: `stop` also hides the
@@ -63,7 +78,7 @@ final class MouseTools {
     /// runs after every config write, so it would fail and log on each. The
     /// grant watcher applies the config again once it lands.
     func start() {
-        guard tap == nil, WindowAccess.isTrusted else { return }
+        guard tap == nil, isTrusted() else { return }
         var mask: CGEventMask = 0
         if highlightEnabled {
             mask |= (1 << CGEventType.leftMouseDown.rawValue)
@@ -76,7 +91,7 @@ final class MouseTools {
 
         // A listen-only tap: these tools watch the pointer, they never take an
         // event away from anybody.
-        tap = EventTap(mask: mask, options: .listenOnly, name: "mouse-tools") { [unowned self] type, event in
+        tap = tapFactory(mask, .listenOnly, "mouse-tools") { [unowned self] type, event in
             handle(type, event)
             return Unmanaged.passUnretained(event)
         }
@@ -85,6 +100,7 @@ final class MouseTools {
 
     func stop() {
         tap = nil
+        tapGeneration += 1
         pendingCrosshair = nil
         crosshairUpdateScheduled = false
         lastCrosshair = nil
@@ -150,8 +166,10 @@ final class MouseTools {
             guard highlightEnabled else { return }
             let point = event.unflippedLocation
             let right = type == .rightMouseDown
+            let generation = tapGeneration
             DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
+                guard let self, tap != nil, highlightEnabled,
+                      tapGeneration == generation else { return }
                 overlay.pulse(at: point, right: right, look: look)
             }
         case .mouseMoved, .leftMouseDragged:
@@ -161,9 +179,12 @@ final class MouseTools {
             pendingCrosshair = point
             guard !crosshairUpdateScheduled else { return }
             crosshairUpdateScheduled = true
+            let generation = tapGeneration
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 crosshairUpdateScheduled = false
+                guard tap != nil, crosshairsEnabled,
+                      tapGeneration == generation else { return }
                 guard let point = pendingCrosshair else { return }
                 pendingCrosshair = nil
                 lastCrosshair = point

--- a/App/Sources/plonk/MouseTools.swift
+++ b/App/Sources/plonk/MouseTools.swift
@@ -23,6 +23,8 @@ final class MouseTools {
     private var tap: EventTap?
     private var spotlightToken = 0
     private var lastCrosshair: NSPoint?
+    private var pendingCrosshair: NSPoint?
+    private var crosshairUpdateScheduled = false
 
     var highlightEnabled = false
     var crosshairsEnabled = false {
@@ -38,9 +40,15 @@ final class MouseTools {
     /// a spotlight that blinks out under the user's hand.
     func apply(_ config: Config) {
         let was = look
+        let wasHighlighting = highlightEnabled
+        let wasCrosshairs = crosshairsEnabled
         look = PointerAppearance(config)
         highlightEnabled = config.highlightClicksEnabled && config.isEnabled(.mouse)
         crosshairsEnabled = config.crosshairsEnabled && config.isEnabled(.mouse)
+        if tap != nil,
+           highlightEnabled != wasHighlighting || crosshairsEnabled != wasCrosshairs {
+            stop()
+        }
         if highlightEnabled || crosshairsEnabled {
             start()
             // A crosshair already on screen is repainted the way it now looks,
@@ -56,11 +64,15 @@ final class MouseTools {
     /// grant watcher applies the config again once it lands.
     func start() {
         guard tap == nil, WindowAccess.isTrusted else { return }
-        let mask: CGEventMask =
-            (1 << CGEventType.leftMouseDown.rawValue) |
-            (1 << CGEventType.rightMouseDown.rawValue) |
-            (1 << CGEventType.mouseMoved.rawValue) |
-            (1 << CGEventType.leftMouseDragged.rawValue)
+        var mask: CGEventMask = 0
+        if highlightEnabled {
+            mask |= (1 << CGEventType.leftMouseDown.rawValue)
+                | (1 << CGEventType.rightMouseDown.rawValue)
+        }
+        if crosshairsEnabled {
+            mask |= (1 << CGEventType.mouseMoved.rawValue)
+                | (1 << CGEventType.leftMouseDragged.rawValue)
+        }
 
         // A listen-only tap: these tools watch the pointer, they never take an
         // event away from anybody.
@@ -73,6 +85,9 @@ final class MouseTools {
 
     func stop() {
         tap = nil
+        pendingCrosshair = nil
+        crosshairUpdateScheduled = false
+        lastCrosshair = nil
         overlay.hide()
     }
 
@@ -142,8 +157,16 @@ final class MouseTools {
         case .mouseMoved, .leftMouseDragged:
             guard crosshairsEnabled, spotlightToken == 0 || !overlay.isSpotlighting else { return }
             let point = event.unflippedLocation
+            guard point != lastCrosshair else { return }
+            pendingCrosshair = point
+            guard !crosshairUpdateScheduled else { return }
+            crosshairUpdateScheduled = true
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
+                crosshairUpdateScheduled = false
+                guard let point = pendingCrosshair else { return }
+                pendingCrosshair = nil
+                lastCrosshair = point
                 overlay.show(.crosshairs, at: point, look: look)
             }
         default:
@@ -161,8 +184,11 @@ final class MouseTools {
             return
         }
         if crosshairsEnabled {
-            overlay.show(.crosshairs, at: NSEvent.mouseLocation, look: look)
+            let point = NSEvent.mouseLocation
+            lastCrosshair = point
+            overlay.show(.crosshairs, at: point, look: look)
         } else {
+            lastCrosshair = nil
             overlay.hide()
         }
     }

--- a/App/Sources/plonk/Router+Workspaces.swift
+++ b/App/Sources/plonk/Router+Workspaces.swift
@@ -43,7 +43,19 @@ extension Router {
             respond(.failed("launching is not available"))
             return
         }
-        let screen = (body["screen"] as? NSNumber)?.intValue
+        let screen: Int?
+        switch ScreenInput.parse(body["screen"]) {
+        case .omitted:
+            screen = nil
+        case .attached(let index, _):
+            screen = index
+        case .invalidType:
+            respond(.badRequest("screen must be a monitor index"))
+            return
+        case .notFound(let index):
+            respond(.notFound("no screen \(index)"))
+            return
+        }
         launchWorkspace(name, workspace, screen) { results in
             respond(.ok([
                 "ok": results.allSatisfy { $0["ok"] as? Bool == true },
@@ -87,10 +99,9 @@ extension Router {
 
     /// Everything on screen, as a workspace.
     func snapshotWorkspace() -> [WorkspaceItem] {
-        windows.listWindows().compactMap { entry in
-            let screen = entry["screen"] as? Int
-            return WorkspaceItem(window: entry,
-                                 screenUUID: screen.flatMap { ScreenIdentity.uuid(forIndex: $0) })
+        windows.windowSnapshots().compactMap { snapshot in
+            WorkspaceItem(window: snapshot,
+                          screenUUID: ScreenIdentity.uuid(forIndex: snapshot.screen))
         }
     }
 }

--- a/App/Sources/plonk/Router+Zones.swift
+++ b/App/Sources/plonk/Router+Zones.swift
@@ -37,12 +37,21 @@ extension Router {
         } else if body["gap"] != nil {
             return .badRequest("gap must be a number of points, or null for the default")
         }
+        let screenKeys: [String]?
+        switch ScreenInput.parse(body["screen"]) {
+        case .omitted:
+            screenKeys = nil
+        case .attached(_, let keys):
+            screenKeys = keys
+        case .invalidType:
+            return .badRequest("screen must be a monitor index")
+        case .notFound(let screen):
+            return .notFound("no screen \(screen)")
+        }
         store.update {
             $0.zoneSets[name] = zones
             if let gap { $0.zoneSetGaps[name] = gap }
-            if let screen = (body["screen"] as? NSNumber)?.intValue {
-                $0.assignZoneSet(name, forKeys: ScreenIdentity.keys(forIndex: screen))
-            }
+            if let screenKeys { $0.assignZoneSet(name, forKeys: screenKeys) }
         }
         didChangeZones?()
         var reply: [String: Any] = ["ok": true, "saved": name, "zones": zones.count]
@@ -51,9 +60,15 @@ extension Router {
     }
 
     func assignZoneSetRoute(_ body: [String: Any]) -> HTTPResponse {
-        guard let screen = (body["screen"] as? NSNumber)?.intValue else {
+        let screenKeys: [String]
+        switch ScreenInput.parse(body["screen"]) {
+        case .attached(_, let keys):
+            screenKeys = keys
+        case .omitted, .invalidType:
             return .badRequest("body must include screen; omit name for the default set "
                                + "(\(BuiltinZoneSets.defaultName)), pass \"edge\" for edge snapping")
+        case .notFound(let index):
+            return .notFound("no screen \(index)")
         }
         let requested = (body["name"] as? String)?.trimmingCharacters(in: .whitespaces)
         let assignment: String?
@@ -68,7 +83,7 @@ extension Router {
             }
             assignment = name
         }
-        store.update { $0.assignZoneSet(assignment, forKeys: ScreenIdentity.keys(forIndex: screen)) }
+        store.update { $0.assignZoneSet(assignment, forKeys: screenKeys) }
         didChangeZones?()
         return .ok(["ok": true])
     }
@@ -101,10 +116,9 @@ extension Router {
         }
         var screenUUID: String?
         var screenIndex: Int?
-        if let screen = (body["screen"] as? NSNumber)?.intValue {
-            guard let uuid = ScreenIdentity.uuid(forIndex: screen) else {
-                return .notFound("no screen \(screen)")
-            }
+        switch ScreenInput.parse(body["screen"]) {
+        case .attached(let screen, let keys):
+            guard let uuid = keys.first else { return .notFound("no screen \(screen)") }
             // A rule for a zone the named screen does not have would sit in
             // the list and never fire; better refused now, with the count.
             if case .failure(let refusal) = numberedZones(onScreen: screen, holding: zone) {
@@ -112,8 +126,12 @@ extension Router {
             }
             screenUUID = uuid
             screenIndex = screen
-        } else if body["screen"] != nil, !(body["screen"] is NSNull) {
+        case .invalidType:
             return .badRequest("screen must be a monitor index")
+        case .notFound(let screen):
+            return .notFound("no screen \(screen)")
+        case .omitted:
+            break
         }
         let rule = AppRule(app: app, zone: zone, screenUUID: screenUUID)
         store.update { $0.appRules = AppRules.upsert(rule, in: $0.appRules) }
@@ -164,8 +182,18 @@ extension Router {
             return .badRequest("body must be {\"app\", \"zone\": 1-based index or name, \"title\"?, \"screen\"?}")
         }
         let title = body["title"] as? String
-        guard let screen = (body["screen"] as? NSNumber)?.intValue
-                ?? windows.screenIndex(ofApp: app, titleContains: title) else {
+        let requestedScreen: Int?
+        switch ScreenInput.parse(body["screen"]) {
+        case .attached(let screen, _):
+            requestedScreen = screen
+        case .omitted:
+            requestedScreen = nil
+        case .invalidType:
+            return .badRequest("screen must be a monitor index")
+        case .notFound(let screen):
+            return .notFound("no screen \(screen)")
+        }
+        guard let screen = requestedScreen ?? windows.screenIndex(ofApp: app, titleContains: title) else {
             return .notFound("app \"\(app)\" is not running")
         }
         let zones = store.config.zones(forKeys: ScreenIdentity.keys(forIndex: screen))

--- a/App/Sources/plonk/RulerRoutes.swift
+++ b/App/Sources/plonk/RulerRoutes.swift
@@ -29,7 +29,19 @@ final class RulerRoutes {
             return
         }
 
-        let index = (body["screen"] as? NSNumber)?.intValue ?? 0
+        let index: Int
+        switch ScreenInput.parse(body["screen"]) {
+        case .omitted:
+            index = 0
+        case .attached(let attached, _):
+            index = attached
+        case .invalidType:
+            respond(.badRequest("screen must be a monitor index"))
+            return
+        case .notFound(let missing):
+            respond(.notFound("no screen \(missing); get_state lists them"))
+            return
+        }
         guard let screen = windows.screens().first(where: { $0.index == index }) else {
             respond(.notFound("no screen \(index); get_state lists them"))
             return

--- a/App/Sources/plonk/ScreenIdentity.swift
+++ b/App/Sources/plonk/ScreenIdentity.swift
@@ -21,6 +21,14 @@ enum ScreenIdentity {
         return [uuid, String(index)]
     }
 
+    /// Storage keys only when the screen is attached now. Routes use this
+    /// before persisting an index supplied by a client; `keys(forIndex:)`
+    /// deliberately keeps accepting a bare legacy index while reading config.
+    static func attachedKeys(forIndex index: Int) -> [String]? {
+        guard let uuid = uuid(forIndex: index) else { return nil }
+        return [uuid, String(index)]
+    }
+
     /// The screen the pointer is on, falling back to the first one: a shortcut
     /// with no window to read a screen from acts on the one being looked at.
     static var indexUnderCursor: Int {

--- a/App/Sources/plonk/ScreenInput.swift
+++ b/App/Sources/plonk/ScreenInput.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A monitor index crossing the untyped HTTP boundary. Parsing it once keeps
+/// every route from disagreeing about strings, booleans and detached screens.
+enum ScreenInput {
+    enum Result {
+        case omitted
+        case attached(index: Int, keys: [String])
+        case invalidType
+        case notFound(Int)
+    }
+
+    static func parse(_ value: Any?) -> Result {
+        guard let value, !(value is NSNull) else { return .omitted }
+        guard !(value is Bool), let index = (value as? NSNumber)?.intValue else {
+            return .invalidType
+        }
+        guard let keys = ScreenIdentity.attachedKeys(forIndex: index) else {
+            return .notFound(index)
+        }
+        return .attached(index: index, keys: keys)
+    }
+}

--- a/App/Sources/plonk/ShortcutGuide.swift
+++ b/App/Sources/plonk/ShortcutGuide.swift
@@ -32,9 +32,7 @@ enum ShortcutGuide {
     private static func collect(pid: pid_t) -> [Item] {
         let application = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(application, 1.0)
-        guard let value = copy(application, kAXMenuBarAttribute),
-              CFGetTypeID(value) == AXUIElementGetTypeID() else { return [] }
-        let bar = value as! AXUIElement
+        guard let bar = element(application, kAXMenuBarAttribute) else { return [] }
 
         var items: [Item] = []
         for topLevel in children(of: bar) {
@@ -98,6 +96,12 @@ enum ShortcutGuide {
 
     private static func string(_ element: AXUIElement, _ attribute: String) -> String? {
         copy(element, attribute) as? String
+    }
+
+    private static func element(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+        guard let value = copy(element, attribute), CFGetTypeID(value) == AXUIElementGetTypeID()
+        else { return nil }
+        return (value as! AXUIElement)
     }
 
     private static func children(of element: AXUIElement) -> [AXUIElement] {

--- a/App/Sources/plonk/WindowAccess.swift
+++ b/App/Sources/plonk/WindowAccess.swift
@@ -36,18 +36,31 @@ enum WindowAccess {
         return value
     }
 
+    private static func value(_ el: AXUIElement, _ name: String, type: AXValueType) -> AXValue? {
+        guard let value = attribute(el, name), CFGetTypeID(value) == AXValueGetTypeID() else { return nil }
+        let typed = value as! AXValue
+        guard AXValueGetType(typed) == type else { return nil }
+        return typed
+    }
+
+    private static func elementAttribute(_ el: AXUIElement, _ name: String) -> AXUIElement? {
+        guard let value = attribute(el, name), CFGetTypeID(value) == AXUIElementGetTypeID()
+        else { return nil }
+        return (value as! AXUIElement)
+    }
+
     static func windows(of pid: pid_t) -> [AXUIElement] {
         guard let windows = attribute(application(pid), kAXWindowsAttribute) as? [AXUIElement] else { return [] }
         return windows.filter { (attribute($0, kAXRoleAttribute) as? String) == kAXWindowRole }
     }
 
     static func frame(of win: AXUIElement) -> CGRect? {
-        guard let posVal = attribute(win, kAXPositionAttribute),
-              let sizeVal = attribute(win, kAXSizeAttribute) else { return nil }
+        guard let posVal = value(win, kAXPositionAttribute, type: .cgPoint),
+              let sizeVal = value(win, kAXSizeAttribute, type: .cgSize) else { return nil }
         var pos = CGPoint.zero
         var size = CGSize.zero
-        guard AXValueGetValue(posVal as! AXValue, .cgPoint, &pos),
-              AXValueGetValue(sizeVal as! AXValue, .cgSize, &size) else { return nil }
+        guard AXValueGetValue(posVal, .cgPoint, &pos),
+              AXValueGetValue(sizeVal, .cgSize, &size) else { return nil }
         return CGRect(origin: pos, size: size)
     }
 
@@ -77,10 +90,7 @@ enum WindowAccess {
 
     static func focusedWindow(of app: NSRunningApplication) -> AXUIElement? {
         let pid = app.processIdentifier
-        if let focused = attribute(application(pid), kAXFocusedWindowAttribute),
-           CFGetTypeID(focused) == AXUIElementGetTypeID() {
-            return (focused as! AXUIElement)
-        }
+        if let focused = elementAttribute(application(pid), kAXFocusedWindowAttribute) { return focused }
         return windows(of: pid).first { !isMinimized($0) }
     }
 
@@ -97,9 +107,8 @@ enum WindowAccess {
         // there because a malformed AX tree can contain a cycle.
         for _ in 0..<10 {
             if (attribute(current, kAXRoleAttribute) as? String) == kAXWindowRole { return current }
-            guard let parent = attribute(current, kAXParentAttribute),
-                  CFGetTypeID(parent) == AXUIElementGetTypeID() else { return nil }
-            current = (parent as! AXUIElement)
+            guard let parent = elementAttribute(current, kAXParentAttribute) else { return nil }
+            current = parent
         }
         return nil
     }

--- a/App/Sources/plonk/WindowManager.swift
+++ b/App/Sources/plonk/WindowManager.swift
@@ -87,8 +87,8 @@ final class WindowManager {
 
     // MARK: - Public API
 
-    func listWindows() -> [[String: Any]] {
-        var result: [[String: Any]] = []
+    func windowSnapshots() -> [WindowSnapshot] {
+        var result: [WindowSnapshot] = []
         let allScreens = screens()
         let ownPID = ProcessInfo.processInfo.processIdentifier
         for app in runningApps() where app.processIdentifier != ownPID {
@@ -97,32 +97,27 @@ final class WindowManager {
                 guard let f = frame(ofWindow: win) else { continue }
                 let minimized = WindowAccess.isMinimized(win)
                 let index = screenIndex(containing: f, in: allScreens)
-                var entry: [String: Any] = [
-                    "app": name,
-                    "pid": app.processIdentifier,
-                    "title": WindowAccess.title(of: win),
-                    "minimized": minimized,
-                    "screen": index,
-                    "window_index": windowIndex,
-                    // Doubles, not CGFloat: CGFloat is its own struct, and a
-                    // [String: CGFloat] does not cast to [String: Double].
-                    "frame": ["x": Double(f.origin.x), "y": Double(f.origin.y),
-                              "w": Double(f.width), "h": Double(f.height)],
-                ]
-                if let bundleID = app.bundleIdentifier { entry["bundle_id"] = bundleID }
-                if let path = app.bundleURL?.path { entry["bundle_path"] = path }
-                if !minimized, let frac = ZoneGeometry.fraction(of: f, in: allScreens[index].visible) {
-                    entry["fraction"] = [
-                        "x": (frac.x * 100).rounded() / 100,
-                        "y": (frac.y * 100).rounded() / 100,
-                        "w": (frac.w * 100).rounded() / 100,
-                        "h": (frac.h * 100).rounded() / 100,
-                    ]
+                let raw = minimized ? nil : ZoneGeometry.fraction(of: f, in: allScreens[index].visible)
+                let fraction = raw.map {
+                    FracRect(($0.x * 100).rounded() / 100,
+                             ($0.y * 100).rounded() / 100,
+                             ($0.w * 100).rounded() / 100,
+                             ($0.h * 100).rounded() / 100)
                 }
-                result.append(entry)
+                result.append(WindowSnapshot(
+                    app: name, pid: app.processIdentifier,
+                    title: WindowAccess.title(of: win), minimized: minimized,
+                    screen: index, windowIndex: windowIndex, frame: f,
+                    fraction: fraction, bundleID: app.bundleIdentifier,
+                    bundlePath: app.bundleURL?.path
+                ))
             }
         }
         return result
+    }
+
+    func listWindows() -> [[String: Any]] {
+        windowSnapshots().map(\.asDict)
     }
 
     /// Place one window by app name. Returns an error string, or nil on success.

--- a/App/Sources/plonk/WindowSnapshot.swift
+++ b/App/Sources/plonk/WindowSnapshot.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// One window as core code sees it. The untyped dictionary belongs only at
+/// the HTTP boundary; workspace snapshots consume this value directly.
+struct WindowSnapshot {
+    let app: String
+    let pid: pid_t
+    let title: String
+    let minimized: Bool
+    let screen: Int
+    let windowIndex: Int
+    let frame: CGRect
+    let fraction: FracRect?
+    let bundleID: String?
+    let bundlePath: String?
+
+    var asDict: [String: Any] {
+        var result: [String: Any] = [
+            "app": app,
+            "pid": pid,
+            "title": title,
+            "minimized": minimized,
+            "screen": screen,
+            "window_index": windowIndex,
+            "frame": ["x": Double(frame.minX), "y": Double(frame.minY),
+                      "w": Double(frame.width), "h": Double(frame.height)],
+        ]
+        if let fraction {
+            result["fraction"] = ["x": fraction.x, "y": fraction.y,
+                                  "w": fraction.w, "h": fraction.h]
+        }
+        if let bundleID { result["bundle_id"] = bundleID }
+        if let bundlePath { result["bundle_path"] = bundlePath }
+        return result
+    }
+}

--- a/App/Sources/plonk/Workspace.swift
+++ b/App/Sources/plonk/Workspace.swift
@@ -83,6 +83,20 @@ struct WorkspaceItem: Codable {
         )
     }
 
+    init?(window snapshot: WindowSnapshot, screenUUID: String? = nil) {
+        guard !snapshot.minimized, let fraction = snapshot.fraction else { return nil }
+        self.init(
+            app: snapshot.app,
+            bundleID: snapshot.bundleID,
+            bundlePath: snapshot.bundlePath,
+            title: snapshot.title.isEmpty ? nil : snapshot.title,
+            windowIndex: snapshot.windowIndex,
+            screen: snapshot.screen,
+            screenUUID: screenUUID,
+            x: fraction.x, y: fraction.y, w: fraction.w, h: fraction.h
+        )
+    }
+
     var asDict: [String: Any] {
         var result: [String: Any] = [
             "app": app,

--- a/App/Tests/plonkTests/AgentAdapterRunnerTests.swift
+++ b/App/Tests/plonkTests/AgentAdapterRunnerTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import plonk
+
+struct AgentAdapterRunnerTests {
+    @Test func capturesTheLastErrorWithoutBlockingOnVerboseOutput() async throws {
+        let runner = AgentAdapterRunner()
+        let adapter = AgentAdapter(
+            name: "fixture",
+            command: "yes noise | head -c 100000 >&2; printf '\\nlast-error\\n' >&2; exit 7; : {prompt}"
+        )
+        let result = await withCheckedContinuation { continuation in
+            runner.run(adapter, prompt: "hello") { continuation.resume(returning: $0) }
+        }
+        guard case .finished(let finished) = result else {
+            Issue.record("adapter did not run")
+            return
+        }
+        #expect(finished.status == 7)
+        #expect(finished.lastError == "last-error")
+    }
+}

--- a/App/Tests/plonkTests/AwakeManagerTests.swift
+++ b/App/Tests/plonkTests/AwakeManagerTests.swift
@@ -4,6 +4,19 @@ import Foundation
 
 struct AwakeManagerTests {
 
+    @Test func watchingIsIdempotentAndStopsSymmetrically() {
+        let awake = AwakeManager()
+        awake.startWatching()
+        let timer = awake.watchTimer
+        #expect(timer != nil)
+        awake.startWatching()
+        #expect(awake.watchTimer === timer)
+        awake.stopWatching()
+        #expect(awake.watchTimer == nil)
+        #expect(awake.wakeToken == nil)
+        #expect(awake.powerSource == nil)
+    }
+
     @Test func restoreResumesASessionThatIsStillRunning() {
         let awake = AwakeManager()
         awake.restore(sessionEnd: Date().addingTimeInterval(600))

--- a/App/Tests/plonkTests/EventLifecycleTests.swift
+++ b/App/Tests/plonkTests/EventLifecycleTests.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Testing
+@testable import plonk
+
+private final class FakeEventTap: EventTapToken {}
+
+struct EventLifecycleTests {
+    @Test @MainActor func mouseTapListensOnlyToEventsItsEnabledToolsNeed() {
+        var masks: [CGEventMask] = []
+        let mouse = MouseTools(tapFactory: { mask, _, _, _ in
+            masks.append(mask)
+            return FakeEventTap()
+        }, isTrusted: { true })
+        var config = Config()
+        config.highlightClicksEnabled = true
+        mouse.apply(config)
+        #expect(masks.count == 1)
+        #expect(masks[0] & (1 << CGEventType.leftMouseDown.rawValue) != 0)
+        #expect(masks[0] & (1 << CGEventType.mouseMoved.rawValue) == 0)
+
+        config.crosshairsEnabled = true
+        mouse.apply(config)
+        #expect(masks.count == 2)
+        #expect(masks[1] & (1 << CGEventType.mouseMoved.rawValue) != 0)
+
+        config.highlightClicksEnabled = false
+        config.crosshairsEnabled = false
+        mouse.apply(config)
+        mouse.stop()
+    }
+
+    @Test func dragMonitorsStartOnceAndAreRemovedWhenDisabled() {
+        var added = 0
+        var removed = 0
+        let manager = DragSnapManager(
+            windows: WindowManager(),
+            addMonitor: { _, _ in
+                added += 1
+                return NSObject()
+            },
+            removeMonitor: { _ in removed += 1 }
+        )
+        var config = Config()
+        manager.apply(config)
+        manager.start()
+        #expect(added == 2)
+        config.dragSnapEnabled = false
+        manager.apply(config)
+        #expect(removed == 2)
+    }
+}

--- a/App/Tests/plonkTests/RouterTests.swift
+++ b/App/Tests/plonkTests/RouterTests.swift
@@ -105,12 +105,12 @@ struct RouterTests {
             launched = (name, workspace.apps, screen)
             done([["ok": true, "app": "Safari"]])
         }
-        let response = h.post("/workspaces/launch", ["name": "work", "screen": 1])
+        let response = h.post("/workspaces/launch", ["name": "work", "screen": 0])
         #expect(response.status == 200)
         #expect(response.json["ok"] as? Bool == true)
         #expect(launched?.name == "work")
         #expect(launched?.apps == ["Safari"])
-        #expect(launched?.screen == 1)
+        #expect(launched?.screen == 0)
     }
 
     @Test func deletingReportsWhetherItExisted() {

--- a/App/Tests/plonkTests/ScreenInputTests.swift
+++ b/App/Tests/plonkTests/ScreenInputTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import plonk
+
+struct ScreenInputTests {
+    @Test func absentAndNullAreOmitted() {
+        guard case .omitted = ScreenInput.parse(nil) else {
+            Issue.record("nil was not omitted")
+            return
+        }
+        guard case .omitted = ScreenInput.parse(NSNull()) else {
+            Issue.record("null was not omitted")
+            return
+        }
+    }
+
+    @Test func stringsAndBooleansAreNotMonitorIndices() {
+        guard case .invalidType = ScreenInput.parse("0") else {
+            Issue.record("string screen was accepted")
+            return
+        }
+        guard case .invalidType = ScreenInput.parse(true) else {
+            Issue.record("boolean screen was accepted")
+            return
+        }
+    }
+
+    @Test func aMissingMonitorIsNamed() {
+        guard case .notFound(let index) = ScreenInput.parse(Int.max) else {
+            Issue.record("missing screen was accepted")
+            return
+        }
+        #expect(index == Int.max)
+    }
+
+    @Test func zoneRoutesDoNotPersistAMissingMonitor() {
+        let h = RouterHarness()
+        let zones: [[String: Any]] = [["x": 0, "y": 0, "w": 1, "h": 1]]
+        let missing = Int.max
+        #expect(h.post("/zones/save", ["name": "lost", "zones": zones,
+                                        "screen": missing]).status == 404)
+        #expect(h.store.config.zoneSets["lost"] == nil)
+        #expect(h.post("/zones/assign", ["screen": missing]).status == 404)
+        #expect(h.store.config.screenZoneSets[String(missing)] == nil)
+    }
+}

--- a/App/Tests/plonkTests/WindowSnapshotTests.swift
+++ b/App/Tests/plonkTests/WindowSnapshotTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import plonk
+
+struct WindowSnapshotTests {
+    @Test func typedSnapshotKeepsWorkspaceIdentityAndSerializesDoubles() throws {
+        let snapshot = WindowSnapshot(
+            app: "Code", pid: 42, title: "plonk", minimized: false,
+            screen: 1, windowIndex: 2,
+            frame: CGRect(x: 10, y: 20, width: 800, height: 600),
+            fraction: FracRect(0.1, 0.2, 0.5, 0.6),
+            bundleID: "com.microsoft.VSCode", bundlePath: "/Applications/Code.app"
+        )
+        let item = try #require(WorkspaceItem(window: snapshot, screenUUID: "display"))
+        #expect(item.title == "plonk")
+        #expect(item.windowIndex == 2)
+        #expect(item.screenUUID == "display")
+        let frame = try #require(snapshot.asDict["frame"] as? [String: Double])
+        #expect(frame["w"] == 800)
+    }
+
+    @Test func minimizedSnapshotIsNotAWorkspaceItem() {
+        let snapshot = WindowSnapshot(
+            app: "Code", pid: 42, title: "", minimized: true,
+            screen: 0, windowIndex: 0, frame: .zero,
+            fraction: nil, bundleID: nil, bundlePath: nil
+        )
+        #expect(WorkspaceItem(window: snapshot) == nil)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 What changed in each release, from a user's side. The commit log has the rest.
 
+## Unreleased
+
+### Changed
+
+- **Background pointer work stays asleep when it is not needed.** Click
+  highlighting no longer listens to every mouse movement, crosshair movement
+  coalesces bursts before redrawing, and drag snapping removes its global
+  monitors while the feature is switched off.
+
 Versions before 0.1.0 shipped in two days and are summarized rather than
 itemized. The dates are real; the tidiness is not — most of what is listed
 under 0.0.4 was written the same afternoon it went out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ What changed in each release, from a user's side. The commit log has the rest.
   highlighting no longer listens to every mouse movement, crosshair movement
   coalesces bursts before redrawing, and drag snapping removes its global
   monitors while the feature is switched off.
+- **Screen-aware API calls reject displays that are not attached.** A bad
+  monitor index can no longer leave an unreachable zone assignment in the
+  saved config.
 
 Versions before 0.1.0 shipped in two days and are summarized rather than
 itemized. The dates are real; the tidiness is not — most of what is listed


### PR DESCRIPTION
## What changed

- reduce idle pointer polling and make event watcher teardown deterministic
- validate screen inputs before persisting or applying routes
- replace loose window dictionaries with typed snapshots internally
- isolate agent adapter processes from the main thread and drain stderr safely
- guard Accessibility value casts by their Core Foundation types

## Why

This lowers idle CPU use and removes lifecycle, input-validation, process I/O, and unsafe-cast failure modes found during the Swift code review.

## Verification

- `(cd App && swift build)`
- `./scripts/test.sh` — 585 tests in 77 suites
- `./scripts/lint.sh`
- `node scripts/check-strings.mjs`
- `./scripts/check-security-claims.sh`
- `./scripts/build.sh`
- `curl --fail --silent 127.0.0.1:43917/ping`